### PR TITLE
M29: Cross-Scene Node Index API

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build cross-scene index
+        run: npm run build:cross-scene-index
+
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         id: playwright-cache

--- a/api/node-scenes.ts
+++ b/api/node-scenes.ts
@@ -1,0 +1,364 @@
+/**
+ * Node Scenes API Endpoint
+ *
+ * Returns all datasets where a given entity appears, enabling cross-scene discovery.
+ * Supports single and batch lookups by wikidataId, wikipediaTitle, or nodeId.
+ *
+ * @endpoint GET /api/node-scenes
+ *
+ * Single lookup query params (at least one required):
+ * - ?wikidataId=Q154781
+ * - ?wikipediaTitle=Marsilio_Ficino
+ * - ?nodeId=person-ficino
+ *
+ * Batch lookup query params (comma-separated):
+ * - ?wikidataIds=Q154781,Q937,Q5879
+ * - ?wikipediaTitles=Marsilio_Ficino,Voltaire
+ * - ?nodeIds=person-ficino,person-voltaire
+ *
+ * @returns Single lookup: { identity, appearances, totalAppearances }
+ * @returns Batch lookup: { results: { [key]: {...} }, notFound: [...] }
+ */
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import fs from 'fs';
+import path from 'path';
+
+interface EntityAppearance {
+  datasetId: string;
+  datasetName: string;
+  nodeId: string;
+  nodeTitle: string;
+}
+
+interface EntityRecord {
+  wikidataId?: string;
+  wikipediaTitle?: string;
+  canonicalTitle: string;
+  appearances: EntityAppearance[];
+}
+
+interface SingleLookupResponse {
+  identity: {
+    wikidataId?: string;
+    wikipediaTitle?: string;
+    canonicalTitle: string;
+  };
+  appearances: EntityAppearance[];
+  totalAppearances: number;
+}
+
+interface BatchLookupResponse {
+  results: Record<string, SingleLookupResponse>;
+  notFound: string[];
+}
+
+/**
+ * Set CORS headers for cross-origin requests
+ */
+function setCorsHeaders(res: VercelResponse): void {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+/**
+ * Get the shard filename for a wikidata QID
+ */
+function getWikidataShardFilename(qid: string): string {
+  const match = qid.match(/^Q(\d+)$/);
+  if (!match) {
+    return 'other.json';
+  }
+
+  const num = parseInt(match[1], 10);
+  const shardStart = Math.floor(num / 100000) * 100000;
+  const shardEnd = shardStart + 99999;
+
+  return `Q${shardStart}-Q${shardEnd}.json`;
+}
+
+/**
+ * Load a wikidata index shard
+ */
+function loadWikidataShard(
+  indexPath: string,
+  qid: string
+): Record<string, EntityRecord> | null {
+  const shardName = getWikidataShardFilename(qid);
+  const shardPath = path.join(indexPath, 'by-wikidata', shardName);
+
+  if (!fs.existsSync(shardPath)) {
+    return null;
+  }
+
+  try {
+    const content = fs.readFileSync(shardPath, 'utf-8');
+    return JSON.parse(content);
+  } catch (error) {
+    console.error(`Failed to load wikidata shard ${shardName}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Load the wikipedia index
+ */
+function loadWikipediaIndex(
+  indexPath: string
+): Record<string, EntityRecord> | null {
+  const indexFilePath = path.join(indexPath, 'by-wikipedia', 'titles.json');
+
+  if (!fs.existsSync(indexFilePath)) {
+    return null;
+  }
+
+  try {
+    const content = fs.readFileSync(indexFilePath, 'utf-8');
+    return JSON.parse(content);
+  } catch (error) {
+    console.error('Failed to load wikipedia index:', error);
+    return null;
+  }
+}
+
+/**
+ * Load the nodeid index
+ */
+function loadNodeIdIndex(
+  indexPath: string
+): Record<string, EntityRecord> | null {
+  const indexFilePath = path.join(indexPath, 'by-nodeid', 'nodeids.json');
+
+  if (!fs.existsSync(indexFilePath)) {
+    return null;
+  }
+
+  try {
+    const content = fs.readFileSync(indexFilePath, 'utf-8');
+    return JSON.parse(content);
+  } catch (error) {
+    console.error('Failed to load nodeid index:', error);
+    return null;
+  }
+}
+
+/**
+ * Lookup entity by wikidataId
+ */
+function lookupByWikidataId(
+  indexPath: string,
+  wikidataId: string
+): EntityRecord | null {
+  const shard = loadWikidataShard(indexPath, wikidataId);
+  if (!shard) {
+    return null;
+  }
+
+  return shard[wikidataId] || null;
+}
+
+/**
+ * Lookup entity by wikipediaTitle
+ */
+function lookupByWikipediaTitle(
+  indexPath: string,
+  wikipediaTitle: string
+): EntityRecord | null {
+  const index = loadWikipediaIndex(indexPath);
+  if (!index) {
+    return null;
+  }
+
+  return index[wikipediaTitle] || null;
+}
+
+/**
+ * Lookup entity by nodeId
+ */
+function lookupByNodeId(
+  indexPath: string,
+  nodeId: string
+): EntityRecord | null {
+  const index = loadNodeIdIndex(indexPath);
+  if (!index) {
+    return null;
+  }
+
+  return index[nodeId] || null;
+}
+
+/**
+ * Convert entity record to response format
+ */
+function formatEntityResponse(record: EntityRecord): SingleLookupResponse {
+  return {
+    identity: {
+      wikidataId: record.wikidataId,
+      wikipediaTitle: record.wikipediaTitle,
+      canonicalTitle: record.canonicalTitle,
+    },
+    appearances: record.appearances,
+    totalAppearances: record.appearances.length,
+  };
+}
+
+/**
+ * Handle single lookup request
+ */
+function handleSingleLookup(
+  indexPath: string,
+  query: {
+    wikidataId?: string;
+    wikipediaTitle?: string;
+    nodeId?: string;
+  }
+): SingleLookupResponse | null {
+  // Try each identifier in order of preference
+  if (query.wikidataId) {
+    const record = lookupByWikidataId(indexPath, query.wikidataId);
+    if (record) {
+      return formatEntityResponse(record);
+    }
+  }
+
+  if (query.wikipediaTitle) {
+    const record = lookupByWikipediaTitle(indexPath, query.wikipediaTitle);
+    if (record) {
+      return formatEntityResponse(record);
+    }
+  }
+
+  if (query.nodeId) {
+    const record = lookupByNodeId(indexPath, query.nodeId);
+    if (record) {
+      return formatEntityResponse(record);
+    }
+  }
+
+  // Return empty result instead of null for not found
+  return {
+    identity: {
+      wikidataId: query.wikidataId,
+      wikipediaTitle: query.wikipediaTitle,
+      canonicalTitle: '',
+    },
+    appearances: [],
+    totalAppearances: 0,
+  };
+}
+
+/**
+ * Handle batch lookup request
+ */
+function handleBatchLookup(
+  indexPath: string,
+  query: {
+    wikidataIds?: string;
+    wikipediaTitles?: string;
+    nodeIds?: string;
+  }
+): BatchLookupResponse {
+  const results: Record<string, SingleLookupResponse> = {};
+  const notFound: string[] = [];
+
+  // Process wikidataIds
+  if (query.wikidataIds) {
+    const ids = query.wikidataIds.split(',').map(id => id.trim());
+    for (const id of ids) {
+      const result = handleSingleLookup(indexPath, { wikidataId: id });
+      if (result && result.totalAppearances > 0) {
+        results[id] = result;
+      } else {
+        notFound.push(id);
+      }
+    }
+  }
+
+  // Process wikipediaTitles
+  if (query.wikipediaTitles) {
+    const titles = query.wikipediaTitles.split(',').map(t => t.trim());
+    for (const title of titles) {
+      const result = handleSingleLookup(indexPath, { wikipediaTitle: title });
+      if (result && result.totalAppearances > 0) {
+        results[title] = result;
+      } else {
+        notFound.push(title);
+      }
+    }
+  }
+
+  // Process nodeIds
+  if (query.nodeIds) {
+    const ids = query.nodeIds.split(',').map(id => id.trim());
+    for (const id of ids) {
+      const result = handleSingleLookup(indexPath, { nodeId: id });
+      if (result && result.totalAppearances > 0) {
+        results[id] = result;
+      } else {
+        notFound.push(id);
+      }
+    }
+  }
+
+  return { results, notFound };
+}
+
+/**
+ * Main handler
+ */
+export default function handler(
+  req: VercelRequest,
+  res: VercelResponse
+): VercelResponse | void {
+  setCorsHeaders(res);
+
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end();
+  }
+
+  // Only allow GET requests
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const indexPath = path.join(process.cwd(), 'public', 'cross-scene-index');
+
+  // Check if index exists
+  if (!fs.existsSync(indexPath)) {
+    return res.status(503).json({
+      error: 'Cross-scene index not available',
+      message: 'Index has not been generated yet',
+    });
+  }
+
+  const query = req.query as {
+    wikidataId?: string;
+    wikipediaTitle?: string;
+    nodeId?: string;
+    wikidataIds?: string;
+    wikipediaTitles?: string;
+    nodeIds?: string;
+  };
+
+  // Determine if this is a batch or single lookup
+  const isBatch =
+    query.wikidataIds || query.wikipediaTitles || query.nodeIds;
+
+  if (isBatch) {
+    // Handle batch lookup
+    const result = handleBatchLookup(indexPath, query);
+    return res.status(200).json(result);
+  } else {
+    // Handle single lookup
+    if (!query.wikidataId && !query.wikipediaTitle && !query.nodeId) {
+      return res.status(400).json({
+        error: 'Missing identifier',
+        message: 'Provide at least one of: wikidataId, wikipediaTitle, nodeId',
+      });
+    }
+
+    const result = handleSingleLookup(indexPath, query);
+    return res.status(200).json(result);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "preview": "vite preview",
     "validate:datasets": "npx tsx scripts/validate-datasets/index.ts",
     "validate:datasets:strict": "npx tsx scripts/validate-datasets/index.ts --strict",
+    "build:cross-scene-index": "npx tsx scripts/build-cross-scene-index/index.ts",
     "e2e:server": "tsx scripts/e2e-server.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"

--- a/public/cross-scene-index/by-nodeid/nodeids.json
+++ b/public/cross-scene-index/by-nodeid/nodeids.json
@@ -1,0 +1,19061 @@
+{
+  "person-geoffrey-hinton": {
+    "wikidataId": "Q7841039",
+    "wikipediaTitle": "Geoffrey_Hinton",
+    "canonicalTitle": "Geoffrey Hinton",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-geoffrey-hinton",
+        "nodeTitle": "Geoffrey Hinton"
+      }
+    ]
+  },
+  "person-yoshua-bengio": {
+    "wikidataId": "Q5987936",
+    "wikipediaTitle": "Yoshua_Bengio",
+    "canonicalTitle": "Yoshua Bengio",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-yoshua-bengio",
+        "nodeTitle": "Yoshua Bengio"
+      }
+    ]
+  },
+  "person-yann-lecun": {
+    "wikidataId": "Q1371324",
+    "wikipediaTitle": "Yann_LeCun",
+    "canonicalTitle": "Yann LeCun",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-yann-lecun",
+        "nodeTitle": "Yann LeCun"
+      }
+    ]
+  },
+  "person-sam-altman": {
+    "wikidataId": "Q7407929",
+    "wikipediaTitle": "Sam_Altman",
+    "canonicalTitle": "Sam Altman",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-sam-altman",
+        "nodeTitle": "Sam Altman"
+      }
+    ]
+  },
+  "person-elon-musk": {
+    "wikidataId": "Q317521",
+    "wikipediaTitle": "Elon_Musk",
+    "canonicalTitle": "Elon Musk",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-elon-musk",
+        "nodeTitle": "Elon Musk"
+      }
+    ]
+  },
+  "person-ilya-sutskever": {
+    "wikidataId": "Q28738478",
+    "wikipediaTitle": "Ilya_Sutskever",
+    "canonicalTitle": "Ilya Sutskever",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-ilya-sutskever",
+        "nodeTitle": "Ilya Sutskever"
+      }
+    ]
+  },
+  "person-greg-brockman": {
+    "wikidataId": "Q28733656",
+    "wikipediaTitle": "Greg_Brockman",
+    "canonicalTitle": "Greg Brockman",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-greg-brockman",
+        "nodeTitle": "Greg Brockman"
+      }
+    ]
+  },
+  "person-andrej-karpathy": {
+    "wikidataId": "Q26884227",
+    "wikipediaTitle": "Andrej_Karpathy",
+    "canonicalTitle": "Andrej Karpathy",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-andrej-karpathy",
+        "nodeTitle": "Andrej Karpathy"
+      }
+    ]
+  },
+  "person-john-schulman": {
+    "wikidataId": "Q64944657",
+    "wikipediaTitle": "John_Schulman_(computer_scientist)",
+    "canonicalTitle": "John Schulman",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-john-schulman",
+        "nodeTitle": "John Schulman"
+      }
+    ]
+  },
+  "person-wojciech-zaremba": {
+    "wikidataId": "Q55609966",
+    "wikipediaTitle": "Wojciech_Zaremba",
+    "canonicalTitle": "Wojciech Zaremba",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-wojciech-zaremba",
+        "nodeTitle": "Wojciech Zaremba"
+      }
+    ]
+  },
+  "person-durk-kingma": {
+    "wikidataId": "Q56034965",
+    "wikipediaTitle": "Diederik_P._Kingma",
+    "canonicalTitle": "Durk Kingma",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-durk-kingma",
+        "nodeTitle": "Durk Kingma"
+      }
+    ]
+  },
+  "person-trevor-blackwell": {
+    "wikidataId": "Q7838396",
+    "wikipediaTitle": "Trevor_Blackwell",
+    "canonicalTitle": "Trevor Blackwell",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-trevor-blackwell",
+        "nodeTitle": "Trevor Blackwell"
+      }
+    ]
+  },
+  "person-vicki-cheung": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Vicki Cheung",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-vicki-cheung",
+        "nodeTitle": "Vicki Cheung"
+      }
+    ]
+  },
+  "person-pamela-vagata": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Pamela Vagata",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-pamela-vagata",
+        "nodeTitle": "Pamela Vagata"
+      }
+    ]
+  },
+  "person-alec-radford": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Alec Radford",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-alec-radford",
+        "nodeTitle": "Alec Radford"
+      }
+    ]
+  },
+  "person-mira-murati": {
+    "wikidataId": "Q110560178",
+    "wikipediaTitle": "Mira_Murati",
+    "canonicalTitle": "Mira Murati",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-mira-murati",
+        "nodeTitle": "Mira Murati"
+      }
+    ]
+  },
+  "person-aditya-ramesh": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Aditya Ramesh",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-aditya-ramesh",
+        "nodeTitle": "Aditya Ramesh"
+      }
+    ]
+  },
+  "person-mark-chen": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Mark Chen",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-mark-chen",
+        "nodeTitle": "Mark Chen"
+      }
+    ]
+  },
+  "person-jan-leike": {
+    "wikidataId": "Q130449908",
+    "wikipediaTitle": "Jan_Leike",
+    "canonicalTitle": "Jan Leike",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jan-leike",
+        "nodeTitle": "Jan Leike"
+      }
+    ]
+  },
+  "person-barret-zoph": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Barret Zoph",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-barret-zoph",
+        "nodeTitle": "Barret Zoph"
+      }
+    ]
+  },
+  "person-lukasz-kaiser": {
+    "wikidataId": "Q57430008",
+    "wikipediaTitle": "Łukasz_Kaiser",
+    "canonicalTitle": "Łukasz Kaiser",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-lukasz-kaiser",
+        "nodeTitle": "Łukasz Kaiser"
+      }
+    ]
+  },
+  "person-dario-amodei": {
+    "wikidataId": "Q108741568",
+    "wikipediaTitle": "Dario_Amodei",
+    "canonicalTitle": "Dario Amodei",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-dario-amodei",
+        "nodeTitle": "Dario Amodei"
+      }
+    ]
+  },
+  "person-daniela-amodei": {
+    "wikidataId": "Q108743009",
+    "wikipediaTitle": "Daniela_Amodei",
+    "canonicalTitle": "Daniela Amodei",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-daniela-amodei",
+        "nodeTitle": "Daniela Amodei"
+      }
+    ]
+  },
+  "person-jared-kaplan": {
+    "wikidataId": "Q108742236",
+    "wikipediaTitle": "Jared_Kaplan_(physicist)",
+    "canonicalTitle": "Jared Kaplan",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jared-kaplan",
+        "nodeTitle": "Jared Kaplan"
+      }
+    ]
+  },
+  "person-jack-clark": {
+    "wikidataId": "Q108742779",
+    "wikipediaTitle": "Jack_Clark_(AI_researcher)",
+    "canonicalTitle": "Jack Clark",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jack-clark",
+        "nodeTitle": "Jack Clark"
+      }
+    ]
+  },
+  "person-tom-brown": {
+    "wikidataId": "Q108741880",
+    "wikipediaTitle": "Tom_Brown_(AI_researcher)",
+    "canonicalTitle": "Tom Brown",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-tom-brown",
+        "nodeTitle": "Tom Brown"
+      }
+    ]
+  },
+  "person-sam-mccandlish": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Sam McCandlish",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-sam-mccandlish",
+        "nodeTitle": "Sam McCandlish"
+      }
+    ]
+  },
+  "person-chris-olah": {
+    "wikidataId": "Q108742500",
+    "wikipediaTitle": "Christopher_Olah",
+    "canonicalTitle": "Chris Olah",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-chris-olah",
+        "nodeTitle": "Chris Olah"
+      }
+    ]
+  },
+  "person-niki-parmar": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Niki Parmar",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-niki-parmar",
+        "nodeTitle": "Niki Parmar"
+      }
+    ]
+  },
+  "person-demis-hassabis": {
+    "wikidataId": "Q19845246",
+    "wikipediaTitle": "Demis_Hassabis",
+    "canonicalTitle": "Demis Hassabis",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-demis-hassabis",
+        "nodeTitle": "Demis Hassabis"
+      }
+    ]
+  },
+  "person-shane-legg": {
+    "wikidataId": "Q7489091",
+    "wikipediaTitle": "Shane_Legg",
+    "canonicalTitle": "Shane Legg",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-shane-legg",
+        "nodeTitle": "Shane Legg"
+      }
+    ]
+  },
+  "person-mustafa-suleyman": {
+    "wikidataId": "Q30593017",
+    "wikipediaTitle": "Mustafa_Suleyman",
+    "canonicalTitle": "Mustafa Suleyman",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-mustafa-suleyman",
+        "nodeTitle": "Mustafa Suleyman"
+      }
+    ]
+  },
+  "person-john-jumper": {
+    "wikidataId": "Q115667430",
+    "wikipediaTitle": "John_Jumper",
+    "canonicalTitle": "John Jumper",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-john-jumper",
+        "nodeTitle": "John Jumper"
+      }
+    ]
+  },
+  "person-david-silver": {
+    "wikidataId": "Q23831774",
+    "wikipediaTitle": "David_Silver_(computer_scientist)",
+    "canonicalTitle": "David Silver",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-david-silver",
+        "nodeTitle": "David Silver"
+      }
+    ]
+  },
+  "person-aja-huang": {
+    "wikidataId": "Q23831959",
+    "wikipediaTitle": "Aja_Huang",
+    "canonicalTitle": "Aja Huang",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-aja-huang",
+        "nodeTitle": "Aja Huang"
+      }
+    ]
+  },
+  "person-pushmeet-kohli": {
+    "wikidataId": "Q55641992",
+    "wikipediaTitle": "Pushmeet_Kohli",
+    "canonicalTitle": "Pushmeet Kohli",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-pushmeet-kohli",
+        "nodeTitle": "Pushmeet Kohli"
+      }
+    ]
+  },
+  "person-oriol-vinyals": {
+    "wikidataId": "Q35064943",
+    "wikipediaTitle": "Oriol_Vinyals",
+    "canonicalTitle": "Oriol Vinyals",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-oriol-vinyals",
+        "nodeTitle": "Oriol Vinyals"
+      }
+    ]
+  },
+  "person-jeff-dean": {
+    "wikidataId": "Q6176204",
+    "wikipediaTitle": "Jeff_Dean",
+    "canonicalTitle": "Jeff Dean",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jeff-dean",
+        "nodeTitle": "Jeff Dean"
+      }
+    ]
+  },
+  "person-andrew-ng": {
+    "wikidataId": "Q9381540",
+    "wikipediaTitle": "Andrew_Ng",
+    "canonicalTitle": "Andrew Ng",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-andrew-ng",
+        "nodeTitle": "Andrew Ng"
+      }
+    ]
+  },
+  "person-greg-corrado": {
+    "wikidataId": "Q24709116",
+    "wikipediaTitle": "Greg_Corrado",
+    "canonicalTitle": "Greg Corrado",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-greg-corrado",
+        "nodeTitle": "Greg Corrado"
+      }
+    ]
+  },
+  "person-quoc-le": {
+    "wikidataId": "Q22908016",
+    "wikipediaTitle": "Quoc_Viet_Le",
+    "canonicalTitle": "Quoc V. Le",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-quoc-le",
+        "nodeTitle": "Quoc V. Le"
+      }
+    ]
+  },
+  "person-samy-bengio": {
+    "wikidataId": "Q60740282",
+    "wikipediaTitle": "Samy_Bengio",
+    "canonicalTitle": "Samy Bengio",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-samy-bengio",
+        "nodeTitle": "Samy Bengio"
+      }
+    ]
+  },
+  "person-noam-shazeer": {
+    "wikidataId": "Q57431260",
+    "wikipediaTitle": "Noam_Shazeer",
+    "canonicalTitle": "Noam Shazeer",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-noam-shazeer",
+        "nodeTitle": "Noam Shazeer"
+      }
+    ]
+  },
+  "person-ashish-vaswani": {
+    "wikidataId": "Q56062424",
+    "wikipediaTitle": "Ashish_Vaswani",
+    "canonicalTitle": "Ashish Vaswani",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-ashish-vaswani",
+        "nodeTitle": "Ashish Vaswani"
+      }
+    ]
+  },
+  "person-jakob-uszkoreit": {
+    "wikidataId": "Q57430055",
+    "wikipediaTitle": "Jakob_Uszkoreit",
+    "canonicalTitle": "Jakob Uszkoreit",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jakob-uszkoreit",
+        "nodeTitle": "Jakob Uszkoreit"
+      }
+    ]
+  },
+  "person-llion-jones": {
+    "wikidataId": "Q57430117",
+    "wikipediaTitle": "Llion_Jones",
+    "canonicalTitle": "Llion Jones",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-llion-jones",
+        "nodeTitle": "Llion Jones"
+      }
+    ]
+  },
+  "person-aidan-gomez": {
+    "wikidataId": "Q57430148",
+    "wikipediaTitle": "Aidan_Gomez",
+    "canonicalTitle": "Aidan Gomez",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-aidan-gomez",
+        "nodeTitle": "Aidan Gomez"
+      }
+    ]
+  },
+  "person-illia-polosukhin": {
+    "wikidataId": "Q57430190",
+    "wikipediaTitle": "Illia_Polosukhin",
+    "canonicalTitle": "Illia Polosukhin",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-illia-polosukhin",
+        "nodeTitle": "Illia Polosukhin"
+      }
+    ]
+  },
+  "person-alex-krizhevsky": {
+    "wikidataId": "Q22078899",
+    "wikipediaTitle": "Alex_Krizhevsky",
+    "canonicalTitle": "Alex Krizhevsky",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-alex-krizhevsky",
+        "nodeTitle": "Alex Krizhevsky"
+      }
+    ]
+  },
+  "person-ruslan-salakhutdinov": {
+    "wikidataId": "Q7381579",
+    "wikipediaTitle": "Russ_Salakhutdinov",
+    "canonicalTitle": "Ruslan Salakhutdinov",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-ruslan-salakhutdinov",
+        "nodeTitle": "Ruslan Salakhutdinov"
+      }
+    ]
+  },
+  "person-yee-whye-teh": {
+    "wikidataId": "Q8050866",
+    "wikipediaTitle": "Yee-Whye_Teh",
+    "canonicalTitle": "Yee-Whye Teh",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-yee-whye-teh",
+        "nodeTitle": "Yee-Whye Teh"
+      }
+    ]
+  },
+  "person-george-dahl": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "George Dahl",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-george-dahl",
+        "nodeTitle": "George Dahl"
+      }
+    ]
+  },
+  "person-nitish-srivastava": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Nitish Srivastava",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-nitish-srivastava",
+        "nodeTitle": "Nitish Srivastava"
+      }
+    ]
+  },
+  "person-ian-goodfellow": {
+    "wikidataId": "Q27311979",
+    "wikipediaTitle": "Ian_Goodfellow",
+    "canonicalTitle": "Ian Goodfellow",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-ian-goodfellow",
+        "nodeTitle": "Ian Goodfellow"
+      }
+    ]
+  },
+  "person-aaron-courville": {
+    "wikidataId": "Q27312191",
+    "wikipediaTitle": "Aaron_Courville",
+    "canonicalTitle": "Aaron Courville",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-aaron-courville",
+        "nodeTitle": "Aaron Courville"
+      }
+    ]
+  },
+  "person-kyunghyun-cho": {
+    "wikidataId": "Q60740345",
+    "wikipediaTitle": "Kyunghyun_Cho",
+    "canonicalTitle": "Kyunghyun Cho",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-kyunghyun-cho",
+        "nodeTitle": "Kyunghyun Cho"
+      }
+    ]
+  },
+  "person-pascal-vincent": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Pascal Vincent",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-pascal-vincent",
+        "nodeTitle": "Pascal Vincent"
+      }
+    ]
+  },
+  "person-doina-precup": {
+    "wikidataId": "Q29039302",
+    "wikipediaTitle": "Doina_Precup",
+    "canonicalTitle": "Doina Precup",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-doina-precup",
+        "nodeTitle": "Doina Precup"
+      }
+    ]
+  },
+  "person-fei-fei-li": {
+    "wikidataId": "Q8991031",
+    "wikipediaTitle": "Fei-Fei_Li",
+    "canonicalTitle": "Fei-Fei Li",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-fei-fei-li",
+        "nodeTitle": "Fei-Fei Li"
+      }
+    ]
+  },
+  "person-pieter-abbeel": {
+    "wikidataId": "Q7193306",
+    "wikipediaTitle": "Pieter_Abbeel",
+    "canonicalTitle": "Pieter Abbeel",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-pieter-abbeel",
+        "nodeTitle": "Pieter Abbeel"
+      }
+    ]
+  },
+  "person-daphne-koller": {
+    "wikidataId": "Q450599",
+    "wikipediaTitle": "Daphne_Koller",
+    "canonicalTitle": "Daphne Koller",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-daphne-koller",
+        "nodeTitle": "Daphne Koller"
+      }
+    ]
+  },
+  "person-timnit-gebru": {
+    "wikidataId": "Q47488089",
+    "wikipediaTitle": "Timnit_Gebru",
+    "canonicalTitle": "Timnit Gebru",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-timnit-gebru",
+        "nodeTitle": "Timnit Gebru"
+      }
+    ]
+  },
+  "person-olga-russakovsky": {
+    "wikidataId": "Q21545259",
+    "wikipediaTitle": "Olga_Russakovsky",
+    "canonicalTitle": "Olga Russakovsky",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-olga-russakovsky",
+        "nodeTitle": "Olga Russakovsky"
+      }
+    ]
+  },
+  "person-richard-socher": {
+    "wikidataId": "Q25460599",
+    "wikipediaTitle": "Richard_Socher",
+    "canonicalTitle": "Richard Socher",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-richard-socher",
+        "nodeTitle": "Richard Socher"
+      }
+    ]
+  },
+  "person-joelle-pineau": {
+    "wikidataId": "Q56603936",
+    "wikipediaTitle": "Joelle_Pineau",
+    "canonicalTitle": "Joelle Pineau",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-joelle-pineau",
+        "nodeTitle": "Joelle Pineau"
+      }
+    ]
+  },
+  "person-jerome-pesenti": {
+    "wikidataId": "Q6181986",
+    "wikipediaTitle": "Jerome_Pesenti",
+    "canonicalTitle": "Jerome Pesenti",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jerome-pesenti",
+        "nodeTitle": "Jerome Pesenti"
+      }
+    ]
+  },
+  "person-hugo-touvron": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Hugo Touvron",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-hugo-touvron",
+        "nodeTitle": "Hugo Touvron"
+      }
+    ]
+  },
+  "person-guillaume-lample": {
+    "wikidataId": "Q118283055",
+    "wikipediaTitle": "Guillaume_Lample",
+    "canonicalTitle": "Guillaume Lample",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-guillaume-lample",
+        "nodeTitle": "Guillaume Lample"
+      }
+    ]
+  },
+  "person-armand-joulin": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Armand Joulin",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-armand-joulin",
+        "nodeTitle": "Armand Joulin"
+      }
+    ]
+  },
+  "person-baptiste-roziere": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Baptiste Rozière",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-baptiste-roziere",
+        "nodeTitle": "Baptiste Rozière"
+      }
+    ]
+  },
+  "person-naman-goyal": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Naman Goyal",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-naman-goyal",
+        "nodeTitle": "Naman Goyal"
+      }
+    ]
+  },
+  "person-timothee-lacroix": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Timothée Lacroix",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-timothee-lacroix",
+        "nodeTitle": "Timothée Lacroix"
+      }
+    ]
+  },
+  "person-arthur-mensch": {
+    "wikidataId": "Q118282911",
+    "wikipediaTitle": "Arthur_Mensch",
+    "canonicalTitle": "Arthur Mensch",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-arthur-mensch",
+        "nodeTitle": "Arthur Mensch"
+      }
+    ]
+  },
+  "person-igor-babuschkin": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Igor Babuschkin",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-igor-babuschkin",
+        "nodeTitle": "Igor Babuschkin"
+      }
+    ]
+  },
+  "person-tony-wu": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Yuhuai \"Tony\" Wu",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-tony-wu",
+        "nodeTitle": "Yuhuai \"Tony\" Wu"
+      }
+    ]
+  },
+  "person-christian-szegedy": {
+    "wikidataId": "Q21167448",
+    "wikipediaTitle": "Christian_Szegedy",
+    "canonicalTitle": "Christian Szegedy",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-christian-szegedy",
+        "nodeTitle": "Christian Szegedy"
+      }
+    ]
+  },
+  "person-jimmy-ba": {
+    "wikidataId": "Q115591629",
+    "wikipediaTitle": "Jimmy_Ba",
+    "canonicalTitle": "Jimmy Ba",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jimmy-ba",
+        "nodeTitle": "Jimmy Ba"
+      }
+    ]
+  },
+  "person-clement-delangue": {
+    "wikidataId": "Q117270377",
+    "wikipediaTitle": "Clem_Delangue",
+    "canonicalTitle": "Clément Delangue",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-clement-delangue",
+        "nodeTitle": "Clément Delangue"
+      }
+    ]
+  },
+  "person-julien-chaumond": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Julien Chaumond",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-julien-chaumond",
+        "nodeTitle": "Julien Chaumond"
+      }
+    ]
+  },
+  "person-thomas-wolf": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Thomas Wolf",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-thomas-wolf",
+        "nodeTitle": "Thomas Wolf"
+      }
+    ]
+  },
+  "person-margaret-mitchell": {
+    "wikidataId": "Q106409817",
+    "wikipediaTitle": "Margaret_Mitchell_(scientist)",
+    "canonicalTitle": "Margaret Mitchell",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-margaret-mitchell",
+        "nodeTitle": "Margaret Mitchell"
+      }
+    ]
+  },
+  "person-emad-mostaque": {
+    "wikidataId": "Q113414756",
+    "wikipediaTitle": "Emad_Mostaque",
+    "canonicalTitle": "Emad Mostaque",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-emad-mostaque",
+        "nodeTitle": "Emad Mostaque"
+      }
+    ]
+  },
+  "person-robin-rombach": {
+    "wikidataId": "Q113500048",
+    "wikipediaTitle": "Robin_Rombach",
+    "canonicalTitle": "Robin Rombach",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-robin-rombach",
+        "nodeTitle": "Robin Rombach"
+      }
+    ]
+  },
+  "person-andreas-blattmann": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Andreas Blattmann",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-andreas-blattmann",
+        "nodeTitle": "Andreas Blattmann"
+      }
+    ]
+  },
+  "person-ivan-zhang": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Ivan Zhang",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-ivan-zhang",
+        "nodeTitle": "Ivan Zhang"
+      }
+    ]
+  },
+  "person-nick-frosst": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Nick Frosst",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-nick-frosst",
+        "nodeTitle": "Nick Frosst"
+      }
+    ]
+  },
+  "person-richard-sutton": {
+    "wikidataId": "Q7330296",
+    "wikipediaTitle": "Richard_S._Sutton",
+    "canonicalTitle": "Richard Sutton",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-richard-sutton",
+        "nodeTitle": "Richard Sutton"
+      }
+    ]
+  },
+  "person-michael-jordan": {
+    "wikidataId": "Q1927926",
+    "wikipediaTitle": "Michael_I._Jordan",
+    "canonicalTitle": "Michael I. Jordan",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-michael-jordan",
+        "nodeTitle": "Michael I. Jordan"
+      }
+    ]
+  },
+  "person-david-ha": {
+    "wikidataId": "Q126330684",
+    "wikipediaTitle": "David_Ha_(computer_scientist)",
+    "canonicalTitle": "David Ha",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-david-ha",
+        "nodeTitle": "David Ha"
+      }
+    ]
+  },
+  "person-percy-liang": {
+    "wikidataId": "Q56677851",
+    "wikipediaTitle": "Percy_Liang",
+    "canonicalTitle": "Percy Liang",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-percy-liang",
+        "nodeTitle": "Percy Liang"
+      }
+    ]
+  },
+  "object-transformer-paper": {
+    "wikidataId": "Q108765213",
+    "wikipediaTitle": "Attention_Is_All_You_Need",
+    "canonicalTitle": "Attention Is All You Need",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-transformer-paper",
+        "nodeTitle": "Attention Is All You Need"
+      }
+    ]
+  },
+  "object-alexnet-paper": {
+    "wikidataId": "Q16520311",
+    "wikipediaTitle": "AlexNet",
+    "canonicalTitle": "ImageNet Classification with Deep Convolutional Neural Networks",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-alexnet-paper",
+        "nodeTitle": "ImageNet Classification with Deep Convolutional Neural Networks"
+      }
+    ]
+  },
+  "object-gan-paper": {
+    "wikidataId": "Q25347847",
+    "wikipediaTitle": "Generative_adversarial_network",
+    "canonicalTitle": "Generative Adversarial Networks",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gan-paper",
+        "nodeTitle": "Generative Adversarial Networks"
+      }
+    ]
+  },
+  "object-adam-paper": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Adam: A Method for Stochastic Optimization",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-adam-paper",
+        "nodeTitle": "Adam: A Method for Stochastic Optimization"
+      }
+    ]
+  },
+  "object-dropout-paper": {
+    "wikidataId": "Q26903314",
+    "wikipediaTitle": "Dropout_(neural_networks)",
+    "canonicalTitle": "Dropout: A Simple Way to Prevent Neural Networks from Overfitting",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-dropout-paper",
+        "nodeTitle": "Dropout: A Simple Way to Prevent Neural Networks from Overfitting"
+      }
+    ]
+  },
+  "object-gpt1": {
+    "wikidataId": "Q115646799",
+    "wikipediaTitle": "GPT-1",
+    "canonicalTitle": "GPT-1",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt1",
+        "nodeTitle": "GPT-1"
+      }
+    ]
+  },
+  "object-gpt2": {
+    "wikidataId": "Q65089522",
+    "wikipediaTitle": "GPT-2",
+    "canonicalTitle": "GPT-2",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt2",
+        "nodeTitle": "GPT-2"
+      }
+    ]
+  },
+  "object-gpt3": {
+    "wikidataId": "Q97252119",
+    "wikipediaTitle": "GPT-3",
+    "canonicalTitle": "GPT-3",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt3",
+        "nodeTitle": "GPT-3"
+      }
+    ]
+  },
+  "object-gpt4": {
+    "wikidataId": "Q116709893",
+    "wikipediaTitle": "GPT-4",
+    "canonicalTitle": "GPT-4",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt4",
+        "nodeTitle": "GPT-4"
+      }
+    ]
+  },
+  "object-chatgpt": {
+    "wikidataId": "Q115035180",
+    "wikipediaTitle": "ChatGPT",
+    "canonicalTitle": "ChatGPT",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-chatgpt",
+        "nodeTitle": "ChatGPT"
+      }
+    ]
+  },
+  "object-dalle": {
+    "wikidataId": "Q104831864",
+    "wikipediaTitle": "DALL-E",
+    "canonicalTitle": "DALL-E",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-dalle",
+        "nodeTitle": "DALL-E"
+      }
+    ]
+  },
+  "object-clip": {
+    "wikidataId": "Q120206584",
+    "wikipediaTitle": "CLIP_(language_model)",
+    "canonicalTitle": "CLIP",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-clip",
+        "nodeTitle": "CLIP"
+      }
+    ]
+  },
+  "object-codex": {
+    "wikidataId": "Q107588589",
+    "wikipediaTitle": "OpenAI_Codex",
+    "canonicalTitle": "Codex / GitHub Copilot",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-codex",
+        "nodeTitle": "Codex / GitHub Copilot"
+      }
+    ]
+  },
+  "object-claude": {
+    "wikidataId": "Q116965708",
+    "wikipediaTitle": "Claude_(language_model)",
+    "canonicalTitle": "Claude",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-claude",
+        "nodeTitle": "Claude"
+      }
+    ]
+  },
+  "object-constitutional-ai": {
+    "wikidataId": "Q120201695",
+    "wikipediaTitle": "Constitutional_AI",
+    "canonicalTitle": "Constitutional AI Paper",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-constitutional-ai",
+        "nodeTitle": "Constitutional AI Paper"
+      }
+    ]
+  },
+  "object-scaling-laws": {
+    "wikidataId": "Q110561437",
+    "wikipediaTitle": "Neural_scaling_law",
+    "canonicalTitle": "Scaling Laws for Neural Language Models",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-scaling-laws",
+        "nodeTitle": "Scaling Laws for Neural Language Models"
+      }
+    ]
+  },
+  "object-llama": {
+    "wikidataId": "Q117276906",
+    "wikipediaTitle": "Llama_(language_model)",
+    "canonicalTitle": "LLaMA",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama",
+        "nodeTitle": "LLaMA"
+      }
+    ]
+  },
+  "object-llama2": {
+    "wikidataId": "Q117276906",
+    "wikipediaTitle": "Llama_(language_model)",
+    "canonicalTitle": "LLaMA 2",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama2",
+        "nodeTitle": "LLaMA 2"
+      }
+    ]
+  },
+  "object-code-llama": {
+    "wikidataId": "Q120696689",
+    "wikipediaTitle": "Code_Llama",
+    "canonicalTitle": "Code Llama",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-code-llama",
+        "nodeTitle": "Code Llama"
+      }
+    ]
+  },
+  "object-alphago": {
+    "wikidataId": "Q19829553",
+    "wikipediaTitle": "AlphaGo",
+    "canonicalTitle": "AlphaGo",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-alphago",
+        "nodeTitle": "AlphaGo"
+      }
+    ]
+  },
+  "object-alphafold2": {
+    "wikidataId": "Q66091709",
+    "wikipediaTitle": "AlphaFold",
+    "canonicalTitle": "AlphaFold 2",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-alphafold2",
+        "nodeTitle": "AlphaFold 2"
+      }
+    ]
+  },
+  "object-gemini": {
+    "wikidataId": "Q118389636",
+    "wikipediaTitle": "Gemini_(chatbot)",
+    "canonicalTitle": "Gemini",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gemini",
+        "nodeTitle": "Gemini"
+      }
+    ]
+  },
+  "object-tensorflow": {
+    "wikidataId": "Q21447974",
+    "wikipediaTitle": "TensorFlow",
+    "canonicalTitle": "TensorFlow",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-tensorflow",
+        "nodeTitle": "TensorFlow"
+      }
+    ]
+  },
+  "object-bert": {
+    "wikidataId": "Q60751127",
+    "wikipediaTitle": "BERT_(language_model)",
+    "canonicalTitle": "BERT",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-bert",
+        "nodeTitle": "BERT"
+      }
+    ]
+  },
+  "object-word2vec": {
+    "wikidataId": "Q18685271",
+    "wikipediaTitle": "Word2vec",
+    "canonicalTitle": "Word2Vec",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-word2vec",
+        "nodeTitle": "Word2Vec"
+      }
+    ]
+  },
+  "object-mistral-7b": {
+    "wikidataId": "Q118473029",
+    "wikipediaTitle": "Mistral_AI#Models",
+    "canonicalTitle": "Mistral 7B",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-mistral-7b",
+        "nodeTitle": "Mistral 7B"
+      }
+    ]
+  },
+  "object-stable-diffusion": {
+    "wikidataId": "Q113414728",
+    "wikipediaTitle": "Stable_Diffusion",
+    "canonicalTitle": "Stable Diffusion",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-stable-diffusion",
+        "nodeTitle": "Stable Diffusion"
+      }
+    ]
+  },
+  "object-transformers-library": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Hugging Face Transformers Library",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-transformers-library",
+        "nodeTitle": "Hugging Face Transformers Library"
+      }
+    ]
+  },
+  "object-grok": {
+    "wikidataId": "Q122645637",
+    "wikipediaTitle": "Grok_(chatbot)",
+    "canonicalTitle": "Grok",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-grok",
+        "nodeTitle": "Grok"
+      }
+    ]
+  },
+  "object-deep-learning-book": {
+    "wikidataId": "Q28153721",
+    "wikipediaTitle": "Deep_Learning_(book)",
+    "canonicalTitle": "Deep Learning Textbook",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-deep-learning-book",
+        "nodeTitle": "Deep Learning Textbook"
+      }
+    ]
+  },
+  "object-rl-book": {
+    "wikidataId": "Q7310217",
+    "wikipediaTitle": "Reinforcement_Learning:_An_Introduction",
+    "canonicalTitle": "Reinforcement Learning: An Introduction",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-rl-book",
+        "nodeTitle": "Reinforcement Learning: An Introduction"
+      }
+    ]
+  },
+  "object-cs231n": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "CS231n: Convolutional Neural Networks for Visual Recognition",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-cs231n",
+        "nodeTitle": "CS231n: Convolutional Neural Networks for Visual Recognition"
+      }
+    ]
+  },
+  "object-coursera-ml": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Machine Learning (Coursera)",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-coursera-ml",
+        "nodeTitle": "Machine Learning (Coursera)"
+      }
+    ]
+  },
+  "object-distill": {
+    "wikidataId": "Q63405023",
+    "wikipediaTitle": "Distill_(journal)",
+    "canonicalTitle": "Distill.pub",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-distill",
+        "nodeTitle": "Distill.pub"
+      }
+    ]
+  },
+  "location-new-york": {
+    "wikidataId": "Q60",
+    "wikipediaTitle": "New_York_City",
+    "canonicalTitle": "New York City, New York",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-new-york",
+        "nodeTitle": "New York City, New York"
+      }
+    ]
+  },
+  "location-nyu": {
+    "wikidataId": "Q49210",
+    "wikipediaTitle": "New_York_University",
+    "canonicalTitle": "New York University",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-nyu",
+        "nodeTitle": "New York University"
+      }
+    ]
+  },
+  "location-san-francisco": {
+    "wikidataId": "Q62",
+    "wikipediaTitle": "San_Francisco",
+    "canonicalTitle": "San Francisco, California",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-san-francisco",
+        "nodeTitle": "San Francisco, California"
+      }
+    ]
+  },
+  "location-mountain-view": {
+    "wikidataId": "Q486860",
+    "wikipediaTitle": "Mountain_View,_California",
+    "canonicalTitle": "Mountain View, California",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-mountain-view",
+        "nodeTitle": "Mountain View, California"
+      }
+    ]
+  },
+  "location-london": {
+    "wikidataId": "Q84",
+    "wikipediaTitle": "London",
+    "canonicalTitle": "London, United Kingdom",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-london",
+        "nodeTitle": "London, United Kingdom"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-london",
+        "nodeTitle": "London"
+      }
+    ]
+  },
+  "location-paris": {
+    "wikidataId": "Q90",
+    "wikipediaTitle": "Paris",
+    "canonicalTitle": "Paris, France",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris, France"
+      },
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris"
+      }
+    ]
+  },
+  "location-toronto": {
+    "wikidataId": "Q172",
+    "wikipediaTitle": "Toronto",
+    "canonicalTitle": "Toronto, Canada",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-toronto",
+        "nodeTitle": "Toronto, Canada"
+      }
+    ]
+  },
+  "location-montreal": {
+    "wikidataId": "Q340",
+    "wikipediaTitle": "Montreal",
+    "canonicalTitle": "Montreal, Canada",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-montreal",
+        "nodeTitle": "Montreal, Canada"
+      }
+    ]
+  },
+  "location-stanford": {
+    "wikidataId": "Q41506",
+    "wikipediaTitle": "Stanford_University",
+    "canonicalTitle": "Stanford University",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-stanford",
+        "nodeTitle": "Stanford University"
+      },
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-stanford",
+        "nodeTitle": "Stanford University"
+      }
+    ]
+  },
+  "location-utoronto": {
+    "wikidataId": "Q180865",
+    "wikipediaTitle": "University_of_Toronto",
+    "canonicalTitle": "University of Toronto",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-utoronto",
+        "nodeTitle": "University of Toronto"
+      }
+    ]
+  },
+  "location-umontreal": {
+    "wikidataId": "Q392189",
+    "wikipediaTitle": "Université_de_Montréal",
+    "canonicalTitle": "Université de Montréal",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-umontreal",
+        "nodeTitle": "Université de Montréal"
+      }
+    ]
+  },
+  "location-ucberkeley": {
+    "wikidataId": "Q168756",
+    "wikipediaTitle": "University_of_California,_Berkeley",
+    "canonicalTitle": "UC Berkeley",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-ucberkeley",
+        "nodeTitle": "UC Berkeley"
+      }
+    ]
+  },
+  "location-cmu": {
+    "wikidataId": "Q190080",
+    "wikipediaTitle": "Carnegie_Mellon_University",
+    "canonicalTitle": "Carnegie Mellon University",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-cmu",
+        "nodeTitle": "Carnegie Mellon University"
+      }
+    ]
+  },
+  "location-tokyo": {
+    "wikidataId": "Q1490",
+    "wikipediaTitle": "Tokyo",
+    "canonicalTitle": "Tokyo, Japan",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-tokyo",
+        "nodeTitle": "Tokyo, Japan"
+      }
+    ]
+  },
+  "location-edmonton": {
+    "wikidataId": "Q2096",
+    "wikipediaTitle": "Edmonton",
+    "canonicalTitle": "Edmonton, Canada",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-edmonton",
+        "nodeTitle": "Edmonton, Canada"
+      }
+    ]
+  },
+  "location-ualberta": {
+    "wikidataId": "Q38948",
+    "wikipediaTitle": "University_of_Alberta",
+    "canonicalTitle": "University of Alberta",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-ualberta",
+        "nodeTitle": "University of Alberta"
+      }
+    ]
+  },
+  "entity-openai": {
+    "wikidataId": "Q21708200",
+    "wikipediaTitle": "OpenAI",
+    "canonicalTitle": "OpenAI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-openai",
+        "nodeTitle": "OpenAI"
+      }
+    ]
+  },
+  "entity-anthropic": {
+    "wikidataId": "Q106006054",
+    "wikipediaTitle": "Anthropic",
+    "canonicalTitle": "Anthropic",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-anthropic",
+        "nodeTitle": "Anthropic"
+      }
+    ]
+  },
+  "entity-google-deepmind": {
+    "wikidataId": "Q118358654",
+    "wikipediaTitle": "Google_DeepMind",
+    "canonicalTitle": "Google DeepMind",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-google-deepmind",
+        "nodeTitle": "Google DeepMind"
+      }
+    ]
+  },
+  "entity-deepmind": {
+    "wikidataId": "Q15733006",
+    "wikipediaTitle": "Google_DeepMind",
+    "canonicalTitle": "DeepMind",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-deepmind",
+        "nodeTitle": "DeepMind"
+      }
+    ]
+  },
+  "entity-google-brain": {
+    "wikidataId": "Q21072607",
+    "wikipediaTitle": "Google_Brain",
+    "canonicalTitle": "Google Brain",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-google-brain",
+        "nodeTitle": "Google Brain"
+      }
+    ]
+  },
+  "entity-meta-ai": {
+    "wikidataId": "Q19600170",
+    "wikipediaTitle": "Meta_AI",
+    "canonicalTitle": "Meta AI / FAIR",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-meta-ai",
+        "nodeTitle": "Meta AI / FAIR"
+      }
+    ]
+  },
+  "entity-xai": {
+    "wikidataId": "Q120303340",
+    "wikipediaTitle": "XAI_(company)",
+    "canonicalTitle": "xAI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-xai",
+        "nodeTitle": "xAI"
+      }
+    ]
+  },
+  "entity-mistral": {
+    "wikidataId": "Q118473029",
+    "wikipediaTitle": "Mistral_AI",
+    "canonicalTitle": "Mistral AI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-mistral",
+        "nodeTitle": "Mistral AI"
+      }
+    ]
+  },
+  "entity-huggingface": {
+    "wikidataId": "Q90727997",
+    "wikipediaTitle": "Hugging_Face",
+    "canonicalTitle": "Hugging Face",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-huggingface",
+        "nodeTitle": "Hugging Face"
+      }
+    ]
+  },
+  "entity-stability": {
+    "wikidataId": "Q113414756",
+    "wikipediaTitle": "Stability_AI",
+    "canonicalTitle": "Stability AI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-stability",
+        "nodeTitle": "Stability AI"
+      }
+    ]
+  },
+  "entity-cohere": {
+    "wikidataId": "Q117181040",
+    "wikipediaTitle": "Cohere",
+    "canonicalTitle": "Cohere",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-cohere",
+        "nodeTitle": "Cohere"
+      }
+    ]
+  },
+  "entity-sakana": {
+    "wikidataId": "Q121668234",
+    "wikipediaTitle": "Sakana_AI",
+    "canonicalTitle": "Sakana AI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-sakana",
+        "nodeTitle": "Sakana AI"
+      }
+    ]
+  },
+  "entity-mila": {
+    "wikidataId": "Q29056997",
+    "wikipediaTitle": "Mila_(research_institute)",
+    "canonicalTitle": "MILA",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-mila",
+        "nodeTitle": "MILA"
+      }
+    ]
+  },
+  "entity-vector-institute": {
+    "wikidataId": "Q39076395",
+    "wikipediaTitle": "Vector_Institute",
+    "canonicalTitle": "Vector Institute",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-vector-institute",
+        "nodeTitle": "Vector Institute"
+      }
+    ]
+  },
+  "entity-stanford-hai": {
+    "wikidataId": "Q106481889",
+    "wikipediaTitle": "Stanford_Institute_for_Human-Centered_AI",
+    "canonicalTitle": "Stanford HAI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-stanford-hai",
+        "nodeTitle": "Stanford HAI"
+      }
+    ]
+  },
+  "entity-bair": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "BAIR",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-bair",
+        "nodeTitle": "BAIR"
+      }
+    ]
+  },
+  "entity-neurips": {
+    "wikidataId": "Q2016462",
+    "wikipediaTitle": "Conference_on_Neural_Information_Processing_Systems",
+    "canonicalTitle": "NeurIPS",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-neurips",
+        "nodeTitle": "NeurIPS"
+      }
+    ]
+  },
+  "entity-iclr": {
+    "wikidataId": "Q57085111",
+    "wikipediaTitle": "International_Conference_on_Learning_Representations",
+    "canonicalTitle": "ICLR",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-iclr",
+        "nodeTitle": "ICLR"
+      }
+    ]
+  },
+  "entity-ssi": {
+    "wikidataId": "Q126055790",
+    "wikipediaTitle": "Safe_Superintelligence_Inc.",
+    "canonicalTitle": "Safe Superintelligence Inc.",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-ssi",
+        "nodeTitle": "Safe Superintelligence Inc."
+      }
+    ]
+  },
+  "entity-dair": {
+    "wikidataId": "Q110131254",
+    "wikipediaTitle": "Distributed_Artificial_Intelligence_Research_Institute",
+    "canonicalTitle": "DAIR Institute",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-dair",
+        "nodeTitle": "DAIR Institute"
+      }
+    ]
+  },
+  "entity-toronto-school": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Toronto School of Deep Learning",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-toronto-school",
+        "nodeTitle": "Toronto School of Deep Learning"
+      }
+    ]
+  },
+  "entity-montreal-school": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Montreal School of Deep Learning",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-montreal-school",
+        "nodeTitle": "Montreal School of Deep Learning"
+      }
+    ]
+  },
+  "person-tomas-mikolov": {
+    "wikidataId": "Q21658269",
+    "wikipediaTitle": "Tomáš_Mikolov",
+    "canonicalTitle": "Tomas Mikolov",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-tomas-mikolov",
+        "nodeTitle": "Tomas Mikolov"
+      }
+    ]
+  },
+  "person-jacob-devlin": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Jacob Devlin",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jacob-devlin",
+        "nodeTitle": "Jacob Devlin"
+      }
+    ]
+  },
+  "person-max-welling": {
+    "wikidataId": "Q6795393",
+    "wikipediaTitle": "Max_Welling",
+    "canonicalTitle": "Max Welling",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-max-welling",
+        "nodeTitle": "Max Welling"
+      }
+    ]
+  },
+  "object-vae-paper": {
+    "wikidataId": "Q25348086",
+    "wikipediaTitle": "Variational_autoencoder",
+    "canonicalTitle": "Auto-Encoding Variational Bayes",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-vae-paper",
+        "nodeTitle": "Auto-Encoding Variational Bayes"
+      }
+    ]
+  },
+  "object-ppo-paper": {
+    "wikidataId": "Q113503106",
+    "wikipediaTitle": "Proximal_policy_optimization",
+    "canonicalTitle": "Proximal Policy Optimization Algorithms",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-ppo-paper",
+        "nodeTitle": "Proximal Policy Optimization Algorithms"
+      }
+    ]
+  },
+  "object-trpo-paper": {
+    "wikidataId": "Q113503095",
+    "wikipediaTitle": "Trust_region_policy_optimization",
+    "canonicalTitle": "Trust Region Policy Optimization",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-trpo-paper",
+        "nodeTitle": "Trust Region Policy Optimization"
+      }
+    ]
+  },
+  "object-claude3": {
+    "wikidataId": "Q116965708",
+    "wikipediaTitle": "Claude_(language_model)",
+    "canonicalTitle": "Claude 3",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-claude3",
+        "nodeTitle": "Claude 3"
+      }
+    ]
+  },
+  "object-llama3": {
+    "wikidataId": "Q117276906",
+    "wikipediaTitle": "Llama_(language_model)",
+    "canonicalTitle": "LLaMA 3",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama3",
+        "nodeTitle": "LLaMA 3"
+      }
+    ]
+  },
+  "entity-inflection": {
+    "wikidataId": "Q110894704",
+    "wikipediaTitle": "Inflection_AI",
+    "canonicalTitle": "Inflection AI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-inflection",
+        "nodeTitle": "Inflection AI"
+      }
+    ]
+  },
+  "entity-character-ai": {
+    "wikidataId": "Q110891631",
+    "wikipediaTitle": "Character.ai",
+    "canonicalTitle": "Character.AI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-character-ai",
+        "nodeTitle": "Character.AI"
+      }
+    ]
+  },
+  "entity-amazon-ai": {
+    "wikidataId": "Q456157",
+    "wikipediaTitle": "Amazon_Web_Services",
+    "canonicalTitle": "Amazon AI / AWS",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-amazon-ai",
+        "nodeTitle": "Amazon AI / AWS"
+      }
+    ]
+  },
+  "entity-microsoft-ai": {
+    "wikidataId": "Q111449379",
+    "wikipediaTitle": "Microsoft_Copilot",
+    "canonicalTitle": "Microsoft AI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-microsoft-ai",
+        "nodeTitle": "Microsoft AI"
+      }
+    ]
+  },
+  "location-seattle": {
+    "wikidataId": "Q5083",
+    "wikipediaTitle": "Seattle",
+    "canonicalTitle": "Seattle, Washington",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-seattle",
+        "nodeTitle": "Seattle, Washington"
+      }
+    ]
+  },
+  "location-redmond": {
+    "wikidataId": "Q108524",
+    "wikipediaTitle": "Redmond,_Washington",
+    "canonicalTitle": "Redmond, Washington",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-redmond",
+        "nodeTitle": "Redmond, Washington"
+      }
+    ]
+  },
+  "object-gpt4o": {
+    "wikidataId": "Q126055869",
+    "wikipediaTitle": "GPT-4o",
+    "canonicalTitle": "GPT-4o",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt4o",
+        "nodeTitle": "GPT-4o"
+      }
+    ]
+  },
+  "object-gpt4o-mini": {
+    "wikidataId": "Q126055869",
+    "wikipediaTitle": "GPT-4o",
+    "canonicalTitle": "GPT-4o mini",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt4o-mini",
+        "nodeTitle": "GPT-4o mini"
+      }
+    ]
+  },
+  "object-o1": {
+    "wikidataId": "Q131065549",
+    "wikipediaTitle": "OpenAI_o1",
+    "canonicalTitle": "o1",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-o1",
+        "nodeTitle": "o1"
+      }
+    ]
+  },
+  "object-o3": {
+    "wikidataId": "Q133034217",
+    "wikipediaTitle": "OpenAI_o3",
+    "canonicalTitle": "o3",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-o3",
+        "nodeTitle": "o3"
+      }
+    ]
+  },
+  "object-gpt45": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "GPT-4.5 (Orion)",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt45",
+        "nodeTitle": "GPT-4.5 (Orion)"
+      }
+    ]
+  },
+  "object-claude35-sonnet": {
+    "wikidataId": "Q116965708",
+    "wikipediaTitle": "Claude_(language_model)",
+    "canonicalTitle": "Claude 3.5 Sonnet",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-claude35-sonnet",
+        "nodeTitle": "Claude 3.5 Sonnet"
+      }
+    ]
+  },
+  "object-claude4": {
+    "wikidataId": "Q116965708",
+    "wikipediaTitle": "Claude_(language_model)",
+    "canonicalTitle": "Claude 4",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-claude4",
+        "nodeTitle": "Claude 4"
+      }
+    ]
+  },
+  "object-claude45": {
+    "wikidataId": "Q116965708",
+    "wikipediaTitle": "Claude_(language_model)",
+    "canonicalTitle": "Claude 4.5",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-claude45",
+        "nodeTitle": "Claude 4.5"
+      }
+    ]
+  },
+  "object-gemini15": {
+    "wikidataId": "Q118389636",
+    "wikipediaTitle": "Gemini_(chatbot)",
+    "canonicalTitle": "Gemini 1.5 Pro",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gemini15",
+        "nodeTitle": "Gemini 1.5 Pro"
+      }
+    ]
+  },
+  "object-gemini20": {
+    "wikidataId": "Q118389636",
+    "wikipediaTitle": "Gemini_(chatbot)",
+    "canonicalTitle": "Gemini 2.0",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gemini20",
+        "nodeTitle": "Gemini 2.0"
+      }
+    ]
+  },
+  "object-gemini25": {
+    "wikidataId": "Q118389636",
+    "wikipediaTitle": "Gemini_(chatbot)",
+    "canonicalTitle": "Gemini 2.5",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gemini25",
+        "nodeTitle": "Gemini 2.5"
+      }
+    ]
+  },
+  "object-llama31": {
+    "wikidataId": "Q117276906",
+    "wikipediaTitle": "Llama_(language_model)",
+    "canonicalTitle": "LLaMA 3.1",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama31",
+        "nodeTitle": "LLaMA 3.1"
+      }
+    ]
+  },
+  "object-llama32": {
+    "wikidataId": "Q117276906",
+    "wikipediaTitle": "Llama_(language_model)",
+    "canonicalTitle": "LLaMA 3.2",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama32",
+        "nodeTitle": "LLaMA 3.2"
+      }
+    ]
+  },
+  "object-llama33": {
+    "wikidataId": "Q117276906",
+    "wikipediaTitle": "Llama_(language_model)",
+    "canonicalTitle": "LLaMA 3.3",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama33",
+        "nodeTitle": "LLaMA 3.3"
+      }
+    ]
+  },
+  "object-llama4": {
+    "wikidataId": "Q117276906",
+    "wikipediaTitle": "Llama_(language_model)",
+    "canonicalTitle": "LLaMA 4",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama4",
+        "nodeTitle": "LLaMA 4"
+      }
+    ]
+  },
+  "object-mixtral-8x22b": {
+    "wikidataId": "Q122968991",
+    "wikipediaTitle": "Mixtral",
+    "canonicalTitle": "Mixtral 8x22B",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-mixtral-8x22b",
+        "nodeTitle": "Mixtral 8x22B"
+      }
+    ]
+  },
+  "object-pixtral": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Pixtral",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-pixtral",
+        "nodeTitle": "Pixtral"
+      }
+    ]
+  },
+  "object-mistral-large3": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Mistral Large 3",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-mistral-large3",
+        "nodeTitle": "Mistral Large 3"
+      }
+    ]
+  },
+  "object-grok2": {
+    "wikidataId": "Q122645637",
+    "wikipediaTitle": "Grok_(chatbot)",
+    "canonicalTitle": "Grok 2",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-grok2",
+        "nodeTitle": "Grok 2"
+      }
+    ]
+  },
+  "object-grok3": {
+    "wikidataId": "Q122645637",
+    "wikipediaTitle": "Grok_(chatbot)",
+    "canonicalTitle": "Grok 3",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-grok3",
+        "nodeTitle": "Grok 3"
+      }
+    ]
+  },
+  "object-command-r-plus": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Command R+",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-command-r-plus",
+        "nodeTitle": "Command R+"
+      }
+    ]
+  },
+  "object-command-a": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Command A",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-command-a",
+        "nodeTitle": "Command A"
+      }
+    ]
+  },
+  "object-nova": {
+    "wikidataId": "Q133138199",
+    "wikipediaTitle": "Amazon_Nova",
+    "canonicalTitle": "Amazon Nova",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-nova",
+        "nodeTitle": "Amazon Nova"
+      }
+    ]
+  },
+  "object-nova-premier": {
+    "wikidataId": "Q133138199",
+    "wikipediaTitle": "Amazon_Nova",
+    "canonicalTitle": "Nova Premier",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-nova-premier",
+        "nodeTitle": "Nova Premier"
+      }
+    ]
+  },
+  "person-erik-satie": {
+    "wikidataId": "Q187192",
+    "wikipediaTitle": "Erik_Satie",
+    "canonicalTitle": "Erik Satie",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-erik-satie",
+        "nodeTitle": "Erik Satie"
+      }
+    ]
+  },
+  "person-luigi-russolo": {
+    "wikidataId": "Q434916",
+    "wikipediaTitle": "Luigi_Russolo",
+    "canonicalTitle": "Luigi Russolo",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-luigi-russolo",
+        "nodeTitle": "Luigi Russolo"
+      }
+    ]
+  },
+  "person-john-cage": {
+    "wikidataId": "Q180727",
+    "wikipediaTitle": "John_Cage",
+    "canonicalTitle": "John Cage",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-john-cage",
+        "nodeTitle": "John Cage"
+      }
+    ]
+  },
+  "person-morton-feldman": {
+    "wikidataId": "Q316427",
+    "wikipediaTitle": "Morton_Feldman",
+    "canonicalTitle": "Morton Feldman",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-morton-feldman",
+        "nodeTitle": "Morton Feldman"
+      }
+    ]
+  },
+  "person-pierre-schaeffer": {
+    "wikidataId": "Q315744",
+    "wikipediaTitle": "Pierre_Schaeffer",
+    "canonicalTitle": "Pierre Schaeffer",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-pierre-schaeffer",
+        "nodeTitle": "Pierre Schaeffer"
+      }
+    ]
+  },
+  "person-pierre-henry": {
+    "wikidataId": "Q544469",
+    "wikipediaTitle": "Pierre_Henry",
+    "canonicalTitle": "Pierre Henry",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-pierre-henry",
+        "nodeTitle": "Pierre Henry"
+      }
+    ]
+  },
+  "person-francois-bayle": {
+    "wikidataId": "Q1450908",
+    "wikipediaTitle": "François_Bayle",
+    "canonicalTitle": "François Bayle",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-francois-bayle",
+        "nodeTitle": "François Bayle"
+      }
+    ]
+  },
+  "person-karlheinz-stockhausen": {
+    "wikidataId": "Q154556",
+    "wikipediaTitle": "Karlheinz_Stockhausen",
+    "canonicalTitle": "Karlheinz Stockhausen",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-karlheinz-stockhausen",
+        "nodeTitle": "Karlheinz Stockhausen"
+      }
+    ]
+  },
+  "person-la-monte-young": {
+    "wikidataId": "Q432822",
+    "wikipediaTitle": "La_Monte_Young",
+    "canonicalTitle": "La Monte Young",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-la-monte-young",
+        "nodeTitle": "La Monte Young"
+      }
+    ]
+  },
+  "person-pauline-oliveros": {
+    "wikidataId": "Q444857",
+    "wikipediaTitle": "Pauline_Oliveros",
+    "canonicalTitle": "Pauline Oliveros",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-pauline-oliveros",
+        "nodeTitle": "Pauline Oliveros"
+      }
+    ]
+  },
+  "person-tony-conrad": {
+    "wikidataId": "Q481477",
+    "wikipediaTitle": "Tony_Conrad",
+    "canonicalTitle": "Tony Conrad",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-tony-conrad",
+        "nodeTitle": "Tony Conrad"
+      }
+    ]
+  },
+  "person-david-tudor": {
+    "wikidataId": "Q1176914",
+    "wikipediaTitle": "David_Tudor",
+    "canonicalTitle": "David Tudor",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-david-tudor",
+        "nodeTitle": "David Tudor"
+      }
+    ]
+  },
+  "person-delia-derbyshire": {
+    "wikidataId": "Q29544",
+    "wikipediaTitle": "Delia_Derbyshire",
+    "canonicalTitle": "Delia Derbyshire",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-delia-derbyshire",
+        "nodeTitle": "Delia Derbyshire"
+      }
+    ]
+  },
+  "person-raymond-scott": {
+    "wikidataId": "Q1334617",
+    "wikipediaTitle": "Raymond_Scott",
+    "canonicalTitle": "Raymond Scott",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-raymond-scott",
+        "nodeTitle": "Raymond Scott"
+      }
+    ]
+  },
+  "person-leon-theremin": {
+    "wikidataId": "Q333265",
+    "wikipediaTitle": "Léon_Theremin",
+    "canonicalTitle": "Leon Theremin",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-leon-theremin",
+        "nodeTitle": "Leon Theremin"
+      }
+    ]
+  },
+  "person-clara-rockmore": {
+    "wikidataId": "Q271187",
+    "wikipediaTitle": "Clara_Rockmore",
+    "canonicalTitle": "Clara Rockmore",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-clara-rockmore",
+        "nodeTitle": "Clara Rockmore"
+      }
+    ]
+  },
+  "person-maurice-martenot": {
+    "wikidataId": "Q1333326",
+    "wikipediaTitle": "Maurice_Martenot",
+    "canonicalTitle": "Maurice Martenot",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-maurice-martenot",
+        "nodeTitle": "Maurice Martenot"
+      }
+    ]
+  },
+  "person-robert-moog": {
+    "wikidataId": "Q200883",
+    "wikipediaTitle": "Robert_Moog",
+    "canonicalTitle": "Robert Moog",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-robert-moog",
+        "nodeTitle": "Robert Moog"
+      }
+    ]
+  },
+  "person-herb-deutsch": {
+    "wikidataId": "Q1608180",
+    "wikipediaTitle": "Herb_Deutsch",
+    "canonicalTitle": "Herb Deutsch",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-herb-deutsch",
+        "nodeTitle": "Herb Deutsch"
+      }
+    ]
+  },
+  "person-don-buchla": {
+    "wikidataId": "Q1238976",
+    "wikipediaTitle": "Don_Buchla",
+    "canonicalTitle": "Don Buchla",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-don-buchla",
+        "nodeTitle": "Don Buchla"
+      }
+    ]
+  },
+  "person-peter-zinovieff": {
+    "wikidataId": "Q7177851",
+    "wikipediaTitle": "Peter_Zinovieff",
+    "canonicalTitle": "Peter Zinovieff",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-peter-zinovieff",
+        "nodeTitle": "Peter Zinovieff"
+      }
+    ]
+  },
+  "person-david-cockerell": {
+    "wikidataId": null,
+    "wikipediaTitle": "David_Cockerell_(engineer)",
+    "canonicalTitle": "David Cockerell",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-david-cockerell",
+        "nodeTitle": "David Cockerell"
+      }
+    ]
+  },
+  "person-tristram-cary": {
+    "wikidataId": "Q364835",
+    "wikipediaTitle": "Tristram_Cary",
+    "canonicalTitle": "Tristram Cary",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-tristram-cary",
+        "nodeTitle": "Tristram Cary"
+      }
+    ]
+  },
+  "person-suzanne-ciani": {
+    "wikidataId": "Q391625",
+    "wikipediaTitle": "Suzanne_Ciani",
+    "canonicalTitle": "Suzanne Ciani",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-suzanne-ciani",
+        "nodeTitle": "Suzanne Ciani"
+      }
+    ]
+  },
+  "person-edgar-froese": {
+    "wikidataId": "Q505957",
+    "wikipediaTitle": "Edgar_Froese",
+    "canonicalTitle": "Edgar Froese",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-edgar-froese",
+        "nodeTitle": "Edgar Froese"
+      }
+    ]
+  },
+  "person-klaus-schulze": {
+    "wikidataId": "Q168015",
+    "wikipediaTitle": "Klaus_Schulze",
+    "canonicalTitle": "Klaus Schulze",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-klaus-schulze",
+        "nodeTitle": "Klaus Schulze"
+      }
+    ]
+  },
+  "person-conrad-schnitzler": {
+    "wikidataId": "Q571477",
+    "wikipediaTitle": "Conrad_Schnitzler",
+    "canonicalTitle": "Conrad Schnitzler",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-conrad-schnitzler",
+        "nodeTitle": "Conrad Schnitzler"
+      }
+    ]
+  },
+  "person-hans-joachim-roedelius": {
+    "wikidataId": "Q2655756",
+    "wikipediaTitle": "Hans-Joachim_Roedelius",
+    "canonicalTitle": "Hans-Joachim Roedelius",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-hans-joachim-roedelius",
+        "nodeTitle": "Hans-Joachim Roedelius"
+      }
+    ]
+  },
+  "person-dieter-moebius": {
+    "wikidataId": "Q973580",
+    "wikipediaTitle": "Dieter_Moebius",
+    "canonicalTitle": "Dieter Moebius",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-dieter-moebius",
+        "nodeTitle": "Dieter Moebius"
+      }
+    ]
+  },
+  "person-michael-rother": {
+    "wikidataId": "Q729390",
+    "wikipediaTitle": "Michael_Rother",
+    "canonicalTitle": "Michael Rother",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-michael-rother",
+        "nodeTitle": "Michael Rother"
+      }
+    ]
+  },
+  "person-klaus-dinger": {
+    "wikidataId": "Q690282",
+    "wikipediaTitle": "Klaus_Dinger",
+    "canonicalTitle": "Klaus Dinger",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-klaus-dinger",
+        "nodeTitle": "Klaus Dinger"
+      }
+    ]
+  },
+  "person-manuel-gottsching": {
+    "wikidataId": "Q427429",
+    "wikipediaTitle": "Manuel_Göttsching",
+    "canonicalTitle": "Manuel Göttsching",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-manuel-gottsching",
+        "nodeTitle": "Manuel Göttsching"
+      }
+    ]
+  },
+  "person-ralf-hutter": {
+    "wikidataId": "Q372438",
+    "wikipediaTitle": "Ralf_Hütter",
+    "canonicalTitle": "Ralf Hütter",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-ralf-hutter",
+        "nodeTitle": "Ralf Hütter"
+      }
+    ]
+  },
+  "person-florian-schneider": {
+    "wikidataId": "Q435744",
+    "wikipediaTitle": "Florian_Schneider",
+    "canonicalTitle": "Florian Schneider",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-florian-schneider",
+        "nodeTitle": "Florian Schneider"
+      }
+    ]
+  },
+  "person-conny-plank": {
+    "wikidataId": "Q61428",
+    "wikipediaTitle": "Conny_Plank",
+    "canonicalTitle": "Conny Plank",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-conny-plank",
+        "nodeTitle": "Conny Plank"
+      }
+    ]
+  },
+  "person-christopher-franke": {
+    "wikidataId": "Q61272",
+    "wikipediaTitle": "Christopher_Franke",
+    "canonicalTitle": "Christopher Franke",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-christopher-franke",
+        "nodeTitle": "Christopher Franke"
+      }
+    ]
+  },
+  "person-peter-baumann": {
+    "wikidataId": null,
+    "wikipediaTitle": "Peter_Baumann_(musician)",
+    "canonicalTitle": "Peter Baumann",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-peter-baumann",
+        "nodeTitle": "Peter Baumann"
+      }
+    ]
+  },
+  "person-brian-eno": {
+    "wikidataId": "Q569003",
+    "wikipediaTitle": "Brian_Eno",
+    "canonicalTitle": "Brian Eno",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-brian-eno",
+        "nodeTitle": "Brian Eno"
+      }
+    ]
+  },
+  "person-robert-fripp": {
+    "wikidataId": "Q203185",
+    "wikipediaTitle": "Robert_Fripp",
+    "canonicalTitle": "Robert Fripp",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-robert-fripp",
+        "nodeTitle": "Robert Fripp"
+      }
+    ]
+  },
+  "person-harold-budd": {
+    "wikidataId": "Q728029",
+    "wikipediaTitle": "Harold_Budd",
+    "canonicalTitle": "Harold Budd",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-harold-budd",
+        "nodeTitle": "Harold Budd"
+      }
+    ]
+  },
+  "person-daniel-lanois": {
+    "wikidataId": "Q935369",
+    "wikipediaTitle": "Daniel_Lanois",
+    "canonicalTitle": "Daniel Lanois",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-daniel-lanois",
+        "nodeTitle": "Daniel Lanois"
+      }
+    ]
+  },
+  "person-roger-eno": {
+    "wikidataId": "Q1351281",
+    "wikipediaTitle": "Roger_Eno",
+    "canonicalTitle": "Roger Eno",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-roger-eno",
+        "nodeTitle": "Roger Eno"
+      }
+    ]
+  },
+  "person-laraaji": {
+    "wikidataId": "Q13583325",
+    "wikipediaTitle": "Laraaji",
+    "canonicalTitle": "Laraaji",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-laraaji",
+        "nodeTitle": "Laraaji"
+      }
+    ]
+  },
+  "person-gavin-bryars": {
+    "wikidataId": "Q713939",
+    "wikipediaTitle": "Gavin_Bryars",
+    "canonicalTitle": "Gavin Bryars",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-gavin-bryars",
+        "nodeTitle": "Gavin Bryars"
+      }
+    ]
+  },
+  "person-michael-nyman": {
+    "wikidataId": "Q313639",
+    "wikipediaTitle": "Michael_Nyman",
+    "canonicalTitle": "Michael Nyman",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-michael-nyman",
+        "nodeTitle": "Michael Nyman"
+      }
+    ]
+  },
+  "person-jon-hassell": {
+    "wikidataId": "Q782528",
+    "wikipediaTitle": "Jon_Hassell",
+    "canonicalTitle": "Jon Hassell",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-jon-hassell",
+        "nodeTitle": "Jon Hassell"
+      }
+    ]
+  },
+  "person-terry-riley": {
+    "wikidataId": "Q365243",
+    "wikipediaTitle": "Terry_Riley",
+    "canonicalTitle": "Terry Riley",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-terry-riley",
+        "nodeTitle": "Terry Riley"
+      }
+    ]
+  },
+  "person-steve-reich": {
+    "wikidataId": "Q262791",
+    "wikipediaTitle": "Steve_Reich",
+    "canonicalTitle": "Steve Reich",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-steve-reich",
+        "nodeTitle": "Steve Reich"
+      }
+    ]
+  },
+  "person-philip-glass": {
+    "wikidataId": "Q189729",
+    "wikipediaTitle": "Philip_Glass",
+    "canonicalTitle": "Philip Glass",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-philip-glass",
+        "nodeTitle": "Philip Glass"
+      }
+    ]
+  },
+  "person-charlemagne-palestine": {
+    "wikidataId": "Q369916",
+    "wikipediaTitle": "Charlemagne_Palestine",
+    "canonicalTitle": "Charlemagne Palestine",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-charlemagne-palestine",
+        "nodeTitle": "Charlemagne Palestine"
+      }
+    ]
+  },
+  "person-king-tubby": {
+    "wikidataId": "Q451858",
+    "wikipediaTitle": "King_Tubby",
+    "canonicalTitle": "King Tubby",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-king-tubby",
+        "nodeTitle": "King Tubby"
+      }
+    ]
+  },
+  "person-lee-scratch-perry": {
+    "wikidataId": "Q315417",
+    "wikipediaTitle": "Lee_\"Scratch\"_Perry",
+    "canonicalTitle": "Lee \"Scratch\" Perry",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-lee-scratch-perry",
+        "nodeTitle": "Lee \"Scratch\" Perry"
+      }
+    ]
+  },
+  "person-haruomi-hosono": {
+    "wikidataId": "Q705221",
+    "wikipediaTitle": "Haruomi_Hosono",
+    "canonicalTitle": "Haruomi Hosono",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-haruomi-hosono",
+        "nodeTitle": "Haruomi Hosono"
+      }
+    ]
+  },
+  "person-hiroshi-yoshimura": {
+    "wikidataId": "Q11413264",
+    "wikipediaTitle": "Hiroshi_Yoshimura",
+    "canonicalTitle": "Hiroshi Yoshimura",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-hiroshi-yoshimura",
+        "nodeTitle": "Hiroshi Yoshimura"
+      }
+    ]
+  },
+  "person-ryuichi-sakamoto": {
+    "wikidataId": "Q345494",
+    "wikipediaTitle": "Ryuichi_Sakamoto",
+    "canonicalTitle": "Ryuichi Sakamoto",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-ryuichi-sakamoto",
+        "nodeTitle": "Ryuichi Sakamoto"
+      }
+    ]
+  },
+  "person-wendy-carlos": {
+    "wikidataId": "Q44641",
+    "wikipediaTitle": "Wendy_Carlos",
+    "canonicalTitle": "Wendy Carlos",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-wendy-carlos",
+        "nodeTitle": "Wendy Carlos"
+      }
+    ]
+  },
+  "object-satie-furniture-music": {
+    "wikidataId": "Q912383",
+    "wikipediaTitle": "Furniture_music",
+    "canonicalTitle": "Musique d'ameublement (Furniture Music)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-satie-furniture-music",
+        "nodeTitle": "Musique d'ameublement (Furniture Music)"
+      }
+    ]
+  },
+  "object-russolo-art-of-noises": {
+    "wikidataId": "Q2746944",
+    "wikipediaTitle": "The_Art_of_Noises",
+    "canonicalTitle": "The Art of Noises (L'arte dei Rumori)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-russolo-art-of-noises",
+        "nodeTitle": "The Art of Noises (L'arte dei Rumori)"
+      }
+    ]
+  },
+  "object-cage-433": {
+    "wikidataId": "Q12030",
+    "wikipediaTitle": "4′33″",
+    "canonicalTitle": "4'33\"",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-cage-433",
+        "nodeTitle": "4'33\""
+      }
+    ]
+  },
+  "object-schaeffer-etude-chemins-de-fer": {
+    "wikidataId": null,
+    "wikipediaTitle": "Études_de_bruits",
+    "canonicalTitle": "Étude aux chemins de fer",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-schaeffer-etude-chemins-de-fer",
+        "nodeTitle": "Étude aux chemins de fer"
+      }
+    ]
+  },
+  "object-schaeffer-henry-symphonie": {
+    "wikidataId": "Q3507883",
+    "wikipediaTitle": "Symphonie_pour_un_homme_seul",
+    "canonicalTitle": "Symphonie pour un homme seul",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-schaeffer-henry-symphonie",
+        "nodeTitle": "Symphonie pour un homme seul"
+      }
+    ]
+  },
+  "object-stockhausen-gesang": {
+    "wikidataId": "Q1129735",
+    "wikipediaTitle": "Gesang_der_Jünglinge",
+    "canonicalTitle": "Gesang der Jünglinge",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-stockhausen-gesang",
+        "nodeTitle": "Gesang der Jünglinge"
+      }
+    ]
+  },
+  "object-riley-in-c": {
+    "wikidataId": "Q1500990",
+    "wikipediaTitle": "In_C",
+    "canonicalTitle": "In C",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-riley-in-c",
+        "nodeTitle": "In C"
+      }
+    ]
+  },
+  "object-riley-rainbow": {
+    "wikidataId": "Q2819874",
+    "wikipediaTitle": "A_Rainbow_in_Curved_Air",
+    "canonicalTitle": "A Rainbow in Curved Air",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-riley-rainbow",
+        "nodeTitle": "A Rainbow in Curved Air"
+      }
+    ]
+  },
+  "object-reich-its-gonna-rain": {
+    "wikidataId": "Q3155783",
+    "wikipediaTitle": "It's_Gonna_Rain",
+    "canonicalTitle": "It's Gonna Rain",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-reich-its-gonna-rain",
+        "nodeTitle": "It's Gonna Rain"
+      }
+    ]
+  },
+  "object-reich-music-for-18": {
+    "wikidataId": "Q2714697",
+    "wikipediaTitle": "Music_for_18_Musicians",
+    "canonicalTitle": "Music for 18 Musicians",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-reich-music-for-18",
+        "nodeTitle": "Music for 18 Musicians"
+      }
+    ]
+  },
+  "object-young-well-tuned-piano": {
+    "wikidataId": "Q3523344",
+    "wikipediaTitle": "The_Well-Tuned_Piano",
+    "canonicalTitle": "The Well-Tuned Piano",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-young-well-tuned-piano",
+        "nodeTitle": "The Well-Tuned Piano"
+      }
+    ]
+  },
+  "object-young-dream-house": {
+    "wikidataId": null,
+    "wikipediaTitle": "Dream_House_(art_installation)",
+    "canonicalTitle": "Dream House",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-young-dream-house",
+        "nodeTitle": "Dream House"
+      }
+    ]
+  },
+  "object-td-phaedra": {
+    "wikidataId": "Q642815",
+    "wikipediaTitle": "Phaedra_(album)",
+    "canonicalTitle": "Phaedra",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-td-phaedra",
+        "nodeTitle": "Phaedra"
+      }
+    ]
+  },
+  "object-td-rubycon": {
+    "wikidataId": "Q729361",
+    "wikipediaTitle": "Rubycon_(album)",
+    "canonicalTitle": "Rubycon",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-td-rubycon",
+        "nodeTitle": "Rubycon"
+      }
+    ]
+  },
+  "object-td-electronic-meditation": {
+    "wikidataId": "Q2296309",
+    "wikipediaTitle": "Electronic_Meditation",
+    "canonicalTitle": "Electronic Meditation",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-td-electronic-meditation",
+        "nodeTitle": "Electronic Meditation"
+      }
+    ]
+  },
+  "object-schulze-irrlicht": {
+    "wikidataId": "Q240785",
+    "wikipediaTitle": "Irrlicht",
+    "canonicalTitle": "Irrlicht",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-schulze-irrlicht",
+        "nodeTitle": "Irrlicht"
+      }
+    ]
+  },
+  "object-schulze-timewind": {
+    "wikidataId": "Q1933643",
+    "wikipediaTitle": "Timewind",
+    "canonicalTitle": "Timewind",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-schulze-timewind",
+        "nodeTitle": "Timewind"
+      }
+    ]
+  },
+  "object-cluster-zuckerzeit": {
+    "wikidataId": "Q31595",
+    "wikipediaTitle": "Zuckerzeit",
+    "canonicalTitle": "Zuckerzeit",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-cluster-zuckerzeit",
+        "nodeTitle": "Zuckerzeit"
+      }
+    ]
+  },
+  "object-cluster-sowiesoso": {
+    "wikidataId": "Q31512",
+    "wikipediaTitle": "Sowiesoso",
+    "canonicalTitle": "Sowiesoso",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-cluster-sowiesoso",
+        "nodeTitle": "Sowiesoso"
+      }
+    ]
+  },
+  "object-cluster-eno": {
+    "wikidataId": "Q2980401",
+    "wikipediaTitle": "Cluster_&_Eno",
+    "canonicalTitle": "Cluster & Eno",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-cluster-eno",
+        "nodeTitle": "Cluster & Eno"
+      }
+    ]
+  },
+  "object-after-the-heat": {
+    "wikidataId": "Q4690656",
+    "wikipediaTitle": "After_the_Heat",
+    "canonicalTitle": "After the Heat",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-after-the-heat",
+        "nodeTitle": "After the Heat"
+      }
+    ]
+  },
+  "object-harmonia-musik": {
+    "wikidataId": "Q6942662",
+    "wikipediaTitle": "Musik_von_Harmonia",
+    "canonicalTitle": "Musik von Harmonia",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-harmonia-musik",
+        "nodeTitle": "Musik von Harmonia"
+      }
+    ]
+  },
+  "object-harmonia-tracks-traces": {
+    "wikidataId": "Q7831590",
+    "wikipediaTitle": "Tracks_and_Traces",
+    "canonicalTitle": "Tracks and Traces",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-harmonia-tracks-traces",
+        "nodeTitle": "Tracks and Traces"
+      }
+    ]
+  },
+  "object-neu-1": {
+    "wikidataId": "Q1566338",
+    "wikipediaTitle": "Neu!_(album)",
+    "canonicalTitle": "Neu!",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-neu-1",
+        "nodeTitle": "Neu!"
+      }
+    ]
+  },
+  "object-neu-75": {
+    "wikidataId": "Q1065671",
+    "wikipediaTitle": "Neu!_'75",
+    "canonicalTitle": "Neu! 75",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-neu-75",
+        "nodeTitle": "Neu! 75"
+      }
+    ]
+  },
+  "object-gottsching-e2e4": {
+    "wikidataId": "Q1273664",
+    "wikipediaTitle": "E2-E4",
+    "canonicalTitle": "E2-E4",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-gottsching-e2e4",
+        "nodeTitle": "E2-E4"
+      }
+    ]
+  },
+  "object-gottsching-new-age": {
+    "wikidataId": "Q656796",
+    "wikipediaTitle": "New_Age_of_Earth",
+    "canonicalTitle": "New Age of Earth",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-gottsching-new-age",
+        "nodeTitle": "New Age of Earth"
+      }
+    ]
+  },
+  "object-kraftwerk-autobahn": {
+    "wikidataId": "Q544099",
+    "wikipediaTitle": "Autobahn_(album)",
+    "canonicalTitle": "Autobahn",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-kraftwerk-autobahn",
+        "nodeTitle": "Autobahn"
+      }
+    ]
+  },
+  "object-fripp-eno-no-pussyfooting": {
+    "wikidataId": "Q1815536",
+    "wikipediaTitle": "(No_Pussyfooting)",
+    "canonicalTitle": "(No Pussyfooting)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-fripp-eno-no-pussyfooting",
+        "nodeTitle": "(No Pussyfooting)"
+      }
+    ]
+  },
+  "object-fripp-eno-evening-star": {
+    "wikidataId": "Q16928269",
+    "wikipediaTitle": "Evening_Star_(album)",
+    "canonicalTitle": "Evening Star",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-fripp-eno-evening-star",
+        "nodeTitle": "Evening Star"
+      }
+    ]
+  },
+  "object-eno-discreet-music": {
+    "wikidataId": "Q2058212",
+    "wikipediaTitle": "Discreet_Music",
+    "canonicalTitle": "Discreet Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-discreet-music",
+        "nodeTitle": "Discreet Music"
+      }
+    ]
+  },
+  "object-eno-another-green-world": {
+    "wikidataId": "Q771427",
+    "wikipediaTitle": "Another_Green_World",
+    "canonicalTitle": "Another Green World",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-another-green-world",
+        "nodeTitle": "Another Green World"
+      }
+    ]
+  },
+  "object-eno-music-for-airports": {
+    "wikidataId": "Q127100",
+    "wikipediaTitle": "Ambient_1:_Music_for_Airports",
+    "canonicalTitle": "Ambient 1: Music for Airports",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-music-for-airports",
+        "nodeTitle": "Ambient 1: Music for Airports"
+      }
+    ]
+  },
+  "object-eno-budd-plateaux": {
+    "wikidataId": "Q2842051",
+    "wikipediaTitle": "Ambient_2:_The_Plateaux_of_Mirror",
+    "canonicalTitle": "Ambient 2: The Plateaux of Mirror",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-budd-plateaux",
+        "nodeTitle": "Ambient 2: The Plateaux of Mirror"
+      }
+    ]
+  },
+  "object-laraaji-day-of-radiance": {
+    "wikidataId": "Q2842048",
+    "wikipediaTitle": "Ambient_3:_Day_of_Radiance",
+    "canonicalTitle": "Ambient 3: Day of Radiance",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-laraaji-day-of-radiance",
+        "nodeTitle": "Ambient 3: Day of Radiance"
+      }
+    ]
+  },
+  "object-eno-on-land": {
+    "wikidataId": "Q958618",
+    "wikipediaTitle": "Ambient_4:_On_Land",
+    "canonicalTitle": "Ambient 4: On Land",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-on-land",
+        "nodeTitle": "Ambient 4: On Land"
+      }
+    ]
+  },
+  "object-apollo": {
+    "wikidataId": "Q3282479",
+    "wikipediaTitle": "Apollo:_Atmospheres_&_Soundtracks",
+    "canonicalTitle": "Apollo: Atmospheres & Soundtracks",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-apollo",
+        "nodeTitle": "Apollo: Atmospheres & Soundtracks"
+      }
+    ]
+  },
+  "object-eno-budd-pearl": {
+    "wikidataId": "Q3522197",
+    "wikipediaTitle": "The_Pearl_(album)",
+    "canonicalTitle": "The Pearl",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-budd-pearl",
+        "nodeTitle": "The Pearl"
+      }
+    ]
+  },
+  "object-budd-pavilion": {
+    "wikidataId": "Q3522191",
+    "wikipediaTitle": "The_Pavilion_of_Dreams",
+    "canonicalTitle": "The Pavilion of Dreams",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-budd-pavilion",
+        "nodeTitle": "The Pavilion of Dreams"
+      }
+    ]
+  },
+  "object-hassell-eno-fourth-world": {
+    "wikidataId": "Q8135341",
+    "wikipediaTitle": "Fourth_World,_Vol._1:_Possible_Musics",
+    "canonicalTitle": "Fourth World Vol. 1: Possible Musics",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-hassell-eno-fourth-world",
+        "nodeTitle": "Fourth World Vol. 1: Possible Musics"
+      }
+    ]
+  },
+  "object-bryars-titanic": {
+    "wikidataId": null,
+    "wikipediaTitle": "The_Sinking_of_the_Titanic_(album)",
+    "canonicalTitle": "The Sinking of the Titanic",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-bryars-titanic",
+        "nodeTitle": "The Sinking of the Titanic"
+      }
+    ]
+  },
+  "object-bryars-jesus-blood": {
+    "wikidataId": "Q6188046",
+    "wikipediaTitle": "Jesus'_Blood_Never_Failed_Me_Yet",
+    "canonicalTitle": "Jesus' Blood Never Failed Me Yet",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-bryars-jesus-blood",
+        "nodeTitle": "Jesus' Blood Never Failed Me Yet"
+      }
+    ]
+  },
+  "object-nyman-decay": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Decay Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-nyman-decay",
+        "nodeTitle": "Decay Music"
+      }
+    ]
+  },
+  "object-yoshimura-postcards": {
+    "wikidataId": "Q85787170",
+    "wikipediaTitle": "Music_for_Nine_Post_Cards",
+    "canonicalTitle": "Music for Nine Post Cards",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-yoshimura-postcards",
+        "nodeTitle": "Music for Nine Post Cards"
+      }
+    ]
+  },
+  "object-yoshimura-green": {
+    "wikidataId": "Q107388794",
+    "wikipediaTitle": "Green_(Hiroshi_Yoshimura_album)",
+    "canonicalTitle": "Green",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-yoshimura-green",
+        "nodeTitle": "Green"
+      }
+    ]
+  },
+  "object-hosono-watering": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Watering a Flower",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-hosono-watering",
+        "nodeTitle": "Watering a Flower"
+      }
+    ]
+  },
+  "object-sakamoto-async": {
+    "wikidataId": "Q48765523",
+    "wikipediaTitle": "Async_(album)",
+    "canonicalTitle": "async",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-sakamoto-async",
+        "nodeTitle": "async"
+      }
+    ]
+  },
+  "object-carlos-switched-on": {
+    "wikidataId": "Q3283363",
+    "wikipediaTitle": "Switched-On_Bach",
+    "canonicalTitle": "Switched-On Bach",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-carlos-switched-on",
+        "nodeTitle": "Switched-On Bach"
+      }
+    ]
+  },
+  "object-perry-super-ape": {
+    "wikidataId": "Q719189",
+    "wikipediaTitle": "Super_Ape",
+    "canonicalTitle": "Super Ape",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-perry-super-ape",
+        "nodeTitle": "Super Ape"
+      }
+    ]
+  },
+  "object-tubby-dub-roots": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Dub from the Roots",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-tubby-dub-roots",
+        "nodeTitle": "Dub from the Roots"
+      }
+    ]
+  },
+  "object-cage-silence": {
+    "wikidataId": "Q7514348",
+    "wikipediaTitle": "Silence:_Lectures_and_Writings",
+    "canonicalTitle": "Silence",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-cage-silence",
+        "nodeTitle": "Silence"
+      }
+    ]
+  },
+  "object-eno-ambient-manifesto": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Music for Airports Liner Notes",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-ambient-manifesto",
+        "nodeTitle": "Music for Airports Liner Notes"
+      }
+    ]
+  },
+  "object-schaeffer-traite": {
+    "wikidataId": null,
+    "wikipediaTitle": "Traité_des_objets_musicaux",
+    "canonicalTitle": "Traité des objets musicaux",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-schaeffer-traite",
+        "nodeTitle": "Traité des objets musicaux"
+      }
+    ]
+  },
+  "object-nyman-experimental-music": {
+    "wikidataId": null,
+    "wikipediaTitle": "Experimental_Music:_Cage_and_Beyond",
+    "canonicalTitle": "Experimental Music: Cage and Beyond",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-nyman-experimental-music",
+        "nodeTitle": "Experimental Music: Cage and Beyond"
+      }
+    ]
+  },
+  "object-moog-modular": {
+    "wikidataId": "Q426035",
+    "wikipediaTitle": "Moog_synthesizer",
+    "canonicalTitle": "Moog Modular Synthesizer",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-moog-modular",
+        "nodeTitle": "Moog Modular Synthesizer"
+      }
+    ]
+  },
+  "object-minimoog": {
+    "wikidataId": "Q734687",
+    "wikipediaTitle": "Minimoog",
+    "canonicalTitle": "Minimoog",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-minimoog",
+        "nodeTitle": "Minimoog"
+      }
+    ]
+  },
+  "object-buchla-100": {
+    "wikidataId": "Q4676716",
+    "wikipediaTitle": "Buchla_Electronic_Musical_Instruments",
+    "canonicalTitle": "Buchla 100 Series",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-buchla-100",
+        "nodeTitle": "Buchla 100 Series"
+      }
+    ]
+  },
+  "object-buchla-easel": {
+    "wikidataId": null,
+    "wikipediaTitle": "Buchla_Music_Easel",
+    "canonicalTitle": "Buchla Music Easel",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-buchla-easel",
+        "nodeTitle": "Buchla Music Easel"
+      }
+    ]
+  },
+  "object-ems-vcs3": {
+    "wikidataId": "Q514109",
+    "wikipediaTitle": "EMS_VCS_3",
+    "canonicalTitle": "VCS3 (Putney)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-ems-vcs3",
+        "nodeTitle": "VCS3 (Putney)"
+      }
+    ]
+  },
+  "object-ems-synthi-aks": {
+    "wikidataId": "Q3717397",
+    "wikipediaTitle": "EMS_Synthi_AKS",
+    "canonicalTitle": "Synthi AKS",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-ems-synthi-aks",
+        "nodeTitle": "Synthi AKS"
+      }
+    ]
+  },
+  "object-theremin": {
+    "wikidataId": "Q207691",
+    "wikipediaTitle": "Theremin",
+    "canonicalTitle": "Theremin",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-theremin",
+        "nodeTitle": "Theremin"
+      }
+    ]
+  },
+  "object-ondes-martenot": {
+    "wikidataId": "Q862501",
+    "wikipediaTitle": "Ondes_Martenot",
+    "canonicalTitle": "Ondes Martenot",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-ondes-martenot",
+        "nodeTitle": "Ondes Martenot"
+      }
+    ]
+  },
+  "object-intonarumori": {
+    "wikidataId": "Q3153674",
+    "wikipediaTitle": "Intonarumori",
+    "canonicalTitle": "Intonarumori",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-intonarumori",
+        "nodeTitle": "Intonarumori"
+      }
+    ]
+  },
+  "object-frippertronics": {
+    "wikidataId": "Q1054058",
+    "wikipediaTitle": "Frippertronics",
+    "canonicalTitle": "Frippertronics System",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-frippertronics",
+        "nodeTitle": "Frippertronics System"
+      }
+    ]
+  },
+  "object-acousmonium": {
+    "wikidataId": "Q2823426",
+    "wikipediaTitle": "Acousmonium",
+    "canonicalTitle": "Acousmonium",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-acousmonium",
+        "nodeTitle": "Acousmonium"
+      }
+    ]
+  },
+  "object-electronium": {
+    "wikidataId": "Q5358503",
+    "wikipediaTitle": "Electronium",
+    "canonicalTitle": "Electronium",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-electronium",
+        "nodeTitle": "Electronium"
+      }
+    ]
+  },
+  "loc-berlin": {
+    "wikidataId": "Q64",
+    "wikipediaTitle": "Berlin",
+    "canonicalTitle": "Berlin",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-berlin",
+        "nodeTitle": "Berlin"
+      }
+    ]
+  },
+  "loc-dusseldorf": {
+    "wikidataId": "Q1718",
+    "wikipediaTitle": "Düsseldorf",
+    "canonicalTitle": "Düsseldorf",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-dusseldorf",
+        "nodeTitle": "Düsseldorf"
+      }
+    ]
+  },
+  "loc-cologne": {
+    "wikidataId": "Q365",
+    "wikipediaTitle": "Cologne",
+    "canonicalTitle": "Cologne",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-cologne",
+        "nodeTitle": "Cologne"
+      }
+    ]
+  },
+  "loc-forst": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Forst",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-forst",
+        "nodeTitle": "Forst"
+      }
+    ]
+  },
+  "loc-paris": {
+    "wikidataId": "Q90",
+    "wikipediaTitle": "Paris",
+    "canonicalTitle": "Paris",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-paris",
+        "nodeTitle": "Paris"
+      }
+    ]
+  },
+  "loc-london": {
+    "wikidataId": "Q84",
+    "wikipediaTitle": "London",
+    "canonicalTitle": "London",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "loc-london",
+        "nodeTitle": "London"
+      }
+    ]
+  },
+  "loc-new-york": {
+    "wikidataId": "Q60",
+    "wikipediaTitle": "New_York_City",
+    "canonicalTitle": "New York City",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-new-york",
+        "nodeTitle": "New York City"
+      }
+    ]
+  },
+  "loc-san-francisco": {
+    "wikidataId": "Q213205",
+    "wikipediaTitle": "San_Francisco_Bay_Area",
+    "canonicalTitle": "San Francisco Bay Area",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-san-francisco",
+        "nodeTitle": "San Francisco Bay Area"
+      }
+    ]
+  },
+  "loc-kingston": {
+    "wikidataId": "Q34692",
+    "wikipediaTitle": "Kingston,_Jamaica",
+    "canonicalTitle": "Kingston",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-kingston",
+        "nodeTitle": "Kingston"
+      }
+    ]
+  },
+  "loc-tokyo": {
+    "wikidataId": "Q1490",
+    "wikipediaTitle": "Tokyo",
+    "canonicalTitle": "Tokyo",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-tokyo",
+        "nodeTitle": "Tokyo"
+      }
+    ]
+  },
+  "loc-milan": {
+    "wikidataId": "Q490",
+    "wikipediaTitle": "Milan",
+    "canonicalTitle": "Milan",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-milan",
+        "nodeTitle": "Milan"
+      }
+    ]
+  },
+  "loc-hamilton": {
+    "wikidataId": "Q133116",
+    "wikipediaTitle": "Hamilton,_Ontario",
+    "canonicalTitle": "Hamilton, Ontario",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-hamilton",
+        "nodeTitle": "Hamilton, Ontario"
+      }
+    ]
+  },
+  "loc-conny-studio": {
+    "wikidataId": "Q61428",
+    "wikipediaTitle": "Conny_Plank",
+    "canonicalTitle": "Conny Plank's Studio",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-conny-studio",
+        "nodeTitle": "Conny Plank's Studio"
+      }
+    ]
+  },
+  "loc-grm": {
+    "wikidataId": null,
+    "wikipediaTitle": "Groupe_de_recherches_musicales",
+    "canonicalTitle": "GRM (Groupe de Recherches Musicales)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-grm",
+        "nodeTitle": "GRM (Groupe de Recherches Musicales)"
+      }
+    ]
+  },
+  "loc-wdr-studio": {
+    "wikidataId": "Q2358704",
+    "wikipediaTitle": "Studio_for_Electronic_Music_(WDR)",
+    "canonicalTitle": "WDR Studio for Electronic Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-wdr-studio",
+        "nodeTitle": "WDR Studio for Electronic Music"
+      }
+    ]
+  },
+  "loc-bbc-radiophonic": {
+    "wikidataId": "Q1778799",
+    "wikipediaTitle": "BBC_Radiophonic_Workshop",
+    "canonicalTitle": "BBC Radiophonic Workshop",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-bbc-radiophonic",
+        "nodeTitle": "BBC Radiophonic Workshop"
+      }
+    ]
+  },
+  "loc-king-tubby-studio": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "King Tubby's Studio",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-king-tubby-studio",
+        "nodeTitle": "King Tubby's Studio"
+      }
+    ]
+  },
+  "loc-black-ark": {
+    "wikidataId": null,
+    "wikipediaTitle": "Black_Ark",
+    "canonicalTitle": "Black Ark Studio",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-black-ark",
+        "nodeTitle": "Black Ark Studio"
+      }
+    ]
+  },
+  "loc-kling-klang": {
+    "wikidataId": "Q76186012",
+    "wikipediaTitle": "Kling_Klang_Studio",
+    "canonicalTitle": "Kling Klang Studio",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-kling-klang",
+        "nodeTitle": "Kling Klang Studio"
+      }
+    ]
+  },
+  "loc-grant-avenue": {
+    "wikidataId": "Q118898952",
+    "wikipediaTitle": "Grant_Avenue_Studio",
+    "canonicalTitle": "Grant Avenue Studio",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-grant-avenue",
+        "nodeTitle": "Grant Avenue Studio"
+      }
+    ]
+  },
+  "loc-ems-studio": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "EMS Studio",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-ems-studio",
+        "nodeTitle": "EMS Studio"
+      }
+    ]
+  },
+  "loc-hansa": {
+    "wikidataId": "Q667023",
+    "wikipediaTitle": "Hansa_Tonstudio",
+    "canonicalTitle": "Hansa Studio",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-hansa",
+        "nodeTitle": "Hansa Studio"
+      }
+    ]
+  },
+  "loc-sftmc": {
+    "wikidataId": "Q3471440",
+    "wikipediaTitle": "San_Francisco_Tape_Music_Center",
+    "canonicalTitle": "San Francisco Tape Music Center",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-sftmc",
+        "nodeTitle": "San Francisco Tape Music Center"
+      }
+    ]
+  },
+  "loc-mills": {
+    "wikidataId": "Q638859",
+    "wikipediaTitle": "Mills_College",
+    "canonicalTitle": "Mills College",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-mills",
+        "nodeTitle": "Mills College"
+      }
+    ]
+  },
+  "loc-darmstadt": {
+    "wikidataId": null,
+    "wikipediaTitle": "Darmstadt_International_Summer_Courses_for_New_Music",
+    "canonicalTitle": "Darmstadt Summer Courses",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-darmstadt",
+        "nodeTitle": "Darmstadt Summer Courses"
+      }
+    ]
+  },
+  "loc-zodiak": {
+    "wikidataId": "Q218160",
+    "wikipediaTitle": "Zodiak_Free_Arts_Lab",
+    "canonicalTitle": "Zodiak Free Arts Lab",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-zodiak",
+        "nodeTitle": "Zodiak Free Arts Lab"
+      }
+    ]
+  },
+  "loc-british-art-schools": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Ipswich/Winchester Art Schools",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-british-art-schools",
+        "nodeTitle": "Ipswich/Winchester Art Schools"
+      }
+    ]
+  },
+  "loc-dusseldorf-academy": {
+    "wikidataId": "Q662355",
+    "wikipediaTitle": "Kunstakademie_Düsseldorf",
+    "canonicalTitle": "Düsseldorf Art Academy",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-dusseldorf-academy",
+        "nodeTitle": "Düsseldorf Art Academy"
+      }
+    ]
+  },
+  "loc-kitchen": {
+    "wikidataId": null,
+    "wikipediaTitle": "The_Kitchen",
+    "canonicalTitle": "The Kitchen",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-kitchen",
+        "nodeTitle": "The Kitchen"
+      }
+    ]
+  },
+  "loc-washington-square": {
+    "wikidataId": "Q909592",
+    "wikipediaTitle": "Washington_Square_Park",
+    "canonicalTitle": "Washington Square Park",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-washington-square",
+        "nodeTitle": "Washington Square Park"
+      }
+    ]
+  },
+  "loc-dream-house-install": {
+    "wikidataId": null,
+    "wikipediaTitle": "Dream_House_(art_installation)",
+    "canonicalTitle": "Dream House Installation",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-dream-house-install",
+        "nodeTitle": "Dream House Installation"
+      }
+    ]
+  },
+  "loc-young-loft": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "La Monte Young's Loft",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-young-loft",
+        "nodeTitle": "La Monte Young's Loft"
+      }
+    ]
+  },
+  "entity-tangerine-dream": {
+    "wikidataId": "Q153616",
+    "wikipediaTitle": "Tangerine_Dream",
+    "canonicalTitle": "Tangerine Dream",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-tangerine-dream",
+        "nodeTitle": "Tangerine Dream"
+      }
+    ]
+  },
+  "entity-cluster": {
+    "wikidataId": "Q705382",
+    "wikipediaTitle": "Cluster_(band)",
+    "canonicalTitle": "Cluster",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-cluster",
+        "nodeTitle": "Cluster"
+      }
+    ]
+  },
+  "entity-harmonia": {
+    "wikidataId": "Q568238",
+    "wikipediaTitle": "Harmonia_(band)",
+    "canonicalTitle": "Harmonia",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-harmonia",
+        "nodeTitle": "Harmonia"
+      }
+    ]
+  },
+  "entity-neu": {
+    "wikidataId": "Q181874",
+    "wikipediaTitle": "Neu!",
+    "canonicalTitle": "Neu!",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-neu",
+        "nodeTitle": "Neu!"
+      }
+    ]
+  },
+  "entity-kraftwerk": {
+    "wikidataId": "Q44892",
+    "wikipediaTitle": "Kraftwerk",
+    "canonicalTitle": "Kraftwerk",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-kraftwerk",
+        "nodeTitle": "Kraftwerk"
+      }
+    ]
+  },
+  "entity-ash-ra-tempel": {
+    "wikidataId": "Q700817",
+    "wikipediaTitle": "Ash_Ra_Tempel",
+    "canonicalTitle": "Ash Ra Tempel",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-ash-ra-tempel",
+        "nodeTitle": "Ash Ra Tempel"
+      }
+    ]
+  },
+  "entity-theatre-eternal-music": {
+    "wikidataId": "Q3496301",
+    "wikipediaTitle": "Theatre_of_Eternal_Music",
+    "canonicalTitle": "Theatre of Eternal Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-theatre-eternal-music",
+        "nodeTitle": "Theatre of Eternal Music"
+      }
+    ]
+  },
+  "entity-roxy-music": {
+    "wikidataId": "Q334648",
+    "wikipediaTitle": "Roxy_Music",
+    "canonicalTitle": "Roxy Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-roxy-music",
+        "nodeTitle": "Roxy Music"
+      }
+    ]
+  },
+  "entity-king-crimson": {
+    "wikidataId": "Q189382",
+    "wikipediaTitle": "King_Crimson",
+    "canonicalTitle": "King Crimson",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-king-crimson",
+        "nodeTitle": "King Crimson"
+      }
+    ]
+  },
+  "entity-ymo": {
+    "wikidataId": "Q854590",
+    "wikipediaTitle": "Yellow_Magic_Orchestra",
+    "canonicalTitle": "Yellow Magic Orchestra",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-ymo",
+        "nodeTitle": "Yellow Magic Orchestra"
+      }
+    ]
+  },
+  "entity-new-york-school": {
+    "wikidataId": "Q1972942",
+    "wikipediaTitle": "New_York_School_(art)",
+    "canonicalTitle": "New York School",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-new-york-school",
+        "nodeTitle": "New York School"
+      }
+    ]
+  },
+  "entity-deep-listening-band": {
+    "wikidataId": "Q5250235",
+    "wikipediaTitle": "Deep_Listening_Band",
+    "canonicalTitle": "Deep Listening Band",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-deep-listening-band",
+        "nodeTitle": "Deep Listening Band"
+      }
+    ]
+  },
+  "entity-can": {
+    "wikidataId": "Q170132",
+    "wikipediaTitle": "Can_(band)",
+    "canonicalTitle": "Can",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-can",
+        "nodeTitle": "Can"
+      }
+    ]
+  },
+  "entity-faust": {
+    "wikidataId": "Q679697",
+    "wikipediaTitle": "Faust_(band)",
+    "canonicalTitle": "Faust",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-faust",
+        "nodeTitle": "Faust"
+      }
+    ]
+  },
+  "entity-obscure-records": {
+    "wikidataId": "Q3389945",
+    "wikipediaTitle": "Obscure_Records",
+    "canonicalTitle": "Obscure Records",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-obscure-records",
+        "nodeTitle": "Obscure Records"
+      }
+    ]
+  },
+  "entity-ohr": {
+    "wikidataId": "Q1518623",
+    "wikipediaTitle": "Ohr_(record_label)",
+    "canonicalTitle": "Ohr Records",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-ohr",
+        "nodeTitle": "Ohr Records"
+      }
+    ]
+  },
+  "entity-brain": {
+    "wikidataId": null,
+    "wikipediaTitle": "Brain_(record_label)",
+    "canonicalTitle": "Brain Records",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-brain",
+        "nodeTitle": "Brain Records"
+      }
+    ]
+  },
+  "entity-virgin-german": {
+    "wikidataId": "Q203059",
+    "wikipediaTitle": "Virgin_Records",
+    "canonicalTitle": "Virgin Records",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-virgin-german",
+        "nodeTitle": "Virgin Records"
+      }
+    ]
+  },
+  "entity-private-music": {
+    "wikidataId": "Q6318209",
+    "wikipediaTitle": "Private_Music",
+    "canonicalTitle": "Private Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-private-music",
+        "nodeTitle": "Private Music"
+      }
+    ]
+  },
+  "entity-eg-records": {
+    "wikidataId": "Q1611073",
+    "wikipediaTitle": "E.G._Records",
+    "canonicalTitle": "EG Records",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-eg-records",
+        "nodeTitle": "EG Records"
+      }
+    ]
+  },
+  "entity-editions-eg": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Editions EG",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-editions-eg",
+        "nodeTitle": "Editions EG"
+      }
+    ]
+  },
+  "entity-grm-editions": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "GRM Editions",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-grm-editions",
+        "nodeTitle": "GRM Editions"
+      }
+    ]
+  },
+  "entity-ambient-movement": {
+    "wikidataId": "Q193207",
+    "wikipediaTitle": "Ambient_music",
+    "canonicalTitle": "Ambient Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-ambient-movement",
+        "nodeTitle": "Ambient Music"
+      }
+    ]
+  },
+  "entity-musique-concrete": {
+    "wikidataId": "Q823560",
+    "wikipediaTitle": "Musique_concrète",
+    "canonicalTitle": "Musique Concrète",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-musique-concrete",
+        "nodeTitle": "Musique Concrète"
+      }
+    ]
+  },
+  "entity-minimalism": {
+    "wikidataId": "Q572901",
+    "wikipediaTitle": "Minimal_music",
+    "canonicalTitle": "Minimalism",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-minimalism",
+        "nodeTitle": "Minimalism"
+      }
+    ]
+  },
+  "entity-berlin-school": {
+    "wikidataId": null,
+    "wikipediaTitle": "Berlin_School_(electronic_music)",
+    "canonicalTitle": "Berlin School",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-berlin-school",
+        "nodeTitle": "Berlin School"
+      }
+    ]
+  },
+  "entity-krautrock": {
+    "wikidataId": "Q320592",
+    "wikipediaTitle": "Krautrock",
+    "canonicalTitle": "Krautrock",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-krautrock",
+        "nodeTitle": "Krautrock"
+      }
+    ]
+  },
+  "entity-kankyo-ongaku": {
+    "wikidataId": null,
+    "wikipediaTitle": "Kankyō_ongaku",
+    "canonicalTitle": "Kankyō Ongaku",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-kankyo-ongaku",
+        "nodeTitle": "Kankyō Ongaku"
+      }
+    ]
+  },
+  "entity-dub": {
+    "wikidataId": "Q212688",
+    "wikipediaTitle": "Dub_music",
+    "canonicalTitle": "Dub",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-dub",
+        "nodeTitle": "Dub"
+      }
+    ]
+  },
+  "entity-futurism": {
+    "wikidataId": "Q131221",
+    "wikipediaTitle": "Futurism",
+    "canonicalTitle": "Futurism",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-futurism",
+        "nodeTitle": "Futurism"
+      }
+    ]
+  },
+  "entity-ems": {
+    "wikidataId": "Q1326103",
+    "wikipediaTitle": "Electronic_Music_Studios",
+    "canonicalTitle": "EMS (Electronic Music Studios)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-ems",
+        "nodeTitle": "EMS (Electronic Music Studios)"
+      }
+    ]
+  },
+  "entity-moog-music": {
+    "wikidataId": "Q1650528",
+    "wikipediaTitle": "Moog_Music",
+    "canonicalTitle": "Moog Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-moog-music",
+        "nodeTitle": "Moog Music"
+      }
+    ]
+  },
+  "entity-buchla": {
+    "wikidataId": "Q4676716",
+    "wikipediaTitle": "Buchla_Electronic_Musical_Instruments",
+    "canonicalTitle": "Buchla and Associates",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-buchla",
+        "nodeTitle": "Buchla and Associates"
+      }
+    ]
+  },
+  "entity-grm-org": {
+    "wikidataId": null,
+    "wikipediaTitle": "Groupe_de_recherches_musicales",
+    "canonicalTitle": "GRM (Research Organization)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-grm-org",
+        "nodeTitle": "GRM (Research Organization)"
+      }
+    ]
+  },
+  "entity-sftmc-org": {
+    "wikidataId": "Q3471440",
+    "wikipediaTitle": "San_Francisco_Tape_Music_Center",
+    "canonicalTitle": "San Francisco Tape Music Center",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-sftmc-org",
+        "nodeTitle": "San Francisco Tape Music Center"
+      }
+    ]
+  },
+  "person-morton-subotnick": {
+    "wikidataId": "Q962366",
+    "wikipediaTitle": "Morton_Subotnick",
+    "canonicalTitle": "Morton Subotnick",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-morton-subotnick",
+        "nodeTitle": "Morton Subotnick"
+      }
+    ]
+  },
+  "person-jeanne-loriod": {
+    "wikidataId": "Q2574388",
+    "wikipediaTitle": "Jeanne_Loriod",
+    "canonicalTitle": "Jeanne Loriod",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-jeanne-loriod",
+        "nodeTitle": "Jeanne Loriod"
+      }
+    ]
+  },
+  "person-holger-czukay": {
+    "wikidataId": "Q699355",
+    "wikipediaTitle": "Holger_Czukay",
+    "canonicalTitle": "Holger Czukay",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-holger-czukay",
+        "nodeTitle": "Holger Czukay"
+      }
+    ]
+  },
+  "person-midori-takada": {
+    "wikidataId": "Q22341183",
+    "wikipediaTitle": "Midori_Takada",
+    "canonicalTitle": "Midori Takada",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-midori-takada",
+        "nodeTitle": "Midori Takada"
+      }
+    ]
+  },
+  "person-satoshi-ashikawa": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Satoshi Ashikawa",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-satoshi-ashikawa",
+        "nodeTitle": "Satoshi Ashikawa"
+      }
+    ]
+  },
+  "person-richard-d-james": {
+    "wikidataId": "Q223161",
+    "wikipediaTitle": "Aphex_Twin",
+    "canonicalTitle": "Richard D. James (Aphex Twin)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-richard-d-james",
+        "nodeTitle": "Richard D. James (Aphex Twin)"
+      }
+    ]
+  },
+  "person-alex-paterson": {
+    "wikidataId": "Q4717608",
+    "wikipediaTitle": "Alex_Paterson",
+    "canonicalTitle": "Alex Paterson (The Orb)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-alex-paterson",
+        "nodeTitle": "Alex Paterson (The Orb)"
+      }
+    ]
+  },
+  "person-bill-drummond": {
+    "wikidataId": "Q4908833",
+    "wikipediaTitle": "Bill_Drummond",
+    "canonicalTitle": "Bill Drummond",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-bill-drummond",
+        "nodeTitle": "Bill Drummond"
+      }
+    ]
+  },
+  "person-jimmy-cauty": {
+    "wikidataId": "Q5605106",
+    "wikipediaTitle": "Jimmy_Cauty",
+    "canonicalTitle": "Jimmy Cauty",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-jimmy-cauty",
+        "nodeTitle": "Jimmy Cauty"
+      }
+    ]
+  },
+  "object-subotnick-silver-apples": {
+    "wikidataId": "Q43637545",
+    "wikipediaTitle": "Silver_Apples_of_the_Moon",
+    "canonicalTitle": "Silver Apples of the Moon",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-subotnick-silver-apples",
+        "nodeTitle": "Silver Apples of the Moon"
+      }
+    ]
+  },
+  "object-czukay-canaxis": {
+    "wikidataId": null,
+    "wikipediaTitle": "Canaxis",
+    "canonicalTitle": "Canaxis 5",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-czukay-canaxis",
+        "nodeTitle": "Canaxis 5"
+      }
+    ]
+  },
+  "object-takada-looking-glass": {
+    "wikidataId": null,
+    "wikipediaTitle": "Through_the_Looking_Glass_(Midori_Takada_album)",
+    "canonicalTitle": "Through the Looking Glass",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-takada-looking-glass",
+        "nodeTitle": "Through the Looking Glass"
+      }
+    ]
+  },
+  "object-ashikawa-still-way": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Still Way (Wave Notation 2)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-ashikawa-still-way",
+        "nodeTitle": "Still Way (Wave Notation 2)"
+      }
+    ]
+  },
+  "object-aphex-saw-85-92": {
+    "wikidataId": "Q970352",
+    "wikipediaTitle": "Selected_Ambient_Works_85–92",
+    "canonicalTitle": "Selected Ambient Works 85-92",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-aphex-saw-85-92",
+        "nodeTitle": "Selected Ambient Works 85-92"
+      }
+    ]
+  },
+  "object-aphex-saw-ii": {
+    "wikidataId": "Q1933629",
+    "wikipediaTitle": "Selected_Ambient_Works_Volume_II",
+    "canonicalTitle": "Selected Ambient Works Volume II",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-aphex-saw-ii",
+        "nodeTitle": "Selected Ambient Works Volume II"
+      }
+    ]
+  },
+  "object-orb-ultraworld": {
+    "wikidataId": "Q7755273",
+    "wikipediaTitle": "The_Orb's_Adventures_Beyond_the_Ultraworld",
+    "canonicalTitle": "The Orb's Adventures Beyond the Ultraworld",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-orb-ultraworld",
+        "nodeTitle": "The Orb's Adventures Beyond the Ultraworld"
+      }
+    ]
+  },
+  "object-klf-chill-out": {
+    "wikidataId": "Q355395",
+    "wikipediaTitle": "Chill_Out_(The_KLF_album)",
+    "canonicalTitle": "Chill Out",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-klf-chill-out",
+        "nodeTitle": "Chill Out"
+      }
+    ]
+  },
+  "entity-the-orb": {
+    "wikidataId": "Q924993",
+    "wikipediaTitle": "The_Orb",
+    "canonicalTitle": "The Orb",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-the-orb",
+        "nodeTitle": "The Orb"
+      }
+    ]
+  },
+  "entity-klf": {
+    "wikidataId": "Q741316",
+    "wikipediaTitle": "The_KLF",
+    "canonicalTitle": "The KLF",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-klf",
+        "nodeTitle": "The KLF"
+      }
+    ]
+  },
+  "entity-sound-process": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Sound Process",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-sound-process",
+        "nodeTitle": "Sound Process"
+      }
+    ]
+  },
+  "person-johannes-reuchlin": {
+    "wikidataId": "Q60637",
+    "wikipediaTitle": "Johann_Reuchlin",
+    "canonicalTitle": "Johannes Reuchlin",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-johannes-reuchlin",
+        "nodeTitle": "Johannes Reuchlin"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-johannes-reuchlin",
+        "nodeTitle": "Johannes Reuchlin"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-johannes-reuchlin",
+        "nodeTitle": "Johannes Reuchlin"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-johannes-reuchlin",
+        "nodeTitle": "Johannes Reuchlin"
+      }
+    ]
+  },
+  "person-heinrich-cornelius-agrippa": {
+    "wikidataId": "Q60305",
+    "wikipediaTitle": "Heinrich_Cornelius_Agrippa",
+    "canonicalTitle": "Heinrich Cornelius Agrippa",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-heinrich-cornelius-agrippa",
+        "nodeTitle": "Heinrich Cornelius Agrippa"
+      }
+    ]
+  },
+  "person-johannes-trithemius": {
+    "wikidataId": "Q60373",
+    "wikipediaTitle": "Johannes_Trithemius",
+    "canonicalTitle": "Johannes Trithemius",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-johannes-trithemius",
+        "nodeTitle": "Johannes Trithemius"
+      }
+    ]
+  },
+  "person-guillaume-postel": {
+    "wikidataId": "Q723036",
+    "wikipediaTitle": "Guillaume_Postel",
+    "canonicalTitle": "Guillaume Postel",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-guillaume-postel",
+        "nodeTitle": "Guillaume Postel"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-guillaume-postel",
+        "nodeTitle": "Guillaume Postel"
+      }
+    ]
+  },
+  "person-francesco-giorgi": {
+    "wikidataId": "Q1384845",
+    "wikipediaTitle": "Francesco_Giorgio_Veneto",
+    "canonicalTitle": "Francesco Giorgi",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-francesco-giorgi",
+        "nodeTitle": "Francesco Giorgi"
+      }
+    ]
+  },
+  "person-giovanni-pico-della-mirandola": {
+    "wikidataId": "Q185977",
+    "wikipediaTitle": "Giovanni_Pico_della_Mirandola",
+    "canonicalTitle": "Giovanni Pico della Mirandola",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-giovanni-pico-della-mirandola",
+        "nodeTitle": "Giovanni Pico della Mirandola"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-giovanni-pico-della-mirandola",
+        "nodeTitle": "Giovanni Pico della Mirandola"
+      }
+    ]
+  },
+  "person-marsilio-ficino": {
+    "wikidataId": "Q154781",
+    "wikipediaTitle": "Marsilio_Ficino",
+    "canonicalTitle": "Marsilio Ficino",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-marsilio-ficino",
+        "nodeTitle": "Marsilio Ficino"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-marsilio-ficino",
+        "nodeTitle": "Marsilio Ficino"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-marsilio-ficino",
+        "nodeTitle": "Marsilio Ficino"
+      }
+    ]
+  },
+  "person-paracelsus": {
+    "wikidataId": "Q83428",
+    "wikipediaTitle": "Paracelsus",
+    "canonicalTitle": "Paracelsus",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-paracelsus",
+        "nodeTitle": "Paracelsus"
+      },
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-paracelsus",
+        "nodeTitle": "Paracelsus"
+      }
+    ]
+  },
+  "person-egidio-da-viterbo": {
+    "wikidataId": "Q453595",
+    "wikipediaTitle": "Giles_of_Viterbo",
+    "canonicalTitle": "Egidio da Viterbo",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-egidio-da-viterbo",
+        "nodeTitle": "Egidio da Viterbo"
+      }
+    ]
+  },
+  "person-elijah-levita": {
+    "wikidataId": "Q699096",
+    "wikipediaTitle": "Elijah_Levita",
+    "canonicalTitle": "Elijah Levita",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-elijah-levita",
+        "nodeTitle": "Elijah Levita"
+      }
+    ]
+  },
+  "person-johannes-pfefferkorn": {
+    "wikidataId": "Q63203",
+    "wikipediaTitle": "Johannes_Pfefferkorn",
+    "canonicalTitle": "Johannes Pfefferkorn",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-johannes-pfefferkorn",
+        "nodeTitle": "Johannes Pfefferkorn"
+      }
+    ]
+  },
+  "person-jacques-lefevre-detaples": {
+    "wikidataId": "Q332616",
+    "wikipediaTitle": "Jacques_Lefèvre_d'Étaples",
+    "canonicalTitle": "Jacques Lefèvre d'Étaples",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-jacques-lefevre-detaples",
+        "nodeTitle": "Jacques Lefèvre d'Étaples"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-jacques-lefevre-detaples",
+        "nodeTitle": "Jacques Lefèvre d'Étaples"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-jacques-lefevre-detaples",
+        "nodeTitle": "Jacques Lefèvre d'Étaples"
+      }
+    ]
+  },
+  "object-de-arte-cabalistica": {
+    "wikidataId": "Q1180147",
+    "wikipediaTitle": "De_Arte_Cabalistica",
+    "canonicalTitle": "De Arte Cabalistica",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-arte-cabalistica",
+        "nodeTitle": "De Arte Cabalistica"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-arte-cabalistica",
+        "nodeTitle": "De arte cabalistica"
+      }
+    ]
+  },
+  "object-de-verbo-mirifico": {
+    "wikidataId": "Q1180145",
+    "wikipediaTitle": "De_verbo_mirifico",
+    "canonicalTitle": "De Verbo Mirifico",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-verbo-mirifico",
+        "nodeTitle": "De Verbo Mirifico"
+      }
+    ]
+  },
+  "object-de-rudimentis-hebraicis": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "De Rudimentis Hebraicis",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-rudimentis-hebraicis",
+        "nodeTitle": "De Rudimentis Hebraicis"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-rudimentis-hebraicis",
+        "nodeTitle": "De rudimentis Hebraicis"
+      }
+    ]
+  },
+  "object-de-occulta-philosophia": {
+    "wikidataId": "Q328741",
+    "wikipediaTitle": "Three_Books_of_Occult_Philosophy",
+    "canonicalTitle": "De Occulta Philosophia libri tres",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-occulta-philosophia",
+        "nodeTitle": "De Occulta Philosophia libri tres"
+      }
+    ]
+  },
+  "object-de-vanitate-scientiarum": {
+    "wikidataId": "Q1182689",
+    "wikipediaTitle": "De_incertitudine_et_vanitate_scientiarum_et_artium",
+    "canonicalTitle": "De incertitudine et vanitate scientiarum",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-vanitate-scientiarum",
+        "nodeTitle": "De incertitudine et vanitate scientiarum"
+      }
+    ]
+  },
+  "object-steganographia": {
+    "wikidataId": "Q646795",
+    "wikipediaTitle": "Steganographia",
+    "canonicalTitle": "Steganographia",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-steganographia",
+        "nodeTitle": "Steganographia"
+      }
+    ]
+  },
+  "object-polygraphia": {
+    "wikidataId": "Q2101507",
+    "wikipediaTitle": "Polygraphia_(book)",
+    "canonicalTitle": "Polygraphia",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-polygraphia",
+        "nodeTitle": "Polygraphia"
+      }
+    ]
+  },
+  "object-de-septem-secundeis": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "De septem secundeis",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-septem-secundeis",
+        "nodeTitle": "De septem secundeis"
+      }
+    ]
+  },
+  "object-de-harmonia-mundi": {
+    "wikidataId": "Q5247052",
+    "wikipediaTitle": "De_harmonia_mundi",
+    "canonicalTitle": "De Harmonia Mundi totius cantica tria",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-harmonia-mundi",
+        "nodeTitle": "De Harmonia Mundi totius cantica tria"
+      }
+    ]
+  },
+  "object-in-scripturam-sacram-problemata": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "In Scripturam Sacram Problemata",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-in-scripturam-sacram-problemata",
+        "nodeTitle": "In Scripturam Sacram Problemata"
+      }
+    ]
+  },
+  "object-900-theses": {
+    "wikidataId": "Q2674076",
+    "wikipediaTitle": "900_Theses",
+    "canonicalTitle": "Conclusiones philosophicae, cabalisticae et theologicae",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-900-theses",
+        "nodeTitle": "Conclusiones philosophicae, cabalisticae et theologicae"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-900-theses",
+        "nodeTitle": "900 Theses (Conclusiones)"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-900-theses",
+        "nodeTitle": "900 Theses"
+      }
+    ]
+  },
+  "object-oration-dignity-man": {
+    "wikidataId": "Q2021193",
+    "wikipediaTitle": "Oration_on_the_Dignity_of_Man",
+    "canonicalTitle": "Oration on the Dignity of Man",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-oration-dignity-man",
+        "nodeTitle": "Oration on the Dignity of Man"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-oration-dignity-man",
+        "nodeTitle": "Oratio de hominis dignitate"
+      }
+    ]
+  },
+  "object-theologia-platonica": {
+    "wikidataId": "Q7781428",
+    "wikipediaTitle": "Theologia_Platonica",
+    "canonicalTitle": "Theologia Platonica",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-theologia-platonica",
+        "nodeTitle": "Theologia Platonica"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-theologia-platonica",
+        "nodeTitle": "Theologia Platonica (Platonic Theology)"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-theologia-platonica",
+        "nodeTitle": "Theologia Platonica"
+      }
+    ]
+  },
+  "object-de-vita-libri-tres": {
+    "wikidataId": "Q1181428",
+    "wikipediaTitle": "De_vita_libri_tres",
+    "canonicalTitle": "De vita libri tres",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-vita-libri-tres",
+        "nodeTitle": "De vita libri tres"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-de-vita-libri-tres",
+        "nodeTitle": "De Vita Libri Tres (Three Books on Life)"
+      }
+    ]
+  },
+  "object-corpus-hermeticum-translation": {
+    "wikidataId": "Q862087",
+    "wikipediaTitle": "Corpus_Hermeticum",
+    "canonicalTitle": "Corpus Hermeticum (Latin translation)",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-corpus-hermeticum-translation",
+        "nodeTitle": "Corpus Hermeticum (Latin translation)"
+      }
+    ]
+  },
+  "object-de-originibus": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "De originibus seu de Hebraicae linguae et gentis antiquitate",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-originibus",
+        "nodeTitle": "De originibus seu de Hebraicae linguae et gentis antiquitate"
+      }
+    ]
+  },
+  "object-absconditorum-clavis": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Absconditorum clavis",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-absconditorum-clavis",
+        "nodeTitle": "Absconditorum clavis"
+      }
+    ]
+  },
+  "object-masoret-ha-masoret": {
+    "wikidataId": "Q1899088",
+    "wikipediaTitle": "Masoret_HaMasoret",
+    "canonicalTitle": "Masoret ha-Masoret",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-masoret-ha-masoret",
+        "nodeTitle": "Masoret ha-Masoret"
+      }
+    ]
+  },
+  "object-augenspiegel": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Augenspiegel",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-augenspiegel",
+        "nodeTitle": "Augenspiegel"
+      }
+    ]
+  },
+  "object-letters-obscure-men": {
+    "wikidataId": "Q672269",
+    "wikipediaTitle": "Letters_of_Obscure_Men",
+    "canonicalTitle": "Epistolae Obscurorum Virorum",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-letters-obscure-men",
+        "nodeTitle": "Epistolae Obscurorum Virorum"
+      }
+    ]
+  },
+  "location-florence": {
+    "wikidataId": "Q2044",
+    "wikipediaTitle": "Florence",
+    "canonicalTitle": "Florence",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-florence",
+        "nodeTitle": "Florence"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "location-florence",
+        "nodeTitle": "Florence"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-florence",
+        "nodeTitle": "Florence"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-florence",
+        "nodeTitle": "Florence"
+      }
+    ]
+  },
+  "location-venice": {
+    "wikidataId": "Q641",
+    "wikipediaTitle": "Venice",
+    "canonicalTitle": "Venice",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-venice",
+        "nodeTitle": "Venice"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-venice",
+        "nodeTitle": "Venice"
+      }
+    ]
+  },
+  "location-cologne": {
+    "wikidataId": "Q365",
+    "wikipediaTitle": "Cologne",
+    "canonicalTitle": "Cologne",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-cologne",
+        "nodeTitle": "Cologne"
+      }
+    ]
+  },
+  "location-rome": {
+    "wikidataId": "Q220",
+    "wikipediaTitle": "Rome",
+    "canonicalTitle": "Rome",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-rome",
+        "nodeTitle": "Rome"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-rome",
+        "nodeTitle": "Rome"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-rome",
+        "nodeTitle": "Rome"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-rome",
+        "nodeTitle": "Rome"
+      }
+    ]
+  },
+  "location-sponheim-abbey": {
+    "wikidataId": "Q569604",
+    "wikipediaTitle": "Sponheim_Abbey",
+    "canonicalTitle": "Sponheim Abbey",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-sponheim-abbey",
+        "nodeTitle": "Sponheim Abbey"
+      }
+    ]
+  },
+  "location-wuerzburg": {
+    "wikidataId": "Q1728",
+    "wikipediaTitle": "Würzburg",
+    "canonicalTitle": "Würzburg",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-wuerzburg",
+        "nodeTitle": "Würzburg"
+      }
+    ]
+  },
+  "entity-platonic-academy-florence": {
+    "wikidataId": "Q2046693",
+    "wikipediaTitle": "Platonic_Academy_(Florence)",
+    "canonicalTitle": "Platonic Academy of Florence",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "entity-platonic-academy-florence",
+        "nodeTitle": "Platonic Academy of Florence"
+      }
+    ]
+  },
+  "entity-college-de-france": {
+    "wikidataId": "Q202660",
+    "wikipediaTitle": "Collège_de_France",
+    "canonicalTitle": "Collège de France",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "entity-college-de-france",
+        "nodeTitle": "Collège de France"
+      }
+    ]
+  },
+  "entity-university-of-cologne": {
+    "wikidataId": "Q151510",
+    "wikipediaTitle": "University_of_Cologne",
+    "canonicalTitle": "University of Cologne",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "entity-university-of-cologne",
+        "nodeTitle": "University of Cologne"
+      }
+    ]
+  },
+  "entity-dominican-order": {
+    "wikidataId": "Q192632",
+    "wikipediaTitle": "Dominican_Order",
+    "canonicalTitle": "Dominican Order (Cologne)",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "entity-dominican-order",
+        "nodeTitle": "Dominican Order (Cologne)"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-dominican-order",
+        "nodeTitle": "Dominican Order"
+      }
+    ]
+  },
+  "person-lorenzo-de-medici": {
+    "wikidataId": "Q177854",
+    "wikipediaTitle": "Lorenzo_de'_Medici",
+    "canonicalTitle": "Lorenzo de' Medici",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-lorenzo-de-medici",
+        "nodeTitle": "Lorenzo de' Medici"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-lorenzo-de-medici",
+        "nodeTitle": "Lorenzo de' Medici"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-lorenzo-de-medici",
+        "nodeTitle": "Lorenzo de' Medici"
+      }
+    ]
+  },
+  "person-cosimo-de-medici": {
+    "wikidataId": "Q188989",
+    "wikipediaTitle": "Cosimo_de'_Medici",
+    "canonicalTitle": "Cosimo de' Medici",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-cosimo-de-medici",
+        "nodeTitle": "Cosimo de' Medici"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-cosimo-de-medici",
+        "nodeTitle": "Cosimo de' Medici"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-cosimo-de-medici",
+        "nodeTitle": "Cosimo de' Medici"
+      }
+    ]
+  },
+  "person-maximilian-i": {
+    "wikidataId": "Q150726",
+    "wikipediaTitle": "Maximilian_I,_Holy_Roman_Emperor",
+    "canonicalTitle": "Maximilian I, Holy Roman Emperor",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-maximilian-i",
+        "nodeTitle": "Maximilian I, Holy Roman Emperor"
+      }
+    ]
+  },
+  "person-jakob-hoogstraten": {
+    "wikidataId": "Q702058",
+    "wikipediaTitle": "Jakob_van_Hoogstraten",
+    "canonicalTitle": "Jakob van Hoogstraten",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-jakob-hoogstraten",
+        "nodeTitle": "Jakob van Hoogstraten"
+      }
+    ]
+  },
+  "person-flavius-mithridates": {
+    "wikidataId": "Q1426689",
+    "wikipediaTitle": "Flavius_Mithridates",
+    "canonicalTitle": "Flavius Mithridates",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-flavius-mithridates",
+        "nodeTitle": "Flavius Mithridates"
+      }
+    ]
+  },
+  "person-charles-de-bovelles": {
+    "wikidataId": "Q540500",
+    "wikipediaTitle": "Charles_de_Bovelles",
+    "canonicalTitle": "Charles de Bovelles",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-charles-de-bovelles",
+        "nodeTitle": "Charles de Bovelles"
+      }
+    ]
+  },
+  "person-pope-leo-x": {
+    "wikidataId": "Q81520",
+    "wikipediaTitle": "Pope_Leo_X",
+    "canonicalTitle": "Pope Leo X",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-pope-leo-x",
+        "nodeTitle": "Pope Leo X"
+      }
+    ]
+  },
+  "person-pope-innocent-viii": {
+    "wikidataId": "Q170876",
+    "wikipediaTitle": "Pope_Innocent_VIII",
+    "canonicalTitle": "Pope Innocent VIII",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-pope-innocent-viii",
+        "nodeTitle": "Pope Innocent VIII"
+      }
+    ]
+  },
+  "person-ulrich-von-hutten": {
+    "wikidataId": "Q77107",
+    "wikipediaTitle": "Ulrich_von_Hutten",
+    "canonicalTitle": "Ulrich von Hutten",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-ulrich-von-hutten",
+        "nodeTitle": "Ulrich von Hutten"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-ulrich-von-hutten",
+        "nodeTitle": "Ulrich von Hutten"
+      }
+    ]
+  },
+  "person-crotus-rubeanus": {
+    "wikidataId": "Q65521",
+    "wikipediaTitle": "Crotus_Rubeanus",
+    "canonicalTitle": "Crotus Rubeanus",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-crotus-rubeanus",
+        "nodeTitle": "Crotus Rubeanus"
+      }
+    ]
+  },
+  "person-norbert-wiener": {
+    "wikidataId": "Q178577",
+    "wikipediaTitle": "Norbert_Wiener",
+    "canonicalTitle": "Norbert Wiener",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-norbert-wiener",
+        "nodeTitle": "Norbert Wiener"
+      }
+    ]
+  },
+  "person-claude-shannon": {
+    "wikidataId": "Q92760",
+    "wikipediaTitle": "Claude_Shannon",
+    "canonicalTitle": "Claude Shannon",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-claude-shannon",
+        "nodeTitle": "Claude Shannon"
+      }
+    ]
+  },
+  "person-alan-turing": {
+    "wikidataId": "Q7251",
+    "wikipediaTitle": "Alan_Turing",
+    "canonicalTitle": "Alan Turing",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-alan-turing",
+        "nodeTitle": "Alan Turing"
+      }
+    ]
+  },
+  "person-john-von-neumann": {
+    "wikidataId": "Q17455",
+    "wikipediaTitle": "John_von_Neumann",
+    "canonicalTitle": "John von Neumann",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-john-von-neumann",
+        "nodeTitle": "John von Neumann"
+      }
+    ]
+  },
+  "person-gregory-bateson": {
+    "wikidataId": "Q314252",
+    "wikipediaTitle": "Gregory_Bateson",
+    "canonicalTitle": "Gregory Bateson",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-gregory-bateson",
+        "nodeTitle": "Gregory Bateson"
+      }
+    ]
+  },
+  "person-ross-ashby": {
+    "wikidataId": "Q711172",
+    "wikipediaTitle": "W._Ross_Ashby",
+    "canonicalTitle": "W. Ross Ashby",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ross-ashby",
+        "nodeTitle": "W. Ross Ashby"
+      }
+    ]
+  },
+  "person-stafford-beer": {
+    "wikidataId": "Q796226",
+    "wikipediaTitle": "Stafford_Beer",
+    "canonicalTitle": "Stafford Beer",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-stafford-beer",
+        "nodeTitle": "Stafford Beer"
+      }
+    ]
+  },
+  "person-warren-weaver": {
+    "wikidataId": "Q510591",
+    "wikipediaTitle": "Warren_Weaver",
+    "canonicalTitle": "Warren Weaver",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-warren-weaver",
+        "nodeTitle": "Warren Weaver"
+      }
+    ]
+  },
+  "person-richard-hamming": {
+    "wikidataId": "Q92619",
+    "wikipediaTitle": "Richard_Hamming",
+    "canonicalTitle": "Richard Hamming",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-richard-hamming",
+        "nodeTitle": "Richard Hamming"
+      }
+    ]
+  },
+  "person-john-tukey": {
+    "wikidataId": "Q382207",
+    "wikipediaTitle": "John_Tukey",
+    "canonicalTitle": "John Tukey",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-john-tukey",
+        "nodeTitle": "John Tukey"
+      }
+    ]
+  },
+  "person-john-pierce": {
+    "wikidataId": "Q1340677",
+    "wikipediaTitle": "John_R._Pierce",
+    "canonicalTitle": "John R. Pierce",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-john-pierce",
+        "nodeTitle": "John R. Pierce"
+      }
+    ]
+  },
+  "person-hendrik-bode": {
+    "wikidataId": "Q714462",
+    "wikipediaTitle": "Hendrik_Wade_Bode",
+    "canonicalTitle": "Hendrik Bode",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-hendrik-bode",
+        "nodeTitle": "Hendrik Bode"
+      }
+    ]
+  },
+  "person-harry-nyquist": {
+    "wikidataId": "Q316022",
+    "wikipediaTitle": "Harry_Nyquist",
+    "canonicalTitle": "Harry Nyquist",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-harry-nyquist",
+        "nodeTitle": "Harry Nyquist"
+      }
+    ]
+  },
+  "person-ralph-hartley": {
+    "wikidataId": "Q529886",
+    "wikipediaTitle": "Ralph_Hartley",
+    "canonicalTitle": "Ralph Hartley",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ralph-hartley",
+        "nodeTitle": "Ralph Hartley"
+      }
+    ]
+  },
+  "person-david-huffman": {
+    "wikidataId": "Q92784",
+    "wikipediaTitle": "David_A._Huffman",
+    "canonicalTitle": "David Huffman",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-david-huffman",
+        "nodeTitle": "David Huffman"
+      }
+    ]
+  },
+  "person-robert-fano": {
+    "wikidataId": "Q93052",
+    "wikipediaTitle": "Robert_Fano",
+    "canonicalTitle": "Robert Fano",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-robert-fano",
+        "nodeTitle": "Robert Fano"
+      }
+    ]
+  },
+  "person-john-mauchly": {
+    "wikidataId": "Q522162",
+    "wikipediaTitle": "John_Mauchly",
+    "canonicalTitle": "John Mauchly",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-john-mauchly",
+        "nodeTitle": "John Mauchly"
+      }
+    ]
+  },
+  "person-presper-eckert": {
+    "wikidataId": "Q457906",
+    "wikipediaTitle": "J._Presper_Eckert",
+    "canonicalTitle": "J. Presper Eckert",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-presper-eckert",
+        "nodeTitle": "J. Presper Eckert"
+      }
+    ]
+  },
+  "person-herman-goldstine": {
+    "wikidataId": "Q93005",
+    "wikipediaTitle": "Herman_Goldstine",
+    "canonicalTitle": "Herman Goldstine",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-herman-goldstine",
+        "nodeTitle": "Herman Goldstine"
+      }
+    ]
+  },
+  "person-maurice-wilkes": {
+    "wikidataId": "Q62857",
+    "wikipediaTitle": "Maurice_Wilkes",
+    "canonicalTitle": "Maurice Wilkes",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-maurice-wilkes",
+        "nodeTitle": "Maurice Wilkes"
+      }
+    ]
+  },
+  "person-konrad-zuse": {
+    "wikidataId": "Q60093",
+    "wikipediaTitle": "Konrad_Zuse",
+    "canonicalTitle": "Konrad Zuse",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-konrad-zuse",
+        "nodeTitle": "Konrad Zuse"
+      }
+    ]
+  },
+  "person-max-newman": {
+    "wikidataId": "Q707155",
+    "wikipediaTitle": "Max_Newman",
+    "canonicalTitle": "Max Newman",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-max-newman",
+        "nodeTitle": "Max Newman"
+      }
+    ]
+  },
+  "person-tommy-flowers": {
+    "wikidataId": "Q954437",
+    "wikipediaTitle": "Tommy_Flowers",
+    "canonicalTitle": "Tommy Flowers",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-tommy-flowers",
+        "nodeTitle": "Tommy Flowers"
+      }
+    ]
+  },
+  "person-i-j-good": {
+    "wikidataId": "Q224372",
+    "wikipediaTitle": "I._J._Good",
+    "canonicalTitle": "I.J. Good",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-i-j-good",
+        "nodeTitle": "I.J. Good"
+      }
+    ]
+  },
+  "person-warren-mcculloch": {
+    "wikidataId": "Q962174",
+    "wikipediaTitle": "Warren_Sturgis_McCulloch",
+    "canonicalTitle": "Warren McCulloch",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-warren-mcculloch",
+        "nodeTitle": "Warren McCulloch"
+      }
+    ]
+  },
+  "person-walter-pitts": {
+    "wikidataId": "Q705010",
+    "wikipediaTitle": "Walter_Pitts",
+    "canonicalTitle": "Walter Pitts",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-walter-pitts",
+        "nodeTitle": "Walter Pitts"
+      }
+    ]
+  },
+  "person-margaret-mead": {
+    "wikidataId": "Q180099",
+    "wikipediaTitle": "Margaret_Mead",
+    "canonicalTitle": "Margaret Mead",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-margaret-mead",
+        "nodeTitle": "Margaret Mead"
+      }
+    ]
+  },
+  "person-arturo-rosenblueth": {
+    "wikidataId": "Q121729",
+    "wikipediaTitle": "Arturo_Rosenblueth",
+    "canonicalTitle": "Arturo Rosenblueth",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-arturo-rosenblueth",
+        "nodeTitle": "Arturo Rosenblueth"
+      }
+    ]
+  },
+  "person-julian-bigelow": {
+    "wikidataId": "Q328632",
+    "wikipediaTitle": "Julian_Bigelow",
+    "canonicalTitle": "Julian Bigelow",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-julian-bigelow",
+        "nodeTitle": "Julian Bigelow"
+      }
+    ]
+  },
+  "person-lawrence-frank": {
+    "wikidataId": "Q15430706",
+    "wikipediaTitle": "Lawrence_K._Frank",
+    "canonicalTitle": "Lawrence Frank",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-lawrence-frank",
+        "nodeTitle": "Lawrence Frank"
+      }
+    ]
+  },
+  "person-frank-fremont-smith": {
+    "wikidataId": "Q5486704",
+    "wikipediaTitle": "Frank_Fremont-Smith",
+    "canonicalTitle": "Frank Fremont-Smith",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-frank-fremont-smith",
+        "nodeTitle": "Frank Fremont-Smith"
+      }
+    ]
+  },
+  "person-ralph-gerard": {
+    "wikidataId": null,
+    "wikipediaTitle": "Ralph_Waldo_Gerard",
+    "canonicalTitle": "Ralph Gerard",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ralph-gerard",
+        "nodeTitle": "Ralph Gerard"
+      }
+    ]
+  },
+  "person-heinrich-kluver": {
+    "wikidataId": "Q74829",
+    "wikipediaTitle": "Heinrich_Klüver",
+    "canonicalTitle": "Heinrich Klüver",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-heinrich-kluver",
+        "nodeTitle": "Heinrich Klüver"
+      }
+    ]
+  },
+  "person-kurt-lewin": {
+    "wikidataId": "Q77106",
+    "wikipediaTitle": "Kurt_Lewin",
+    "canonicalTitle": "Kurt Lewin",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-kurt-lewin",
+        "nodeTitle": "Kurt Lewin"
+      }
+    ]
+  },
+  "person-jerome-lettvin": {
+    "wikidataId": "Q6182818",
+    "wikipediaTitle": "Jerome_Lettvin",
+    "canonicalTitle": "Jerome Lettvin",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-jerome-lettvin",
+        "nodeTitle": "Jerome Lettvin"
+      }
+    ]
+  },
+  "person-donald-hebb": {
+    "wikidataId": "Q683246",
+    "wikipediaTitle": "Donald_O._Hebb",
+    "canonicalTitle": "Donald Hebb",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-donald-hebb",
+        "nodeTitle": "Donald Hebb"
+      }
+    ]
+  },
+  "person-frank-rosenblatt": {
+    "wikidataId": "Q93018",
+    "wikipediaTitle": "Frank_Rosenblatt",
+    "canonicalTitle": "Frank Rosenblatt",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-frank-rosenblatt",
+        "nodeTitle": "Frank Rosenblatt"
+      }
+    ]
+  },
+  "person-horace-barlow": {
+    "wikidataId": "Q13570719",
+    "wikipediaTitle": "Horace_Barlow",
+    "canonicalTitle": "Horace Barlow",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-horace-barlow",
+        "nodeTitle": "Horace Barlow"
+      }
+    ]
+  },
+  "person-albert-uttley": {
+    "wikidataId": "Q65048378",
+    "wikipediaTitle": "Albert_Uttley",
+    "canonicalTitle": "Albert Uttley",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-albert-uttley",
+        "nodeTitle": "Albert Uttley"
+      }
+    ]
+  },
+  "person-grey-walter": {
+    "wikidataId": "Q1359845",
+    "wikipediaTitle": "William_Grey_Walter",
+    "canonicalTitle": "W. Grey Walter",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-grey-walter",
+        "nodeTitle": "W. Grey Walter"
+      }
+    ]
+  },
+  "person-gordon-pask": {
+    "wikidataId": "Q370461",
+    "wikipediaTitle": "Gordon_Pask",
+    "canonicalTitle": "Gordon Pask",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-gordon-pask",
+        "nodeTitle": "Gordon Pask"
+      }
+    ]
+  },
+  "person-donald-mackay": {
+    "wikidataId": "Q3036050",
+    "wikipediaTitle": "Donald_MacCrimmon_MacKay",
+    "canonicalTitle": "Donald MacKay",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-donald-mackay",
+        "nodeTitle": "Donald MacKay"
+      }
+    ]
+  },
+  "person-john-bates": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "John Bates",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-john-bates",
+        "nodeTitle": "John Bates"
+      }
+    ]
+  },
+  "person-william-rushton": {
+    "wikidataId": null,
+    "wikipediaTitle": "William_A._H._Rushton",
+    "canonicalTitle": "William Rushton",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-william-rushton",
+        "nodeTitle": "William Rushton"
+      }
+    ]
+  },
+  "person-philip-woodward": {
+    "wikidataId": null,
+    "wikipediaTitle": "Philip_M._Woodward",
+    "canonicalTitle": "Philip Woodward",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-philip-woodward",
+        "nodeTitle": "Philip Woodward"
+      }
+    ]
+  },
+  "person-ludwig-von-bertalanffy": {
+    "wikidataId": "Q84345",
+    "wikipediaTitle": "Ludwig_von_Bertalanffy",
+    "canonicalTitle": "Ludwig von Bertalanffy",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ludwig-von-bertalanffy",
+        "nodeTitle": "Ludwig von Bertalanffy"
+      }
+    ]
+  },
+  "person-kenneth-boulding": {
+    "wikidataId": "Q505520",
+    "wikipediaTitle": "Kenneth_E._Boulding",
+    "canonicalTitle": "Kenneth Boulding",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-kenneth-boulding",
+        "nodeTitle": "Kenneth Boulding"
+      }
+    ]
+  },
+  "person-anatol-rapoport": {
+    "wikidataId": "Q487453",
+    "wikipediaTitle": "Anatol_Rapoport",
+    "canonicalTitle": "Anatol Rapoport",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-anatol-rapoport",
+        "nodeTitle": "Anatol Rapoport"
+      }
+    ]
+  },
+  "person-jay-forrester": {
+    "wikidataId": "Q92763",
+    "wikipediaTitle": "Jay_Wright_Forrester",
+    "canonicalTitle": "Jay Forrester",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-jay-forrester",
+        "nodeTitle": "Jay Forrester"
+      }
+    ]
+  },
+  "person-donella-meadows": {
+    "wikidataId": "Q271226",
+    "wikipediaTitle": "Donella_Meadows",
+    "canonicalTitle": "Donella Meadows",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-donella-meadows",
+        "nodeTitle": "Donella Meadows"
+      }
+    ]
+  },
+  "person-russell-ackoff": {
+    "wikidataId": "Q1431186",
+    "wikipediaTitle": "Russell_L._Ackoff",
+    "canonicalTitle": "Russell Ackoff",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-russell-ackoff",
+        "nodeTitle": "Russell Ackoff"
+      }
+    ]
+  },
+  "person-c-west-churchman": {
+    "wikidataId": "Q959763",
+    "wikipediaTitle": "C._West_Churchman",
+    "canonicalTitle": "C. West Churchman",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-c-west-churchman",
+        "nodeTitle": "C. West Churchman"
+      }
+    ]
+  },
+  "person-peter-checkland": {
+    "wikidataId": "Q503806",
+    "wikipediaTitle": "Peter_Checkland",
+    "canonicalTitle": "Peter Checkland",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-peter-checkland",
+        "nodeTitle": "Peter Checkland"
+      }
+    ]
+  },
+  "person-raul-espejo": {
+    "wikidataId": null,
+    "wikipediaTitle": "Raúl_Espejo",
+    "canonicalTitle": "Raúl Espejo",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-raul-espejo",
+        "nodeTitle": "Raúl Espejo"
+      }
+    ]
+  },
+  "person-heinz-von-foerster": {
+    "wikidataId": "Q78688",
+    "wikipediaTitle": "Heinz_von_Foerster",
+    "canonicalTitle": "Heinz von Foerster",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-heinz-von-foerster",
+        "nodeTitle": "Heinz von Foerster"
+      }
+    ]
+  },
+  "person-humberto-maturana": {
+    "wikidataId": "Q376452",
+    "wikipediaTitle": "Humberto_Maturana",
+    "canonicalTitle": "Humberto Maturana",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-humberto-maturana",
+        "nodeTitle": "Humberto Maturana"
+      }
+    ]
+  },
+  "person-francisco-varela": {
+    "wikidataId": "Q923582",
+    "wikipediaTitle": "Francisco_Varela",
+    "canonicalTitle": "Francisco Varela",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-francisco-varela",
+        "nodeTitle": "Francisco Varela"
+      }
+    ]
+  },
+  "person-ernst-von-glasersfeld": {
+    "wikidataId": "Q112176",
+    "wikipediaTitle": "Ernst_von_Glasersfeld",
+    "canonicalTitle": "Ernst von Glasersfeld",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ernst-von-glasersfeld",
+        "nodeTitle": "Ernst von Glasersfeld"
+      }
+    ]
+  },
+  "person-ranulph-glanville": {
+    "wikidataId": "Q1494101",
+    "wikipediaTitle": "Ranulph_Glanville",
+    "canonicalTitle": "Ranulph Glanville",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ranulph-glanville",
+        "nodeTitle": "Ranulph Glanville"
+      }
+    ]
+  },
+  "person-marvin-minsky": {
+    "wikidataId": "Q204815",
+    "wikipediaTitle": "Marvin_Minsky",
+    "canonicalTitle": "Marvin Minsky",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-marvin-minsky",
+        "nodeTitle": "Marvin Minsky"
+      }
+    ]
+  },
+  "person-john-mccarthy": {
+    "wikidataId": "Q92739",
+    "wikipediaTitle": "John_McCarthy_(computer_scientist)",
+    "canonicalTitle": "John McCarthy",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-john-mccarthy",
+        "nodeTitle": "John McCarthy"
+      }
+    ]
+  },
+  "person-allen-newell": {
+    "wikidataId": "Q439245",
+    "wikipediaTitle": "Allen_Newell",
+    "canonicalTitle": "Allen Newell",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-allen-newell",
+        "nodeTitle": "Allen Newell"
+      }
+    ]
+  },
+  "person-herbert-simon": {
+    "wikidataId": "Q181529",
+    "wikipediaTitle": "Herbert_A._Simon",
+    "canonicalTitle": "Herbert Simon",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-herbert-simon",
+        "nodeTitle": "Herbert Simon"
+      }
+    ]
+  },
+  "person-seymour-papert": {
+    "wikidataId": "Q335027",
+    "wikipediaTitle": "Seymour_Papert",
+    "canonicalTitle": "Seymour Papert",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-seymour-papert",
+        "nodeTitle": "Seymour Papert"
+      }
+    ]
+  },
+  "person-oliver-selfridge": {
+    "wikidataId": "Q2651957",
+    "wikipediaTitle": "Oliver_Selfridge",
+    "canonicalTitle": "Oliver Selfridge",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-oliver-selfridge",
+        "nodeTitle": "Oliver Selfridge"
+      }
+    ]
+  },
+  "person-nathaniel-rochester": {
+    "wikidataId": "Q6969830",
+    "wikipediaTitle": "Nathaniel_Rochester_(computer_scientist)",
+    "canonicalTitle": "Nathaniel Rochester",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-nathaniel-rochester",
+        "nodeTitle": "Nathaniel Rochester"
+      }
+    ]
+  },
+  "person-ray-solomonoff": {
+    "wikidataId": "Q3123640",
+    "wikipediaTitle": "Ray_Solomonoff",
+    "canonicalTitle": "Ray Solomonoff",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ray-solomonoff",
+        "nodeTitle": "Ray Solomonoff"
+      }
+    ]
+  },
+  "person-arthur-samuel": {
+    "wikidataId": "Q710266",
+    "wikipediaTitle": "Arthur_Samuel_(computer_scientist)",
+    "canonicalTitle": "Arthur Samuel",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-arthur-samuel",
+        "nodeTitle": "Arthur Samuel"
+      }
+    ]
+  },
+  "person-j-c-r-licklider": {
+    "wikidataId": "Q92778",
+    "wikipediaTitle": "J._C._R._Licklider",
+    "canonicalTitle": "J.C.R. Licklider",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-j-c-r-licklider",
+        "nodeTitle": "J.C.R. Licklider"
+      }
+    ]
+  },
+  "person-douglas-engelbart": {
+    "wikidataId": "Q92614",
+    "wikipediaTitle": "Douglas_Engelbart",
+    "canonicalTitle": "Douglas Engelbart",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-douglas-engelbart",
+        "nodeTitle": "Douglas Engelbart"
+      }
+    ]
+  },
+  "person-alfred-whitehead": {
+    "wikidataId": "Q183372",
+    "wikipediaTitle": "Alfred_North_Whitehead",
+    "canonicalTitle": "Alfred North Whitehead",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-alfred-whitehead",
+        "nodeTitle": "Alfred North Whitehead"
+      }
+    ]
+  },
+  "person-bertrand-russell": {
+    "wikidataId": "Q33760",
+    "wikipediaTitle": "Bertrand_Russell",
+    "canonicalTitle": "Bertrand Russell",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-bertrand-russell",
+        "nodeTitle": "Bertrand Russell"
+      }
+    ]
+  },
+  "person-alonzo-church": {
+    "wikidataId": "Q92741",
+    "wikipediaTitle": "Alonzo_Church",
+    "canonicalTitle": "Alonzo Church",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-alonzo-church",
+        "nodeTitle": "Alonzo Church"
+      }
+    ]
+  },
+  "person-kurt-godel": {
+    "wikidataId": "Q41390",
+    "wikipediaTitle": "Kurt_Gödel",
+    "canonicalTitle": "Kurt Gödel",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-kurt-godel",
+        "nodeTitle": "Kurt Gödel"
+      }
+    ]
+  },
+  "person-walter-cannon": {
+    "wikidataId": "Q503192",
+    "wikipediaTitle": "Walter_Bradford_Cannon",
+    "canonicalTitle": "Walter Cannon",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-walter-cannon",
+        "nodeTitle": "Walter Cannon"
+      }
+    ]
+  },
+  "person-josiah-gibbs": {
+    "wikidataId": "Q153243",
+    "wikipediaTitle": "Josiah_Willard_Gibbs",
+    "canonicalTitle": "Josiah Willard Gibbs",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-josiah-gibbs",
+        "nodeTitle": "Josiah Willard Gibbs"
+      }
+    ]
+  },
+  "person-ludwig-boltzmann": {
+    "wikidataId": "Q84296",
+    "wikipediaTitle": "Ludwig_Boltzmann",
+    "canonicalTitle": "Ludwig Boltzmann",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ludwig-boltzmann",
+        "nodeTitle": "Ludwig Boltzmann"
+      }
+    ]
+  },
+  "person-vannevar-bush": {
+    "wikidataId": "Q299595",
+    "wikipediaTitle": "Vannevar_Bush",
+    "canonicalTitle": "Vannevar Bush",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-vannevar-bush",
+        "nodeTitle": "Vannevar Bush"
+      }
+    ]
+  },
+  "person-charles-peirce": {
+    "wikidataId": "Q187520",
+    "wikipediaTitle": "Charles_Sanders_Peirce",
+    "canonicalTitle": "Charles Sanders Peirce",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-charles-peirce",
+        "nodeTitle": "Charles Sanders Peirce"
+      }
+    ]
+  },
+  "person-oskar-morgenstern": {
+    "wikidataId": "Q94028",
+    "wikipediaTitle": "Oskar_Morgenstern",
+    "canonicalTitle": "Oskar Morgenstern",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-oskar-morgenstern",
+        "nodeTitle": "Oskar Morgenstern"
+      }
+    ]
+  },
+  "person-jean-piaget": {
+    "wikidataId": "Q123190",
+    "wikipediaTitle": "Jean_Piaget",
+    "canonicalTitle": "Jean Piaget",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-jean-piaget",
+        "nodeTitle": "Jean Piaget"
+      }
+    ]
+  },
+  "object-cybernetics-wiener": {
+    "wikidataId": "Q16953441",
+    "wikipediaTitle": "Cybernetics:_Or_Control_and_Communication_in_the_Animal_and_the_Machine",
+    "canonicalTitle": "Cybernetics: Or Control and Communication in the Animal and the Machine",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-cybernetics-wiener",
+        "nodeTitle": "Cybernetics: Or Control and Communication in the Animal and the Machine"
+      }
+    ]
+  },
+  "object-information-theory-shannon": {
+    "wikidataId": "Q724029",
+    "wikipediaTitle": "A_Mathematical_Theory_of_Communication",
+    "canonicalTitle": "A Mathematical Theory of Communication",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-information-theory-shannon",
+        "nodeTitle": "A Mathematical Theory of Communication"
+      }
+    ]
+  },
+  "object-math-theory-communication-book": {
+    "wikidataId": "Q724029",
+    "wikipediaTitle": "A_Mathematical_Theory_of_Communication",
+    "canonicalTitle": "The Mathematical Theory of Communication (book)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-math-theory-communication-book",
+        "nodeTitle": "The Mathematical Theory of Communication (book)"
+      }
+    ]
+  },
+  "object-computable-numbers-turing": {
+    "wikidataId": "Q7854954",
+    "wikipediaTitle": "On_Computable_Numbers,_with_an_Application_to_the_Entscheidungsproblem",
+    "canonicalTitle": "On Computable Numbers, with an Application to the Entscheidungsproblem",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-computable-numbers-turing",
+        "nodeTitle": "On Computable Numbers, with an Application to the Entscheidungsproblem"
+      }
+    ]
+  },
+  "object-computing-machinery-turing": {
+    "wikidataId": "Q772056",
+    "wikipediaTitle": "Computing_Machinery_and_Intelligence",
+    "canonicalTitle": "Computing Machinery and Intelligence",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-computing-machinery-turing",
+        "nodeTitle": "Computing Machinery and Intelligence"
+      }
+    ]
+  },
+  "object-logical-calculus-mcculloch-pitts": {
+    "wikidataId": "Q22337370",
+    "wikipediaTitle": "A_Logical_Calculus_of_the_Ideas_Immanent_in_Nervous_Activity",
+    "canonicalTitle": "A Logical Calculus of the Ideas Immanent in Nervous Activity",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-logical-calculus-mcculloch-pitts",
+        "nodeTitle": "A Logical Calculus of the Ideas Immanent in Nervous Activity"
+      }
+    ]
+  },
+  "object-frogs-eye-lettvin": {
+    "wikidataId": null,
+    "wikipediaTitle": "What_the_Frog's_Eye_Tells_the_Frog's_Brain",
+    "canonicalTitle": "What the Frog's Eye Tells the Frog's Brain",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-frogs-eye-lettvin",
+        "nodeTitle": "What the Frog's Eye Tells the Frog's Brain"
+      }
+    ]
+  },
+  "object-neurodynamics-rosenblatt": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Principles of Neurodynamics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-neurodynamics-rosenblatt",
+        "nodeTitle": "Principles of Neurodynamics"
+      }
+    ]
+  },
+  "object-perceptrons-minsky-papert": {
+    "wikidataId": "Q4359403",
+    "wikipediaTitle": "Perceptrons_(book)",
+    "canonicalTitle": "Perceptrons: An Introduction to Computational Geometry",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-perceptrons-minsky-papert",
+        "nodeTitle": "Perceptrons: An Introduction to Computational Geometry"
+      }
+    ]
+  },
+  "object-organization-behavior-hebb": {
+    "wikidataId": null,
+    "wikipediaTitle": "The_Organization_of_Behavior",
+    "canonicalTitle": "The Organization of Behavior",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-organization-behavior-hebb",
+        "nodeTitle": "The Organization of Behavior"
+      }
+    ]
+  },
+  "object-design-brain-ashby": {
+    "wikidataId": null,
+    "wikipediaTitle": "Design_for_a_Brain",
+    "canonicalTitle": "Design for a Brain",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-design-brain-ashby",
+        "nodeTitle": "Design for a Brain"
+      }
+    ]
+  },
+  "object-intro-cybernetics-ashby": {
+    "wikidataId": "Q97359298",
+    "wikipediaTitle": "An_Introduction_to_Cybernetics",
+    "canonicalTitle": "An Introduction to Cybernetics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-intro-cybernetics-ashby",
+        "nodeTitle": "An Introduction to Cybernetics"
+      }
+    ]
+  },
+  "object-living-brain-walter": {
+    "wikidataId": "Q136953442",
+    "wikipediaTitle": "The_Living_Brain",
+    "canonicalTitle": "The Living Brain",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-living-brain-walter",
+        "nodeTitle": "The Living Brain"
+      }
+    ]
+  },
+  "object-behavior-purpose-teleology": {
+    "wikidataId": null,
+    "wikipediaTitle": "Behavior,_Purpose_and_Teleology",
+    "canonicalTitle": "Behavior, Purpose and Teleology",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-behavior-purpose-teleology",
+        "nodeTitle": "Behavior, Purpose and Teleology"
+      }
+    ]
+  },
+  "object-human-use-wiener": {
+    "wikidataId": "Q7740888",
+    "wikipediaTitle": "The_Human_Use_of_Human_Beings",
+    "canonicalTitle": "The Human Use of Human Beings",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-human-use-wiener",
+        "nodeTitle": "The Human Use of Human Beings"
+      }
+    ]
+  },
+  "object-general-system-theory-bertalanffy": {
+    "wikidataId": null,
+    "wikipediaTitle": "General_System_Theory",
+    "canonicalTitle": "General System Theory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-general-system-theory-bertalanffy",
+        "nodeTitle": "General System Theory"
+      }
+    ]
+  },
+  "object-cybernetics-management-beer": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Cybernetics and Management",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-cybernetics-management-beer",
+        "nodeTitle": "Cybernetics and Management"
+      }
+    ]
+  },
+  "object-brain-firm-beer": {
+    "wikidataId": null,
+    "wikipediaTitle": "Brain_of_the_Firm",
+    "canonicalTitle": "Brain of the Firm",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-brain-firm-beer",
+        "nodeTitle": "Brain of the Firm"
+      }
+    ]
+  },
+  "object-industrial-dynamics-forrester": {
+    "wikidataId": null,
+    "wikipediaTitle": "Industrial_Dynamics",
+    "canonicalTitle": "Industrial Dynamics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-industrial-dynamics-forrester",
+        "nodeTitle": "Industrial Dynamics"
+      }
+    ]
+  },
+  "object-limits-growth-meadows": {
+    "wikidataId": "Q277111",
+    "wikipediaTitle": "The_Limits_to_Growth",
+    "canonicalTitle": "The Limits to Growth",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-limits-growth-meadows",
+        "nodeTitle": "The Limits to Growth"
+      }
+    ]
+  },
+  "object-steps-ecology-mind-bateson": {
+    "wikidataId": "Q1970551",
+    "wikipediaTitle": "Steps_to_an_Ecology_of_Mind",
+    "canonicalTitle": "Steps to an Ecology of Mind",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-steps-ecology-mind-bateson",
+        "nodeTitle": "Steps to an Ecology of Mind"
+      }
+    ]
+  },
+  "object-autopoiesis-cognition": {
+    "wikidataId": null,
+    "wikipediaTitle": "Autopoiesis_and_Cognition",
+    "canonicalTitle": "Autopoiesis and Cognition: The Realization of the Living",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-autopoiesis-cognition",
+        "nodeTitle": "Autopoiesis and Cognition: The Realization of the Living"
+      }
+    ]
+  },
+  "object-observing-systems-foerster": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Observing Systems",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-observing-systems-foerster",
+        "nodeTitle": "Observing Systems"
+      }
+    ]
+  },
+  "object-embodied-mind-varela": {
+    "wikidataId": null,
+    "wikipediaTitle": "The_Embodied_Mind",
+    "canonicalTitle": "The Embodied Mind: Cognitive Science and Human Experience",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-embodied-mind-varela",
+        "nodeTitle": "The Embodied Mind: Cognitive Science and Human Experience"
+      }
+    ]
+  },
+  "object-edvac-report-neumann": {
+    "wikidataId": "Q5452926",
+    "wikipediaTitle": "First_Draft_of_a_Report_on_the_EDVAC",
+    "canonicalTitle": "First Draft of a Report on the EDVAC",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-edvac-report-neumann",
+        "nodeTitle": "First Draft of a Report on the EDVAC"
+      }
+    ]
+  },
+  "object-game-theory-neumann-morgenstern": {
+    "wikidataId": "Q5226156",
+    "wikipediaTitle": "Theory_of_Games_and_Economic_Behavior",
+    "canonicalTitle": "Theory of Games and Economic Behavior",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-game-theory-neumann-morgenstern",
+        "nodeTitle": "Theory of Games and Economic Behavior"
+      }
+    ]
+  },
+  "object-computer-brain-neumann": {
+    "wikidataId": "Q7727248",
+    "wikipediaTitle": "The_Computer_and_the_Brain",
+    "canonicalTitle": "The Computer and the Brain",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-computer-brain-neumann",
+        "nodeTitle": "The Computer and the Brain"
+      }
+    ]
+  },
+  "object-ultraintelligent-machine-good": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Speculations Concerning the First Ultraintelligent Machine",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-ultraintelligent-machine-good",
+        "nodeTitle": "Speculations Concerning the First Ultraintelligent Machine"
+      }
+    ]
+  },
+  "object-dartmouth-proposal": {
+    "wikidataId": "Q2453355",
+    "wikipediaTitle": "Dartmouth_workshop",
+    "canonicalTitle": "A Proposal for the Dartmouth Summer Research Project on Artificial Intelligence",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-dartmouth-proposal",
+        "nodeTitle": "A Proposal for the Dartmouth Summer Research Project on Artificial Intelligence"
+      }
+    ]
+  },
+  "object-man-computer-symbiosis-licklider": {
+    "wikidataId": null,
+    "wikipediaTitle": "Man-Computer_Symbiosis",
+    "canonicalTitle": "Man-Computer Symbiosis",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-man-computer-symbiosis-licklider",
+        "nodeTitle": "Man-Computer Symbiosis"
+      }
+    ]
+  },
+  "object-programs-common-sense-mccarthy": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Programs with Common Sense",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-programs-common-sense-mccarthy",
+        "nodeTitle": "Programs with Common Sense"
+      }
+    ]
+  },
+  "object-society-mind-minsky": {
+    "wikidataId": "Q2414313",
+    "wikipediaTitle": "The_Society_of_Mind",
+    "canonicalTitle": "The Society of Mind",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-society-mind-minsky",
+        "nodeTitle": "The Society of Mind"
+      }
+    ]
+  },
+  "object-unified-theories-newell": {
+    "wikidataId": "Q7884967",
+    "wikipediaTitle": "Unified_Theories_of_Cognition",
+    "canonicalTitle": "Unified Theories of Cognition",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-unified-theories-newell",
+        "nodeTitle": "Unified Theories of Cognition"
+      }
+    ]
+  },
+  "object-macy-proceedings": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Cybernetics: Circular Causal and Feedback Mechanisms (Macy Proceedings)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-macy-proceedings",
+        "nodeTitle": "Cybernetics: Circular Causal and Feedback Mechanisms (Macy Proceedings)"
+      }
+    ]
+  },
+  "object-homeostat-ashby": {
+    "wikidataId": "Q1048881",
+    "wikipediaTitle": "Homeostat",
+    "canonicalTitle": "The Homeostat",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-homeostat-ashby",
+        "nodeTitle": "The Homeostat"
+      }
+    ]
+  },
+  "object-tortoise-robots-walter": {
+    "wikidataId": "Q3532550",
+    "wikipediaTitle": "Turtle_(robot)",
+    "canonicalTitle": "Tortoise Robots (Elmer and Elsie)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-tortoise-robots-walter",
+        "nodeTitle": "Tortoise Robots (Elmer and Elsie)"
+      }
+    ]
+  },
+  "object-perceptron-hardware": {
+    "wikidataId": "Q690207",
+    "wikipediaTitle": "Perceptron",
+    "canonicalTitle": "Mark I Perceptron",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-perceptron-hardware",
+        "nodeTitle": "Mark I Perceptron"
+      }
+    ]
+  },
+  "object-eniac": {
+    "wikidataId": "Q169399",
+    "wikipediaTitle": "ENIAC",
+    "canonicalTitle": "ENIAC",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-eniac",
+        "nodeTitle": "ENIAC"
+      }
+    ]
+  },
+  "object-colossus": {
+    "wikidataId": "Q770597",
+    "wikipediaTitle": "Colossus_computer",
+    "canonicalTitle": "Colossus",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-colossus",
+        "nodeTitle": "Colossus"
+      }
+    ]
+  },
+  "object-edsac": {
+    "wikidataId": "Q863565",
+    "wikipediaTitle": "EDSAC",
+    "canonicalTitle": "EDSAC",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-edsac",
+        "nodeTitle": "EDSAC"
+      }
+    ]
+  },
+  "object-nls-engelbart": {
+    "wikidataId": "Q1050365",
+    "wikipediaTitle": "NLS_(computer_system)",
+    "canonicalTitle": "NLS/Augment System & Mouse",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-nls-engelbart",
+        "nodeTitle": "NLS/Augment System & Mouse"
+      }
+    ]
+  },
+  "location-mit": {
+    "wikidataId": "Q49108",
+    "wikipediaTitle": "Massachusetts_Institute_of_Technology",
+    "canonicalTitle": "Massachusetts Institute of Technology",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-mit",
+        "nodeTitle": "Massachusetts Institute of Technology"
+      }
+    ]
+  },
+  "location-bell-labs": {
+    "wikidataId": "Q217365",
+    "wikipediaTitle": "Bell_Labs",
+    "canonicalTitle": "Bell Labs",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-bell-labs",
+        "nodeTitle": "Bell Labs"
+      }
+    ]
+  },
+  "location-ias-princeton": {
+    "wikidataId": "Q635642",
+    "wikipediaTitle": "Institute_for_Advanced_Study",
+    "canonicalTitle": "Institute for Advanced Study",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-ias-princeton",
+        "nodeTitle": "Institute for Advanced Study"
+      }
+    ]
+  },
+  "location-bcl-illinois": {
+    "wikidataId": "Q164591",
+    "wikipediaTitle": "Biological_Computer_Laboratory",
+    "canonicalTitle": "Biological Computer Laboratory (BCL)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-bcl-illinois",
+        "nodeTitle": "Biological Computer Laboratory (BCL)"
+      }
+    ]
+  },
+  "location-carnegie-mellon": {
+    "wikidataId": "Q190080",
+    "wikipediaTitle": "Carnegie_Mellon_University",
+    "canonicalTitle": "Carnegie Mellon University",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-carnegie-mellon",
+        "nodeTitle": "Carnegie Mellon University"
+      }
+    ]
+  },
+  "location-sri": {
+    "wikidataId": "Q604924",
+    "wikipediaTitle": "SRI_International",
+    "canonicalTitle": "Stanford Research Institute (SRI)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-sri",
+        "nodeTitle": "Stanford Research Institute (SRI)"
+      }
+    ]
+  },
+  "location-cambridge": {
+    "wikidataId": "Q35794",
+    "wikipediaTitle": "University_of_Cambridge",
+    "canonicalTitle": "Cambridge University",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-cambridge",
+        "nodeTitle": "Cambridge University"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-cambridge",
+        "nodeTitle": "University of Cambridge"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-cambridge",
+        "nodeTitle": "Cambridge"
+      }
+    ]
+  },
+  "location-manchester": {
+    "wikidataId": "Q230899",
+    "wikipediaTitle": "University_of_Manchester",
+    "canonicalTitle": "University of Manchester",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-manchester",
+        "nodeTitle": "University of Manchester"
+      }
+    ]
+  },
+  "location-bletchley-park": {
+    "wikidataId": "Q155921",
+    "wikipediaTitle": "Bletchley_Park",
+    "canonicalTitle": "Bletchley Park",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-bletchley-park",
+        "nodeTitle": "Bletchley Park"
+      }
+    ]
+  },
+  "location-npl": {
+    "wikidataId": "Q1967606",
+    "wikipediaTitle": "National_Physical_Laboratory_(United_Kingdom)",
+    "canonicalTitle": "National Physical Laboratory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-npl",
+        "nodeTitle": "National Physical Laboratory"
+      }
+    ]
+  },
+  "location-burden-institute": {
+    "wikidataId": null,
+    "wikipediaTitle": "Burden_Neurological_Institute",
+    "canonicalTitle": "Burden Neurological Institute",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-burden-institute",
+        "nodeTitle": "Burden Neurological Institute"
+      }
+    ]
+  },
+  "location-barnwood-house": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Barnwood House Hospital",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-barnwood-house",
+        "nodeTitle": "Barnwood House Hospital"
+      }
+    ]
+  },
+  "location-beekman-hotel": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Beekman Hotel (Macy Conferences)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-beekman-hotel",
+        "nodeTitle": "Beekman Hotel (Macy Conferences)"
+      }
+    ]
+  },
+  "location-dartmouth": {
+    "wikidataId": "Q49116",
+    "wikipediaTitle": "Dartmouth_College",
+    "canonicalTitle": "Dartmouth College",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-dartmouth",
+        "nodeTitle": "Dartmouth College"
+      }
+    ]
+  },
+  "location-ratio-club-london": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Ratio Club Meeting Venues",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-ratio-club-london",
+        "nodeTitle": "Ratio Club Meeting Venues"
+      }
+    ]
+  },
+  "location-chile": {
+    "wikidataId": "Q232141",
+    "wikipediaTitle": "University_of_Chile",
+    "canonicalTitle": "University of Chile",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-chile",
+        "nodeTitle": "University of Chile"
+      }
+    ]
+  },
+  "location-opsroom-chile": {
+    "wikidataId": "Q1147211",
+    "wikipediaTitle": "Project_Cybersyn",
+    "canonicalTitle": "OPSROOM (Cybersyn)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-opsroom-chile",
+        "nodeTitle": "OPSROOM (Cybersyn)"
+      }
+    ]
+  },
+  "location-vienna": {
+    "wikidataId": "Q1741",
+    "wikipediaTitle": "Vienna",
+    "canonicalTitle": "Vienna",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-vienna",
+        "nodeTitle": "Vienna"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-vienna",
+        "nodeTitle": "Vienna"
+      }
+    ]
+  },
+  "location-mcgill": {
+    "wikidataId": "Q201492",
+    "wikipediaTitle": "McGill_University",
+    "canonicalTitle": "McGill University",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-mcgill",
+        "nodeTitle": "McGill University"
+      }
+    ]
+  },
+  "location-michigan": {
+    "wikidataId": "Q230492",
+    "wikipediaTitle": "University_of_Michigan",
+    "canonicalTitle": "University of Michigan",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-michigan",
+        "nodeTitle": "University of Michigan"
+      }
+    ]
+  },
+  "location-moore-school": {
+    "wikidataId": "Q6908229",
+    "wikipediaTitle": "Moore_School_of_Electrical_Engineering",
+    "canonicalTitle": "Moore School of Electrical Engineering",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-moore-school",
+        "nodeTitle": "Moore School of Electrical Engineering"
+      }
+    ]
+  },
+  "location-rand": {
+    "wikidataId": "Q861141",
+    "wikipediaTitle": "RAND_Corporation",
+    "canonicalTitle": "RAND Corporation",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-rand",
+        "nodeTitle": "RAND Corporation"
+      }
+    ]
+  },
+  "location-cornell-aero": {
+    "wikidataId": null,
+    "wikipediaTitle": "Cornell_Aeronautical_Laboratory",
+    "canonicalTitle": "Cornell Aeronautical Laboratory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-cornell-aero",
+        "nodeTitle": "Cornell Aeronautical Laboratory"
+      }
+    ]
+  },
+  "location-los-alamos": {
+    "wikidataId": "Q379848",
+    "wikipediaTitle": "Los_Alamos_National_Laboratory",
+    "canonicalTitle": "Los Alamos National Laboratory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-los-alamos",
+        "nodeTitle": "Los Alamos National Laboratory"
+      }
+    ]
+  },
+  "location-harvard": {
+    "wikidataId": "Q13371",
+    "wikipediaTitle": "Harvard_University",
+    "canonicalTitle": "Harvard University",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-harvard",
+        "nodeTitle": "Harvard University"
+      }
+    ]
+  },
+  "entity-macy-conferences": {
+    "wikidataId": "Q143363",
+    "wikipediaTitle": "Macy_conferences",
+    "canonicalTitle": "Macy Conferences on Cybernetics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-macy-conferences",
+        "nodeTitle": "Macy Conferences on Cybernetics"
+      }
+    ]
+  },
+  "entity-ratio-club": {
+    "wikidataId": "Q3420069",
+    "wikipediaTitle": "Ratio_Club",
+    "canonicalTitle": "Ratio Club",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-ratio-club",
+        "nodeTitle": "Ratio Club"
+      }
+    ]
+  },
+  "entity-sgsr": {
+    "wikidataId": "Q4330297",
+    "wikipediaTitle": "International_Society_for_the_Systems_Sciences",
+    "canonicalTitle": "Society for General Systems Research",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-sgsr",
+        "nodeTitle": "Society for General Systems Research"
+      }
+    ]
+  },
+  "entity-american-cybernetics": {
+    "wikidataId": "Q4745015",
+    "wikipediaTitle": "American_Society_for_Cybernetics",
+    "canonicalTitle": "American Society for Cybernetics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-american-cybernetics",
+        "nodeTitle": "American Society for Cybernetics"
+      }
+    ]
+  },
+  "entity-uk-cybernetics": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Cybernetics Society (UK)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-uk-cybernetics",
+        "nodeTitle": "Cybernetics Society (UK)"
+      }
+    ]
+  },
+  "entity-dartmouth-conference": {
+    "wikidataId": "Q2453355",
+    "wikipediaTitle": "Dartmouth_workshop",
+    "canonicalTitle": "Dartmouth Conference",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-dartmouth-conference",
+        "nodeTitle": "Dartmouth Conference"
+      }
+    ]
+  },
+  "entity-mit-rle": {
+    "wikidataId": null,
+    "wikipediaTitle": "MIT_Research_Laboratory_of_Electronics",
+    "canonicalTitle": "MIT Research Laboratory of Electronics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-mit-rle",
+        "nodeTitle": "MIT Research Laboratory of Electronics"
+      }
+    ]
+  },
+  "entity-mit-ai-lab": {
+    "wikidataId": "Q1354917",
+    "wikipediaTitle": "MIT_Computer_Science_and_Artificial_Intelligence_Laboratory",
+    "canonicalTitle": "MIT Artificial Intelligence Laboratory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-mit-ai-lab",
+        "nodeTitle": "MIT Artificial Intelligence Laboratory"
+      }
+    ]
+  },
+  "entity-bcl": {
+    "wikidataId": "Q164591",
+    "wikipediaTitle": "Biological_Computer_Laboratory",
+    "canonicalTitle": "Biological Computer Laboratory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-bcl",
+        "nodeTitle": "Biological Computer Laboratory"
+      }
+    ]
+  },
+  "entity-stanford-ai-lab": {
+    "wikidataId": null,
+    "wikipediaTitle": "Stanford_Artificial_Intelligence_Laboratory",
+    "canonicalTitle": "Stanford Artificial Intelligence Laboratory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-stanford-ai-lab",
+        "nodeTitle": "Stanford Artificial Intelligence Laboratory"
+      }
+    ]
+  },
+  "entity-bell-labs-research": {
+    "wikidataId": "Q217365",
+    "wikipediaTitle": "Bell_Labs",
+    "canonicalTitle": "Bell Labs Research",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-bell-labs-research",
+        "nodeTitle": "Bell Labs Research"
+      }
+    ]
+  },
+  "entity-arpa-ipto": {
+    "wikidataId": "Q6030770",
+    "wikipediaTitle": "Information_Processing_Techniques_Office",
+    "canonicalTitle": "ARPA Information Processing Techniques Office",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-arpa-ipto",
+        "nodeTitle": "ARPA Information Processing Techniques Office"
+      }
+    ]
+  },
+  "entity-macy-foundation": {
+    "wikidataId": "Q6290556",
+    "wikipediaTitle": "Josiah_Macy_Jr._Foundation",
+    "canonicalTitle": "Josiah Macy Jr. Foundation",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-macy-foundation",
+        "nodeTitle": "Josiah Macy Jr. Foundation"
+      }
+    ]
+  },
+  "entity-rockefeller-foundation": {
+    "wikidataId": "Q862034",
+    "wikipediaTitle": "Rockefeller_Foundation",
+    "canonicalTitle": "Rockefeller Foundation",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-rockefeller-foundation",
+        "nodeTitle": "Rockefeller Foundation"
+      }
+    ]
+  },
+  "entity-onr": {
+    "wikidataId": "Q1063818",
+    "wikipediaTitle": "Office_of_Naval_Research",
+    "canonicalTitle": "Office of Naval Research",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-onr",
+        "nodeTitle": "Office of Naval Research"
+      }
+    ]
+  },
+  "entity-cybernetics-movement": {
+    "wikidataId": "Q123637",
+    "wikipediaTitle": "Cybernetics",
+    "canonicalTitle": "Cybernetics (Movement)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-cybernetics-movement",
+        "nodeTitle": "Cybernetics (Movement)"
+      }
+    ]
+  },
+  "entity-information-theory": {
+    "wikidataId": "Q131222",
+    "wikipediaTitle": "Information_theory",
+    "canonicalTitle": "Information Theory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-information-theory",
+        "nodeTitle": "Information Theory"
+      }
+    ]
+  },
+  "entity-second-order-cybernetics": {
+    "wikidataId": "Q358532",
+    "wikipediaTitle": "Second-order_cybernetics",
+    "canonicalTitle": "Second-Order Cybernetics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-second-order-cybernetics",
+        "nodeTitle": "Second-Order Cybernetics"
+      }
+    ]
+  },
+  "entity-general-systems-theory": {
+    "wikidataId": "Q269699",
+    "wikipediaTitle": "Systems_theory",
+    "canonicalTitle": "General Systems Theory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-general-systems-theory",
+        "nodeTitle": "General Systems Theory"
+      }
+    ]
+  },
+  "entity-system-dynamics": {
+    "wikidataId": "Q598451",
+    "wikipediaTitle": "System_dynamics",
+    "canonicalTitle": "System Dynamics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-system-dynamics",
+        "nodeTitle": "System Dynamics"
+      }
+    ]
+  },
+  "entity-management-cybernetics": {
+    "wikidataId": "Q1544281",
+    "wikipediaTitle": "Management_cybernetics",
+    "canonicalTitle": "Management Cybernetics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-management-cybernetics",
+        "nodeTitle": "Management Cybernetics"
+      }
+    ]
+  },
+  "entity-symbolic-ai": {
+    "wikidataId": "Q5514059",
+    "wikipediaTitle": "Symbolic_artificial_intelligence",
+    "canonicalTitle": "Symbolic AI / GOFAI",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-symbolic-ai",
+        "nodeTitle": "Symbolic AI / GOFAI"
+      }
+    ]
+  },
+  "entity-connectionism": {
+    "wikidataId": "Q203790",
+    "wikipediaTitle": "Connectionism",
+    "canonicalTitle": "Connectionism / Neural Networks",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-connectionism",
+        "nodeTitle": "Connectionism / Neural Networks"
+      }
+    ]
+  },
+  "entity-autopoiesis": {
+    "wikidataId": "Q599967",
+    "wikipediaTitle": "Autopoiesis",
+    "canonicalTitle": "Autopoiesis",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-autopoiesis",
+        "nodeTitle": "Autopoiesis"
+      }
+    ]
+  },
+  "entity-cybersyn": {
+    "wikidataId": "Q1147211",
+    "wikipediaTitle": "Project_Cybersyn",
+    "canonicalTitle": "Cybersyn (Project Synco)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-cybersyn",
+        "nodeTitle": "Cybersyn (Project Synco)"
+      }
+    ]
+  },
+  "entity-project-mac": {
+    "wikidataId": "Q1354917",
+    "wikipediaTitle": "Project_MAC",
+    "canonicalTitle": "Project MAC",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-project-mac",
+        "nodeTitle": "Project MAC"
+      }
+    ]
+  },
+  "entity-arpanet": {
+    "wikidataId": "Q177524",
+    "wikipediaTitle": "ARPANET",
+    "canonicalTitle": "ARPANET",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-arpanet",
+        "nodeTitle": "ARPANET"
+      }
+    ]
+  },
+  "entity-whirlwind": {
+    "wikidataId": "Q1413683",
+    "wikipediaTitle": "Whirlwind_I",
+    "canonicalTitle": "Whirlwind / SAGE",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-whirlwind",
+        "nodeTitle": "Whirlwind / SAGE"
+      }
+    ]
+  },
+  "person-john-locke": {
+    "wikidataId": "Q9353",
+    "wikipediaTitle": "John_Locke",
+    "canonicalTitle": "John Locke",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-john-locke",
+        "nodeTitle": "John Locke"
+      }
+    ]
+  },
+  "person-isaac-newton": {
+    "wikidataId": "Q935",
+    "wikipediaTitle": "Isaac_Newton",
+    "canonicalTitle": "Isaac Newton",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-isaac-newton",
+        "nodeTitle": "Isaac Newton"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-isaac-newton",
+        "nodeTitle": "Isaac Newton"
+      },
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-isaac-newton",
+        "nodeTitle": "Sir Isaac Newton"
+      }
+    ]
+  },
+  "person-leibniz": {
+    "wikidataId": "Q9047",
+    "wikipediaTitle": "Gottfried_Wilhelm_Leibniz",
+    "canonicalTitle": "Gottfried Wilhelm Leibniz",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-leibniz",
+        "nodeTitle": "Gottfried Wilhelm Leibniz"
+      }
+    ]
+  },
+  "person-voltaire": {
+    "wikidataId": "Q9068",
+    "wikipediaTitle": "Voltaire",
+    "canonicalTitle": "Voltaire",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-voltaire",
+        "nodeTitle": "Voltaire"
+      }
+    ]
+  },
+  "person-diderot": {
+    "wikidataId": "Q448",
+    "wikipediaTitle": "Denis_Diderot",
+    "canonicalTitle": "Denis Diderot",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-diderot",
+        "nodeTitle": "Denis Diderot"
+      }
+    ]
+  },
+  "person-dalembert": {
+    "wikidataId": "Q153232",
+    "wikipediaTitle": "Jean_le_Rond_d'Alembert",
+    "canonicalTitle": "Jean le Rond d'Alembert",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-dalembert",
+        "nodeTitle": "Jean le Rond d'Alembert"
+      }
+    ]
+  },
+  "person-montesquieu": {
+    "wikidataId": "Q15975",
+    "wikipediaTitle": "Montesquieu",
+    "canonicalTitle": "Montesquieu",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-montesquieu",
+        "nodeTitle": "Montesquieu"
+      }
+    ]
+  },
+  "person-rousseau": {
+    "wikidataId": "Q6527",
+    "wikipediaTitle": "Jean-Jacques_Rousseau",
+    "canonicalTitle": "Jean-Jacques Rousseau",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-rousseau",
+        "nodeTitle": "Jean-Jacques Rousseau"
+      }
+    ]
+  },
+  "person-dholbach": {
+    "wikidataId": "Q7104",
+    "wikipediaTitle": "Baron_d'Holbach",
+    "canonicalTitle": "Baron d'Holbach",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-dholbach",
+        "nodeTitle": "Baron d'Holbach"
+      }
+    ]
+  },
+  "person-helvetius": {
+    "wikidataId": "Q190302",
+    "wikipediaTitle": "Claude_Adrien_Helvétius",
+    "canonicalTitle": "Claude-Adrien Helvétius",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-helvetius",
+        "nodeTitle": "Claude-Adrien Helvétius"
+      }
+    ]
+  },
+  "person-condillac": {
+    "wikidataId": "Q272119",
+    "wikipediaTitle": "Étienne_Bonnot_de_Condillac",
+    "canonicalTitle": "Étienne Bonnot de Condillac",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-condillac",
+        "nodeTitle": "Étienne Bonnot de Condillac"
+      }
+    ]
+  },
+  "person-condorcet": {
+    "wikidataId": "Q201477",
+    "wikipediaTitle": "Marquis_de_Condorcet",
+    "canonicalTitle": "Nicolas de Condorcet",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-condorcet",
+        "nodeTitle": "Nicolas de Condorcet"
+      }
+    ]
+  },
+  "person-la-mettrie": {
+    "wikidataId": "Q7068",
+    "wikipediaTitle": "Julien_Offray_de_La_Mettrie",
+    "canonicalTitle": "Julien Offray de La Mettrie",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-la-mettrie",
+        "nodeTitle": "Julien Offray de La Mettrie"
+      }
+    ]
+  },
+  "person-jaucourt": {
+    "wikidataId": "Q584990",
+    "wikipediaTitle": "Louis_de_Jaucourt",
+    "canonicalTitle": "Louis de Jaucourt",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-jaucourt",
+        "nodeTitle": "Louis de Jaucourt"
+      }
+    ]
+  },
+  "person-damilaville": {
+    "wikidataId": "Q3592308",
+    "wikipediaTitle": "Étienne_Noël_Damilaville",
+    "canonicalTitle": "Étienne Noël Damilaville",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-damilaville",
+        "nodeTitle": "Étienne Noël Damilaville"
+      }
+    ]
+  },
+  "person-morellet": {
+    "wikidataId": "Q178653",
+    "wikipediaTitle": "André_Morellet",
+    "canonicalTitle": "André Morellet",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-morellet",
+        "nodeTitle": "André Morellet"
+      }
+    ]
+  },
+  "person-david-hume": {
+    "wikidataId": "Q37160",
+    "wikipediaTitle": "David_Hume",
+    "canonicalTitle": "David Hume",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-david-hume",
+        "nodeTitle": "David Hume"
+      }
+    ]
+  },
+  "person-adam-smith": {
+    "wikidataId": "Q9381",
+    "wikipediaTitle": "Adam_Smith",
+    "canonicalTitle": "Adam Smith",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-adam-smith",
+        "nodeTitle": "Adam Smith"
+      }
+    ]
+  },
+  "person-hutcheson": {
+    "wikidataId": "Q316367",
+    "wikipediaTitle": "Francis_Hutcheson_(philosopher)",
+    "canonicalTitle": "Francis Hutcheson",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-hutcheson",
+        "nodeTitle": "Francis Hutcheson"
+      }
+    ]
+  },
+  "person-thomas-reid": {
+    "wikidataId": "Q316347",
+    "wikipediaTitle": "Thomas_Reid",
+    "canonicalTitle": "Thomas Reid",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-thomas-reid",
+        "nodeTitle": "Thomas Reid"
+      }
+    ]
+  },
+  "person-adam-ferguson": {
+    "wikidataId": "Q183094",
+    "wikipediaTitle": "Adam_Ferguson",
+    "canonicalTitle": "Adam Ferguson",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-adam-ferguson",
+        "nodeTitle": "Adam Ferguson"
+      }
+    ]
+  },
+  "person-william-robertson": {
+    "wikidataId": "Q1113461",
+    "wikipediaTitle": "William_Robertson_(historian)",
+    "canonicalTitle": "William Robertson",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-william-robertson",
+        "nodeTitle": "William Robertson"
+      }
+    ]
+  },
+  "person-lord-kames": {
+    "wikidataId": "Q1341370",
+    "wikipediaTitle": "Henry_Home,_Lord_Kames",
+    "canonicalTitle": "Henry Home, Lord Kames",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-lord-kames",
+        "nodeTitle": "Henry Home, Lord Kames"
+      }
+    ]
+  },
+  "person-dugald-stewart": {
+    "wikidataId": "Q218254",
+    "wikipediaTitle": "Dugald_Stewart",
+    "canonicalTitle": "Dugald Stewart",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-dugald-stewart",
+        "nodeTitle": "Dugald Stewart"
+      }
+    ]
+  },
+  "person-immanuel-kant": {
+    "wikidataId": "Q9312",
+    "wikipediaTitle": "Immanuel_Kant",
+    "canonicalTitle": "Immanuel Kant",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-immanuel-kant",
+        "nodeTitle": "Immanuel Kant"
+      }
+    ]
+  },
+  "person-christian-wolff": {
+    "wikidataId": "Q76510",
+    "wikipediaTitle": "Christian_Wolff_(philosopher)",
+    "canonicalTitle": "Christian Wolff",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-christian-wolff",
+        "nodeTitle": "Christian Wolff"
+      }
+    ]
+  },
+  "person-moses-mendelssohn": {
+    "wikidataId": "Q76997",
+    "wikipediaTitle": "Moses_Mendelssohn",
+    "canonicalTitle": "Moses Mendelssohn",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-moses-mendelssohn",
+        "nodeTitle": "Moses Mendelssohn"
+      }
+    ]
+  },
+  "person-gotthold-lessing": {
+    "wikidataId": "Q34628",
+    "wikipediaTitle": "Gotthold_Ephraim_Lessing",
+    "canonicalTitle": "Gotthold Ephraim Lessing",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-gotthold-lessing",
+        "nodeTitle": "Gotthold Ephraim Lessing"
+      }
+    ]
+  },
+  "person-johann-herder": {
+    "wikidataId": "Q155547",
+    "wikipediaTitle": "Johann_Gottfried_Herder",
+    "canonicalTitle": "Johann Gottfried Herder",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-johann-herder",
+        "nodeTitle": "Johann Gottfried Herder"
+      }
+    ]
+  },
+  "person-baumgarten": {
+    "wikidataId": "Q76517",
+    "wikipediaTitle": "Alexander_Gottlieb_Baumgarten",
+    "canonicalTitle": "Alexander Gottlieb Baumgarten",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-baumgarten",
+        "nodeTitle": "Alexander Gottlieb Baumgarten"
+      }
+    ]
+  },
+  "person-goethe": {
+    "wikidataId": "Q5879",
+    "wikipediaTitle": "Johann_Wolfgang_von_Goethe",
+    "canonicalTitle": "Johann Wolfgang von Goethe",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-goethe",
+        "nodeTitle": "Johann Wolfgang von Goethe"
+      }
+    ]
+  },
+  "person-george-berkeley": {
+    "wikidataId": "Q82049",
+    "wikipediaTitle": "George_Berkeley",
+    "canonicalTitle": "George Berkeley",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-george-berkeley",
+        "nodeTitle": "George Berkeley"
+      }
+    ]
+  },
+  "person-shaftesbury": {
+    "wikidataId": "Q335112",
+    "wikipediaTitle": "Anthony_Ashley-Cooper,_3rd_Earl_of_Shaftesbury",
+    "canonicalTitle": "Anthony Ashley Cooper, 3rd Earl of Shaftesbury",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-shaftesbury",
+        "nodeTitle": "Anthony Ashley Cooper, 3rd Earl of Shaftesbury"
+      }
+    ]
+  },
+  "person-mandeville": {
+    "wikidataId": "Q379912",
+    "wikipediaTitle": "Bernard_Mandeville",
+    "canonicalTitle": "Bernard Mandeville",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-mandeville",
+        "nodeTitle": "Bernard Mandeville"
+      }
+    ]
+  },
+  "person-edmund-burke": {
+    "wikidataId": "Q165792",
+    "wikipediaTitle": "Edmund_Burke",
+    "canonicalTitle": "Edmund Burke",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-edmund-burke",
+        "nodeTitle": "Edmund Burke"
+      }
+    ]
+  },
+  "person-joseph-priestley": {
+    "wikidataId": "Q159636",
+    "wikipediaTitle": "Joseph_Priestley",
+    "canonicalTitle": "Joseph Priestley",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-joseph-priestley",
+        "nodeTitle": "Joseph Priestley"
+      }
+    ]
+  },
+  "person-jeremy-bentham": {
+    "wikidataId": "Q60887",
+    "wikipediaTitle": "Jeremy_Bentham",
+    "canonicalTitle": "Jeremy Bentham",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-jeremy-bentham",
+        "nodeTitle": "Jeremy Bentham"
+      }
+    ]
+  },
+  "person-thomas-paine": {
+    "wikidataId": "Q126462",
+    "wikipediaTitle": "Thomas_Paine",
+    "canonicalTitle": "Thomas Paine",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-thomas-paine",
+        "nodeTitle": "Thomas Paine"
+      }
+    ]
+  },
+  "person-cesare-beccaria": {
+    "wikidataId": "Q223723",
+    "wikipediaTitle": "Cesare_Beccaria",
+    "canonicalTitle": "Cesare Beccaria",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-cesare-beccaria",
+        "nodeTitle": "Cesare Beccaria"
+      }
+    ]
+  },
+  "person-francois-quesnay": {
+    "wikidataId": "Q13575",
+    "wikipediaTitle": "François_Quesnay",
+    "canonicalTitle": "François Quesnay",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-francois-quesnay",
+        "nodeTitle": "François Quesnay"
+      }
+    ]
+  },
+  "person-turgot": {
+    "wikidataId": "Q221303",
+    "wikipediaTitle": "Anne_Robert_Jacques_Turgot",
+    "canonicalTitle": "Anne-Robert-Jacques Turgot",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-turgot",
+        "nodeTitle": "Anne-Robert-Jacques Turgot"
+      }
+    ]
+  },
+  "person-mirabeau-elder": {
+    "wikidataId": "Q947485",
+    "wikipediaTitle": "Victor_de_Riqueti,_marquis_de_Mirabeau",
+    "canonicalTitle": "Victor de Riqueti, Marquis de Mirabeau",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-mirabeau-elder",
+        "nodeTitle": "Victor de Riqueti, Marquis de Mirabeau"
+      }
+    ]
+  },
+  "person-benjamin-franklin": {
+    "wikidataId": "Q34969",
+    "wikipediaTitle": "Benjamin_Franklin",
+    "canonicalTitle": "Benjamin Franklin",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-benjamin-franklin",
+        "nodeTitle": "Benjamin Franklin"
+      }
+    ]
+  },
+  "person-thomas-jefferson": {
+    "wikidataId": "Q11812",
+    "wikipediaTitle": "Thomas_Jefferson",
+    "canonicalTitle": "Thomas Jefferson",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-thomas-jefferson",
+        "nodeTitle": "Thomas Jefferson"
+      }
+    ]
+  },
+  "person-james-madison": {
+    "wikidataId": "Q11813",
+    "wikipediaTitle": "James_Madison",
+    "canonicalTitle": "James Madison",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-james-madison",
+        "nodeTitle": "James Madison"
+      }
+    ]
+  },
+  "person-john-adams": {
+    "wikidataId": "Q11806",
+    "wikipediaTitle": "John_Adams",
+    "canonicalTitle": "John Adams",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-john-adams",
+        "nodeTitle": "John Adams"
+      }
+    ]
+  },
+  "person-leonhard-euler": {
+    "wikidataId": "Q7604",
+    "wikipediaTitle": "Leonhard_Euler",
+    "canonicalTitle": "Leonhard Euler",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-leonhard-euler",
+        "nodeTitle": "Leonhard Euler"
+      }
+    ]
+  },
+  "person-laplace": {
+    "wikidataId": "Q44481",
+    "wikipediaTitle": "Pierre-Simon_Laplace",
+    "canonicalTitle": "Pierre-Simon Laplace",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-laplace",
+        "nodeTitle": "Pierre-Simon Laplace"
+      }
+    ]
+  },
+  "person-lavoisier": {
+    "wikidataId": "Q39607",
+    "wikipediaTitle": "Antoine_Lavoisier",
+    "canonicalTitle": "Antoine Lavoisier",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-lavoisier",
+        "nodeTitle": "Antoine Lavoisier"
+      }
+    ]
+  },
+  "person-buffon": {
+    "wikidataId": "Q229264",
+    "wikipediaTitle": "Georges-Louis_Leclerc,_Comte_de_Buffon",
+    "canonicalTitle": "Georges-Louis Leclerc, Comte de Buffon",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-buffon",
+        "nodeTitle": "Georges-Louis Leclerc, Comte de Buffon"
+      }
+    ]
+  },
+  "person-emilie-du-chatelet": {
+    "wikidataId": "Q7286",
+    "wikipediaTitle": "Émilie_du_Châtelet",
+    "canonicalTitle": "Émilie du Châtelet",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-emilie-du-chatelet",
+        "nodeTitle": "Émilie du Châtelet"
+      }
+    ]
+  },
+  "person-lagrange": {
+    "wikidataId": "Q80222",
+    "wikipediaTitle": "Joseph-Louis_Lagrange",
+    "canonicalTitle": "Joseph-Louis Lagrange",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-lagrange",
+        "nodeTitle": "Joseph-Louis Lagrange"
+      }
+    ]
+  },
+  "person-madame-geoffrin": {
+    "wikidataId": "Q269865",
+    "wikipediaTitle": "Marie_Thérèse_Rodet_Geoffrin",
+    "canonicalTitle": "Marie-Thérèse Rodet Geoffrin",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-madame-geoffrin",
+        "nodeTitle": "Marie-Thérèse Rodet Geoffrin"
+      }
+    ]
+  },
+  "person-julie-de-lespinasse": {
+    "wikidataId": "Q450354",
+    "wikipediaTitle": "Julie_de_Lespinasse",
+    "canonicalTitle": "Julie de Lespinasse",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-julie-de-lespinasse",
+        "nodeTitle": "Julie de Lespinasse"
+      }
+    ]
+  },
+  "person-madame-du-deffand": {
+    "wikidataId": "Q297785",
+    "wikipediaTitle": "Marie_Anne_de_Vichy-Chamrond,_marquise_du_Deffand",
+    "canonicalTitle": "Marie de Vichy-Chamrond, Marquise du Deffand",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-madame-du-deffand",
+        "nodeTitle": "Marie de Vichy-Chamrond, Marquise du Deffand"
+      }
+    ]
+  },
+  "person-madame-helvetius": {
+    "wikidataId": "Q461961",
+    "wikipediaTitle": "Anne-Catherine_de_Ligniville",
+    "canonicalTitle": "Anne-Catherine de Ligniville",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-madame-helvetius",
+        "nodeTitle": "Anne-Catherine de Ligniville"
+      }
+    ]
+  },
+  "person-frederick-great": {
+    "wikidataId": "Q33550",
+    "wikipediaTitle": "Frederick_the_Great",
+    "canonicalTitle": "Frederick II of Prussia",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-frederick-great",
+        "nodeTitle": "Frederick II of Prussia"
+      }
+    ]
+  },
+  "person-catherine-great": {
+    "wikidataId": "Q36450",
+    "wikipediaTitle": "Catherine_the_Great",
+    "canonicalTitle": "Catherine II of Russia",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-catherine-great",
+        "nodeTitle": "Catherine II of Russia"
+      }
+    ]
+  },
+  "object-principia-mathematica": {
+    "wikidataId": "Q205921",
+    "wikipediaTitle": "Philosophiæ_Naturalis_Principia_Mathematica",
+    "canonicalTitle": "Philosophiæ Naturalis Principia Mathematica",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-principia-mathematica",
+        "nodeTitle": "Philosophiæ Naturalis Principia Mathematica"
+      }
+    ]
+  },
+  "object-essay-human-understanding": {
+    "wikidataId": "Q482438",
+    "wikipediaTitle": "An_Essay_Concerning_Human_Understanding",
+    "canonicalTitle": "Essay Concerning Human Understanding",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-essay-human-understanding",
+        "nodeTitle": "Essay Concerning Human Understanding"
+      }
+    ]
+  },
+  "object-two-treatises": {
+    "wikidataId": "Q231949",
+    "wikipediaTitle": "Two_Treatises_of_Government",
+    "canonicalTitle": "Two Treatises of Government",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-two-treatises",
+        "nodeTitle": "Two Treatises of Government"
+      }
+    ]
+  },
+  "object-letter-toleration": {
+    "wikidataId": "Q914139",
+    "wikipediaTitle": "A_Letter_Concerning_Toleration",
+    "canonicalTitle": "A Letter Concerning Toleration",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-letter-toleration",
+        "nodeTitle": "A Letter Concerning Toleration"
+      }
+    ]
+  },
+  "object-opticks": {
+    "wikidataId": "Q74263",
+    "wikipediaTitle": "Opticks",
+    "canonicalTitle": "Opticks",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-opticks",
+        "nodeTitle": "Opticks"
+      }
+    ]
+  },
+  "object-theodicy": {
+    "wikidataId": "Q2166858",
+    "wikipediaTitle": "Théodicée",
+    "canonicalTitle": "Theodicy",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-theodicy",
+        "nodeTitle": "Theodicy"
+      }
+    ]
+  },
+  "object-characteristics": {
+    "wikidataId": "Q335112",
+    "wikipediaTitle": "Characteristics_of_Men,_Manners,_Opinions,_Times",
+    "canonicalTitle": "Characteristics of Men, Manners, Opinions, Times",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-characteristics",
+        "nodeTitle": "Characteristics of Men, Manners, Opinions, Times"
+      }
+    ]
+  },
+  "object-fable-bees": {
+    "wikidataId": "Q1171104",
+    "wikipediaTitle": "The_Fable_of_the_Bees",
+    "canonicalTitle": "The Fable of the Bees",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-fable-bees",
+        "nodeTitle": "The Fable of the Bees"
+      }
+    ]
+  },
+  "object-monadology": {
+    "wikidataId": "Q1211539",
+    "wikipediaTitle": "Monadology",
+    "canonicalTitle": "Monadology",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-monadology",
+        "nodeTitle": "Monadology"
+      }
+    ]
+  },
+  "object-persian-letters": {
+    "wikidataId": "Q1050479",
+    "wikipediaTitle": "Persian_Letters",
+    "canonicalTitle": "Persian Letters",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-persian-letters",
+        "nodeTitle": "Persian Letters"
+      }
+    ]
+  },
+  "object-letters-english": {
+    "wikidataId": "Q2551373",
+    "wikipediaTitle": "Letters_on_the_English",
+    "canonicalTitle": "Letters on the English",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-letters-english",
+        "nodeTitle": "Letters on the English"
+      }
+    ]
+  },
+  "object-elements-newton": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Elements of the Philosophy of Newton",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-elements-newton",
+        "nodeTitle": "Elements of the Philosophy of Newton"
+      }
+    ]
+  },
+  "object-traite-dynamique": {
+    "wikidataId": null,
+    "wikipediaTitle": "Traité_de_Dynamique",
+    "canonicalTitle": "Traité de dynamique",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-traite-dynamique",
+        "nodeTitle": "Traité de dynamique"
+      }
+    ]
+  },
+  "object-essay-origin-knowledge": {
+    "wikidataId": null,
+    "wikipediaTitle": "Essay_on_the_Origin_of_Human_Knowledge",
+    "canonicalTitle": "Essay on the Origin of Human Knowledge",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-essay-origin-knowledge",
+        "nodeTitle": "Essay on the Origin of Human Knowledge"
+      }
+    ]
+  },
+  "object-natural-history-soul": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Natural History of the Soul",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-natural-history-soul",
+        "nodeTitle": "Natural History of the Soul"
+      }
+    ]
+  },
+  "object-homme-machine": {
+    "wikidataId": "Q3203583",
+    "wikipediaTitle": "Man_a_Machine",
+    "canonicalTitle": "Man a Machine",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-homme-machine",
+        "nodeTitle": "Man a Machine"
+      }
+    ]
+  },
+  "object-spirit-laws": {
+    "wikidataId": "Q514727",
+    "wikipediaTitle": "The_Spirit_of_the_Laws",
+    "canonicalTitle": "The Spirit of the Laws",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-spirit-laws",
+        "nodeTitle": "The Spirit of the Laws"
+      }
+    ]
+  },
+  "object-histoire-naturelle": {
+    "wikidataId": "Q3138032",
+    "wikipediaTitle": "Histoire_Naturelle",
+    "canonicalTitle": "Histoire naturelle",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-histoire-naturelle",
+        "nodeTitle": "Histoire naturelle"
+      }
+    ]
+  },
+  "object-encyclopedie": {
+    "wikidataId": "Q447",
+    "wikipediaTitle": "Encyclopédie",
+    "canonicalTitle": "Encyclopédie",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-encyclopedie",
+        "nodeTitle": "Encyclopédie"
+      }
+    ]
+  },
+  "object-preliminary-discourse": {
+    "wikidataId": "Q3030210",
+    "wikipediaTitle": "Preliminary_Discourse_to_the_Encyclopedia_of_Diderot",
+    "canonicalTitle": "Preliminary Discourse to the Encyclopedia",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-preliminary-discourse",
+        "nodeTitle": "Preliminary Discourse to the Encyclopedia"
+      }
+    ]
+  },
+  "object-treatise-sensations": {
+    "wikidataId": null,
+    "wikipediaTitle": "Treatise_on_Sensations",
+    "canonicalTitle": "Treatise on Sensations",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-treatise-sensations",
+        "nodeTitle": "Treatise on Sensations"
+      }
+    ]
+  },
+  "object-discourse-inequality": {
+    "wikidataId": "Q135598",
+    "wikipediaTitle": "Discourse_on_Inequality",
+    "canonicalTitle": "Discourse on the Origin of Inequality",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-discourse-inequality",
+        "nodeTitle": "Discourse on the Origin of Inequality"
+      }
+    ]
+  },
+  "object-de-lesprit": {
+    "wikidataId": null,
+    "wikipediaTitle": "De_l'esprit",
+    "canonicalTitle": "De l'esprit",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-de-lesprit",
+        "nodeTitle": "De l'esprit"
+      }
+    ]
+  },
+  "object-tableau-economique": {
+    "wikidataId": "Q1747160",
+    "wikipediaTitle": "Tableau_économique",
+    "canonicalTitle": "Tableau économique",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-tableau-economique",
+        "nodeTitle": "Tableau économique"
+      }
+    ]
+  },
+  "object-candide": {
+    "wikidataId": "Q215894",
+    "wikipediaTitle": "Candide",
+    "canonicalTitle": "Candide",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-candide",
+        "nodeTitle": "Candide"
+      }
+    ]
+  },
+  "object-christianity-unveiled": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Christianity Unveiled",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-christianity-unveiled",
+        "nodeTitle": "Christianity Unveiled"
+      }
+    ]
+  },
+  "object-social-contract": {
+    "wikidataId": "Q190126",
+    "wikipediaTitle": "The_Social_Contract",
+    "canonicalTitle": "The Social Contract",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-social-contract",
+        "nodeTitle": "The Social Contract"
+      }
+    ]
+  },
+  "object-emile": {
+    "wikidataId": "Q913599",
+    "wikipediaTitle": "Emile,_or_On_Education",
+    "canonicalTitle": "Emile, or On Education",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-emile",
+        "nodeTitle": "Emile, or On Education"
+      }
+    ]
+  },
+  "object-philosophical-dictionary": {
+    "wikidataId": "Q656976",
+    "wikipediaTitle": "Dictionnaire_philosophique",
+    "canonicalTitle": "Philosophical Dictionary",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-philosophical-dictionary",
+        "nodeTitle": "Philosophical Dictionary"
+      }
+    ]
+  },
+  "object-reflections-wealth": {
+    "wikidataId": null,
+    "wikipediaTitle": "Reflections_on_the_Formation_and_Distribution_of_Riches",
+    "canonicalTitle": "Reflections on the Formation and Distribution of Wealth",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-reflections-wealth",
+        "nodeTitle": "Reflections on the Formation and Distribution of Wealth"
+      }
+    ]
+  },
+  "object-system-nature": {
+    "wikidataId": "Q1111930",
+    "wikipediaTitle": "The_System_of_Nature",
+    "canonicalTitle": "The System of Nature",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-system-nature",
+        "nodeTitle": "The System of Nature"
+      }
+    ]
+  },
+  "object-sketch-progress": {
+    "wikidataId": "Q7534728",
+    "wikipediaTitle": "Sketch_for_a_Historical_Picture_of_the_Progress_of_the_Human_Mind",
+    "canonicalTitle": "Sketch for a Historical Picture of the Progress of the Human Mind",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-sketch-progress",
+        "nodeTitle": "Sketch for a Historical Picture of the Progress of the Human Mind"
+      }
+    ]
+  },
+  "object-principles-human-knowledge": {
+    "wikidataId": "Q3267928",
+    "wikipediaTitle": "A_Treatise_Concerning_the_Principles_of_Human_Knowledge",
+    "canonicalTitle": "A Treatise Concerning the Principles of Human Knowledge",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-principles-human-knowledge",
+        "nodeTitle": "A Treatise Concerning the Principles of Human Knowledge"
+      }
+    ]
+  },
+  "object-three-dialogues": {
+    "wikidataId": null,
+    "wikipediaTitle": "Three_Dialogues_between_Hylas_and_Philonous",
+    "canonicalTitle": "Three Dialogues between Hylas and Philonous",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-three-dialogues",
+        "nodeTitle": "Three Dialogues between Hylas and Philonous"
+      }
+    ]
+  },
+  "object-inquiry-beauty-virtue": {
+    "wikidataId": null,
+    "wikipediaTitle": "An_Inquiry_into_the_Original_of_Our_Ideas_of_Beauty_and_Virtue",
+    "canonicalTitle": "Inquiry into the Original of Our Ideas of Beauty and Virtue",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-inquiry-beauty-virtue",
+        "nodeTitle": "Inquiry into the Original of Our Ideas of Beauty and Virtue"
+      }
+    ]
+  },
+  "object-treatise-human-nature": {
+    "wikidataId": "Q2451675",
+    "wikipediaTitle": "A_Treatise_of_Human_Nature",
+    "canonicalTitle": "A Treatise of Human Nature",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-treatise-human-nature",
+        "nodeTitle": "A Treatise of Human Nature"
+      }
+    ]
+  },
+  "object-enquiry-human-understanding": {
+    "wikidataId": "Q1306656",
+    "wikipediaTitle": "An_Enquiry_Concerning_Human_Understanding",
+    "canonicalTitle": "An Enquiry Concerning Human Understanding",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-enquiry-human-understanding",
+        "nodeTitle": "An Enquiry Concerning Human Understanding"
+      }
+    ]
+  },
+  "object-essays-morality-religion": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Essays on the Principles of Morality and Natural Religion",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-essays-morality-religion",
+        "nodeTitle": "Essays on the Principles of Morality and Natural Religion"
+      }
+    ]
+  },
+  "object-history-england": {
+    "wikidataId": "Q7739783",
+    "wikipediaTitle": "The_History_of_England_(Hume)",
+    "canonicalTitle": "History of England",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-history-england",
+        "nodeTitle": "History of England"
+      }
+    ]
+  },
+  "object-sublime-beautiful": {
+    "wikidataId": "Q947972",
+    "wikipediaTitle": "A_Philosophical_Enquiry_into_the_Origin_of_Our_Ideas_of_the_Sublime_and_Beautiful",
+    "canonicalTitle": "A Philosophical Enquiry into the Sublime and Beautiful",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-sublime-beautiful",
+        "nodeTitle": "A Philosophical Enquiry into the Sublime and Beautiful"
+      }
+    ]
+  },
+  "object-theory-moral-sentiments": {
+    "wikidataId": "Q1438448",
+    "wikipediaTitle": "The_Theory_of_Moral_Sentiments",
+    "canonicalTitle": "The Theory of Moral Sentiments",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-theory-moral-sentiments",
+        "nodeTitle": "The Theory of Moral Sentiments"
+      }
+    ]
+  },
+  "object-history-scotland": {
+    "wikidataId": null,
+    "wikipediaTitle": "History_of_Scotland_(Robertson)",
+    "canonicalTitle": "History of Scotland",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-history-scotland",
+        "nodeTitle": "History of Scotland"
+      }
+    ]
+  },
+  "object-elements-criticism": {
+    "wikidataId": null,
+    "wikipediaTitle": "Elements_of_Criticism",
+    "canonicalTitle": "Elements of Criticism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-elements-criticism",
+        "nodeTitle": "Elements of Criticism"
+      }
+    ]
+  },
+  "object-inquiry-common-sense": {
+    "wikidataId": null,
+    "wikipediaTitle": "Inquiry_into_the_Human_Mind",
+    "canonicalTitle": "Inquiry into the Human Mind on the Principles of Common Sense",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-inquiry-common-sense",
+        "nodeTitle": "Inquiry into the Human Mind on the Principles of Common Sense"
+      }
+    ]
+  },
+  "object-essay-civil-society": {
+    "wikidataId": "Q4749931",
+    "wikipediaTitle": "An_Essay_on_the_History_of_Civil_Society",
+    "canonicalTitle": "Essay on the History of Civil Society",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-essay-civil-society",
+        "nodeTitle": "Essay on the History of Civil Society"
+      }
+    ]
+  },
+  "object-wealth-nations": {
+    "wikidataId": "Q233562",
+    "wikipediaTitle": "The_Wealth_of_Nations",
+    "canonicalTitle": "An Inquiry into the Nature and Causes of the Wealth of Nations",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-wealth-nations",
+        "nodeTitle": "An Inquiry into the Nature and Causes of the Wealth of Nations"
+      }
+    ]
+  },
+  "object-dialogues-natural-religion": {
+    "wikidataId": "Q965564",
+    "wikipediaTitle": "Dialogues_Concerning_Natural_Religion",
+    "canonicalTitle": "Dialogues Concerning Natural Religion",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-dialogues-natural-religion",
+        "nodeTitle": "Dialogues Concerning Natural Religion"
+      }
+    ]
+  },
+  "object-reflections-revolution": {
+    "wikidataId": "Q2287584",
+    "wikipediaTitle": "Reflections_on_the_Revolution_in_France",
+    "canonicalTitle": "Reflections on the Revolution in France",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-reflections-revolution",
+        "nodeTitle": "Reflections on the Revolution in France"
+      }
+    ]
+  },
+  "object-principles-morals-legislation": {
+    "wikidataId": "Q19041209",
+    "wikipediaTitle": "An_Introduction_to_the_Principles_of_Morals_and_Legislation",
+    "canonicalTitle": "Introduction to the Principles of Morals and Legislation",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-principles-morals-legislation",
+        "nodeTitle": "Introduction to the Principles of Morals and Legislation"
+      }
+    ]
+  },
+  "object-german-logic": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Rational Thoughts on God, the World, and the Soul of Man",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-german-logic",
+        "nodeTitle": "Rational Thoughts on God, the World, and the Soul of Man"
+      }
+    ]
+  },
+  "object-aesthetica": {
+    "wikidataId": "Q3606120",
+    "wikipediaTitle": "Aesthetica",
+    "canonicalTitle": "Aesthetica",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-aesthetica",
+        "nodeTitle": "Aesthetica"
+      }
+    ]
+  },
+  "object-metaphysica": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Metaphysica",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-metaphysica",
+        "nodeTitle": "Metaphysica"
+      }
+    ]
+  },
+  "object-laocoon": {
+    "wikidataId": null,
+    "wikipediaTitle": "Laocoön_(essay)",
+    "canonicalTitle": "Laocoon: An Essay on the Limits of Painting and Poetry",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-laocoon",
+        "nodeTitle": "Laocoon: An Essay on the Limits of Painting and Poetry"
+      }
+    ]
+  },
+  "object-phadon": {
+    "wikidataId": null,
+    "wikipediaTitle": "Phädon",
+    "canonicalTitle": "Phädon",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-phadon",
+        "nodeTitle": "Phädon"
+      }
+    ]
+  },
+  "object-treatise-origin-language": {
+    "wikidataId": null,
+    "wikipediaTitle": "Treatise_on_the_Origin_of_Language",
+    "canonicalTitle": "Treatise on the Origin of Language",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-treatise-origin-language",
+        "nodeTitle": "Treatise on the Origin of Language"
+      }
+    ]
+  },
+  "object-nathan-wise": {
+    "wikidataId": "Q286611",
+    "wikipediaTitle": "Nathan_the_Wise",
+    "canonicalTitle": "Nathan the Wise",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-nathan-wise",
+        "nodeTitle": "Nathan the Wise"
+      }
+    ]
+  },
+  "object-critique-pure-reason": {
+    "wikidataId": "Q220002",
+    "wikipediaTitle": "Critique_of_Pure_Reason",
+    "canonicalTitle": "Critique of Pure Reason",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-critique-pure-reason",
+        "nodeTitle": "Critique of Pure Reason"
+      }
+    ]
+  },
+  "object-jerusalem": {
+    "wikidataId": null,
+    "wikipediaTitle": "Jerusalem_(Mendelssohn)",
+    "canonicalTitle": "Jerusalem, or On Religious Power and Judaism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-jerusalem",
+        "nodeTitle": "Jerusalem, or On Religious Power and Judaism"
+      }
+    ]
+  },
+  "object-what-is-enlightenment": {
+    "wikidataId": null,
+    "wikipediaTitle": "Answering_the_Question:_What_Is_Enlightenment%3F",
+    "canonicalTitle": "What is Enlightenment?",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-what-is-enlightenment",
+        "nodeTitle": "What is Enlightenment?"
+      }
+    ]
+  },
+  "object-ideas-philosophy-history": {
+    "wikidataId": null,
+    "wikipediaTitle": "Outlines_of_a_Philosophy_of_the_History_of_Man",
+    "canonicalTitle": "Ideas for the Philosophy of History of Humanity",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-ideas-philosophy-history",
+        "nodeTitle": "Ideas for the Philosophy of History of Humanity"
+      }
+    ]
+  },
+  "object-critique-practical-reason": {
+    "wikidataId": "Q870851",
+    "wikipediaTitle": "Critique_of_Practical_Reason",
+    "canonicalTitle": "Critique of Practical Reason",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-critique-practical-reason",
+        "nodeTitle": "Critique of Practical Reason"
+      }
+    ]
+  },
+  "object-critique-judgment": {
+    "wikidataId": "Q1056332",
+    "wikipediaTitle": "Critique_of_Judgment",
+    "canonicalTitle": "Critique of Judgment",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-critique-judgment",
+        "nodeTitle": "Critique of Judgment"
+      }
+    ]
+  },
+  "object-crimes-punishments": {
+    "wikidataId": "Q2755269",
+    "wikipediaTitle": "On_Crimes_and_Punishments",
+    "canonicalTitle": "On Crimes and Punishments",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-crimes-punishments",
+        "nodeTitle": "On Crimes and Punishments"
+      }
+    ]
+  },
+  "object-experiments-electricity": {
+    "wikidataId": "Q19108828",
+    "wikipediaTitle": "Experiments_and_Observations_on_Electricity",
+    "canonicalTitle": "Experiments and Observations on Electricity",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-experiments-electricity",
+        "nodeTitle": "Experiments and Observations on Electricity"
+      }
+    ]
+  },
+  "object-common-sense": {
+    "wikidataId": "Q843940",
+    "wikipediaTitle": "Common_Sense",
+    "canonicalTitle": "Common Sense",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-common-sense",
+        "nodeTitle": "Common Sense"
+      }
+    ]
+  },
+  "object-declaration-independence": {
+    "wikidataId": "Q127912",
+    "wikipediaTitle": "United_States_Declaration_of_Independence",
+    "canonicalTitle": "Declaration of Independence",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-declaration-independence",
+        "nodeTitle": "Declaration of Independence"
+      }
+    ]
+  },
+  "object-virginia-statute": {
+    "wikidataId": "Q4086736",
+    "wikipediaTitle": "Virginia_Statute_for_Religious_Freedom",
+    "canonicalTitle": "Virginia Statute for Religious Freedom",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-virginia-statute",
+        "nodeTitle": "Virginia Statute for Religious Freedom"
+      }
+    ]
+  },
+  "object-notes-virginia": {
+    "wikidataId": "Q4261404",
+    "wikipediaTitle": "Notes_on_the_State_of_Virginia",
+    "canonicalTitle": "Notes on the State of Virginia",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-notes-virginia",
+        "nodeTitle": "Notes on the State of Virginia"
+      }
+    ]
+  },
+  "object-federalist-papers": {
+    "wikidataId": "Q858036",
+    "wikipediaTitle": "The_Federalist_Papers",
+    "canonicalTitle": "The Federalist Papers",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-federalist-papers",
+        "nodeTitle": "The Federalist Papers"
+      }
+    ]
+  },
+  "object-rights-man": {
+    "wikidataId": "Q979108",
+    "wikipediaTitle": "Rights_of_Man",
+    "canonicalTitle": "Rights of Man",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-rights-man",
+        "nodeTitle": "Rights of Man"
+      }
+    ]
+  },
+  "object-age-reason": {
+    "wikidataId": "Q1983019",
+    "wikipediaTitle": "The_Age_of_Reason",
+    "canonicalTitle": "The Age of Reason",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-age-reason",
+        "nodeTitle": "The Age of Reason"
+      }
+    ]
+  },
+  "object-institutions-physique": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Institutions de physique",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-institutions-physique",
+        "nodeTitle": "Institutions de physique"
+      }
+    ]
+  },
+  "object-principia-translation": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "French Translation of Newton's Principia",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-principia-translation",
+        "nodeTitle": "French Translation of Newton's Principia"
+      }
+    ]
+  },
+  "object-elements-chemistry": {
+    "wikidataId": "Q2163561",
+    "wikipediaTitle": "Traité_Élémentaire_de_Chimie",
+    "canonicalTitle": "Elements of Chemistry",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-elements-chemistry",
+        "nodeTitle": "Elements of Chemistry"
+      }
+    ]
+  },
+  "object-essay-probability-decisions": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Essay on the Application of Analysis to the Probability of Majority Decisions",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-essay-probability-decisions",
+        "nodeTitle": "Essay on the Application of Analysis to the Probability of Majority Decisions"
+      }
+    ]
+  },
+  "location-edinburgh": {
+    "wikidataId": "Q23436",
+    "wikipediaTitle": "Edinburgh",
+    "canonicalTitle": "Edinburgh",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-edinburgh",
+        "nodeTitle": "Edinburgh"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-edinburgh",
+        "nodeTitle": "Edinburgh"
+      }
+    ]
+  },
+  "location-berlin": {
+    "wikidataId": "Q64",
+    "wikipediaTitle": "Berlin",
+    "canonicalTitle": "Berlin",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-berlin",
+        "nodeTitle": "Berlin"
+      }
+    ]
+  },
+  "location-geneva": {
+    "wikidataId": "Q71",
+    "wikipediaTitle": "Geneva",
+    "canonicalTitle": "Geneva",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-geneva",
+        "nodeTitle": "Geneva"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-geneva",
+        "nodeTitle": "Geneva"
+      }
+    ]
+  },
+  "location-amsterdam": {
+    "wikidataId": "Q727",
+    "wikipediaTitle": "Amsterdam",
+    "canonicalTitle": "Amsterdam",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-amsterdam",
+        "nodeTitle": "Amsterdam"
+      }
+    ]
+  },
+  "location-glasgow": {
+    "wikidataId": "Q4093",
+    "wikipediaTitle": "Glasgow",
+    "canonicalTitle": "Glasgow",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-glasgow",
+        "nodeTitle": "Glasgow"
+      }
+    ]
+  },
+  "location-philadelphia": {
+    "wikidataId": "Q1345",
+    "wikipediaTitle": "Philadelphia",
+    "canonicalTitle": "Philadelphia",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-philadelphia",
+        "nodeTitle": "Philadelphia"
+      }
+    ]
+  },
+  "location-konigsberg": {
+    "wikidataId": "Q4120832",
+    "wikipediaTitle": "Königsberg",
+    "canonicalTitle": "Königsberg",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-konigsberg",
+        "nodeTitle": "Königsberg"
+      }
+    ]
+  },
+  "location-st-petersburg": {
+    "wikidataId": "Q656",
+    "wikipediaTitle": "Saint_Petersburg",
+    "canonicalTitle": "St. Petersburg",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-st-petersburg",
+        "nodeTitle": "St. Petersburg"
+      }
+    ]
+  },
+  "location-milan": {
+    "wikidataId": "Q490",
+    "wikipediaTitle": "Milan",
+    "canonicalTitle": "Milan",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-milan",
+        "nodeTitle": "Milan"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-milan",
+        "nodeTitle": "Milan"
+      }
+    ]
+  },
+  "location-univ-edinburgh": {
+    "wikidataId": "Q160302",
+    "wikipediaTitle": "University_of_Edinburgh",
+    "canonicalTitle": "University of Edinburgh",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-univ-edinburgh",
+        "nodeTitle": "University of Edinburgh"
+      }
+    ]
+  },
+  "location-univ-glasgow": {
+    "wikidataId": "Q192775",
+    "wikipediaTitle": "University_of_Glasgow",
+    "canonicalTitle": "University of Glasgow",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-univ-glasgow",
+        "nodeTitle": "University of Glasgow"
+      }
+    ]
+  },
+  "location-univ-halle": {
+    "wikidataId": null,
+    "wikipediaTitle": "University_of_Halle",
+    "canonicalTitle": "University of Halle",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-univ-halle",
+        "nodeTitle": "University of Halle"
+      }
+    ]
+  },
+  "location-univ-konigsberg": {
+    "wikidataId": "Q672420",
+    "wikipediaTitle": "University_of_Königsberg",
+    "canonicalTitle": "University of Königsberg",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-univ-konigsberg",
+        "nodeTitle": "University of Königsberg"
+      }
+    ]
+  },
+  "location-sorbonne": {
+    "wikidataId": "Q209842",
+    "wikipediaTitle": "University_of_Paris",
+    "canonicalTitle": "Sorbonne / University of Paris",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-sorbonne",
+        "nodeTitle": "Sorbonne / University of Paris"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-sorbonne",
+        "nodeTitle": "University of Paris (Sorbonne)"
+      }
+    ]
+  },
+  "location-academie-francaise": {
+    "wikidataId": "Q161806",
+    "wikipediaTitle": "Académie_Française",
+    "canonicalTitle": "Académie française",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-academie-francaise",
+        "nodeTitle": "Académie française"
+      }
+    ]
+  },
+  "location-academie-sciences": {
+    "wikidataId": "Q188771",
+    "wikipediaTitle": "French_Academy_of_Sciences",
+    "canonicalTitle": "Académie des Sciences",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-academie-sciences",
+        "nodeTitle": "Académie des Sciences"
+      }
+    ]
+  },
+  "location-berlin-academy": {
+    "wikidataId": "Q329464",
+    "wikipediaTitle": "Prussian_Academy_of_Sciences",
+    "canonicalTitle": "Berlin Academy",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-berlin-academy",
+        "nodeTitle": "Berlin Academy"
+      }
+    ]
+  },
+  "location-royal-society": {
+    "wikidataId": "Q123885",
+    "wikipediaTitle": "Royal_Society",
+    "canonicalTitle": "Royal Society of London",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-royal-society",
+        "nodeTitle": "Royal Society of London"
+      }
+    ]
+  },
+  "location-amer-phil-society": {
+    "wikidataId": "Q466089",
+    "wikipediaTitle": "American_Philosophical_Society",
+    "canonicalTitle": "American Philosophical Society",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-amer-phil-society",
+        "nodeTitle": "American Philosophical Society"
+      }
+    ]
+  },
+  "location-academie-bordeaux": {
+    "wikidataId": "Q17033033",
+    "wikipediaTitle": "Académie_de_Bordeaux",
+    "canonicalTitle": "Académie de Bordeaux",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-academie-bordeaux",
+        "nodeTitle": "Académie de Bordeaux"
+      }
+    ]
+  },
+  "location-salon-geoffrin": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Salon of Madame Geoffrin",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-salon-geoffrin",
+        "nodeTitle": "Salon of Madame Geoffrin"
+      }
+    ]
+  },
+  "location-salon-holbach": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Salon of Baron d'Holbach",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-salon-holbach",
+        "nodeTitle": "Salon of Baron d'Holbach"
+      }
+    ]
+  },
+  "location-salon-lespinasse": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Salon of Julie de Lespinasse",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-salon-lespinasse",
+        "nodeTitle": "Salon of Julie de Lespinasse"
+      }
+    ]
+  },
+  "location-salon-deffand": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Salon of Madame du Deffand",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-salon-deffand",
+        "nodeTitle": "Salon of Madame du Deffand"
+      }
+    ]
+  },
+  "location-salon-helvetius": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Salon of Madame Helvétius",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-salon-helvetius",
+        "nodeTitle": "Salon of Madame Helvétius"
+      }
+    ]
+  },
+  "location-sans-souci": {
+    "wikidataId": "Q151330",
+    "wikipediaTitle": "Sanssouci",
+    "canonicalTitle": "Sans-Souci Palace",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-sans-souci",
+        "nodeTitle": "Sans-Souci Palace"
+      }
+    ]
+  },
+  "location-versailles": {
+    "wikidataId": "Q2946",
+    "wikipediaTitle": "Palace_of_Versailles",
+    "canonicalTitle": "Versailles",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-versailles",
+        "nodeTitle": "Versailles"
+      }
+    ]
+  },
+  "location-ferney": {
+    "wikidataId": "Q233733",
+    "wikipediaTitle": "Ferney-Voltaire",
+    "canonicalTitle": "Ferney",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-ferney",
+        "nodeTitle": "Ferney"
+      }
+    ]
+  },
+  "location-cirey": {
+    "wikidataId": "Q2240551",
+    "wikipediaTitle": "Château_de_Cirey",
+    "canonicalTitle": "Cirey",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-cirey",
+        "nodeTitle": "Cirey"
+      }
+    ]
+  },
+  "location-winter-palace": {
+    "wikidataId": "Q182147",
+    "wikipediaTitle": "Winter_Palace",
+    "canonicalTitle": "Winter Palace",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-winter-palace",
+        "nodeTitle": "Winter Palace"
+      }
+    ]
+  },
+  "location-amsterdam-publishing": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Amsterdam Publishing Houses",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-amsterdam-publishing",
+        "nodeTitle": "Amsterdam Publishing Houses"
+      }
+    ]
+  },
+  "location-london-publishing": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "London Publishing (Fleet Street)",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-london-publishing",
+        "nodeTitle": "London Publishing (Fleet Street)"
+      }
+    ]
+  },
+  "location-geneva-publishing": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Geneva Publishing",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-geneva-publishing",
+        "nodeTitle": "Geneva Publishing"
+      }
+    ]
+  },
+  "location-select-society": {
+    "wikidataId": null,
+    "wikipediaTitle": "Select_Society",
+    "canonicalTitle": "Select Society",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-select-society",
+        "nodeTitle": "Select Society"
+      }
+    ]
+  },
+  "location-poker-club": {
+    "wikidataId": "Q7757623",
+    "wikipediaTitle": "The_Poker_Club",
+    "canonicalTitle": "Poker Club",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-poker-club",
+        "nodeTitle": "Poker Club"
+      }
+    ]
+  },
+  "location-rankenian-club": {
+    "wikidataId": null,
+    "wikipediaTitle": "Rankenian_Club",
+    "canonicalTitle": "Rankenian Club",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-rankenian-club",
+        "nodeTitle": "Rankenian Club"
+      }
+    ]
+  },
+  "location-cafe-procope": {
+    "wikidataId": "Q751293",
+    "wikipediaTitle": "Café_Procope",
+    "canonicalTitle": "Café Procope",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-cafe-procope",
+        "nodeTitle": "Café Procope"
+      }
+    ]
+  },
+  "entity-encyclopedie-project": {
+    "wikidataId": "Q447",
+    "wikipediaTitle": "Encyclopédie",
+    "canonicalTitle": "Encyclopédie Project",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-encyclopedie-project",
+        "nodeTitle": "Encyclopédie Project"
+      }
+    ]
+  },
+  "entity-philosophes": {
+    "wikidataId": "Q1672919",
+    "wikipediaTitle": "Philosophes",
+    "canonicalTitle": "French Philosophes",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-philosophes",
+        "nodeTitle": "French Philosophes"
+      }
+    ]
+  },
+  "entity-scottish-enlightenment": {
+    "wikidataId": "Q1063038",
+    "wikipediaTitle": "Scottish_Enlightenment",
+    "canonicalTitle": "Scottish Enlightenment",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-scottish-enlightenment",
+        "nodeTitle": "Scottish Enlightenment"
+      }
+    ]
+  },
+  "entity-aufklarung": {
+    "wikidataId": "Q136274201",
+    "wikipediaTitle": "Aufklärung",
+    "canonicalTitle": "German Aufklärung",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-aufklarung",
+        "nodeTitle": "German Aufklärung"
+      }
+    ]
+  },
+  "entity-haskalah": {
+    "wikidataId": "Q472670",
+    "wikipediaTitle": "Haskalah",
+    "canonicalTitle": "Haskalah (Jewish Enlightenment)",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-haskalah",
+        "nodeTitle": "Haskalah (Jewish Enlightenment)"
+      }
+    ]
+  },
+  "entity-physiocracy": {
+    "wikidataId": "Q183244",
+    "wikipediaTitle": "Physiocracy",
+    "canonicalTitle": "Physiocracy",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-physiocracy",
+        "nodeTitle": "Physiocracy"
+      }
+    ]
+  },
+  "entity-british-empiricism": {
+    "wikidataId": "Q83368",
+    "wikipediaTitle": "Empiricism",
+    "canonicalTitle": "British Empiricism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-british-empiricism",
+        "nodeTitle": "British Empiricism"
+      }
+    ]
+  },
+  "entity-continental-rationalism": {
+    "wikidataId": "Q483024",
+    "wikipediaTitle": "Rationalism",
+    "canonicalTitle": "Continental Rationalism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-continental-rationalism",
+        "nodeTitle": "Continental Rationalism"
+      }
+    ]
+  },
+  "entity-utilitarianism": {
+    "wikidataId": "Q160590",
+    "wikipediaTitle": "Utilitarianism",
+    "canonicalTitle": "Utilitarianism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-utilitarianism",
+        "nodeTitle": "Utilitarianism"
+      }
+    ]
+  },
+  "entity-common-sense-philosophy": {
+    "wikidataId": "Q1116026",
+    "wikipediaTitle": "Scottish_common_sense_realism",
+    "canonicalTitle": "Common Sense Philosophy",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-common-sense-philosophy",
+        "nodeTitle": "Common Sense Philosophy"
+      }
+    ]
+  },
+  "entity-radical-enlightenment": {
+    "wikidataId": null,
+    "wikipediaTitle": "Radical_Enlightenment",
+    "canonicalTitle": "Radical Enlightenment",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-radical-enlightenment",
+        "nodeTitle": "Radical Enlightenment"
+      }
+    ]
+  },
+  "entity-academie-francaise": {
+    "wikidataId": "Q161806",
+    "wikipediaTitle": "Académie_Française",
+    "canonicalTitle": "Académie française (Institution)",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-academie-francaise",
+        "nodeTitle": "Académie française (Institution)"
+      }
+    ]
+  },
+  "entity-academie-sciences": {
+    "wikidataId": "Q188771",
+    "wikipediaTitle": "French_Academy_of_Sciences",
+    "canonicalTitle": "Académie des Sciences (Institution)",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-academie-sciences",
+        "nodeTitle": "Académie des Sciences (Institution)"
+      }
+    ]
+  },
+  "entity-berlin-academy": {
+    "wikidataId": "Q329464",
+    "wikipediaTitle": "Prussian_Academy_of_Sciences",
+    "canonicalTitle": "Berlin Academy (Institution)",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-berlin-academy",
+        "nodeTitle": "Berlin Academy (Institution)"
+      }
+    ]
+  },
+  "entity-royal-society": {
+    "wikidataId": "Q123885",
+    "wikipediaTitle": "Royal_Society",
+    "canonicalTitle": "Royal Society of London (Institution)",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-royal-society",
+        "nodeTitle": "Royal Society of London (Institution)"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-royal-society",
+        "nodeTitle": "Royal Society of London"
+      },
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "entity-royal-society",
+        "nodeTitle": "Royal Society"
+      }
+    ]
+  },
+  "entity-amer-phil-society": {
+    "wikidataId": "Q466089",
+    "wikipediaTitle": "American_Philosophical_Society",
+    "canonicalTitle": "American Philosophical Society (Institution)",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-amer-phil-society",
+        "nodeTitle": "American Philosophical Society (Institution)"
+      }
+    ]
+  },
+  "entity-holbach-circle": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "D'Holbach's Circle",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-holbach-circle",
+        "nodeTitle": "D'Holbach's Circle"
+      }
+    ]
+  },
+  "entity-edinburgh-literati": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Edinburgh Literati",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-edinburgh-literati",
+        "nodeTitle": "Edinburgh Literati"
+      }
+    ]
+  },
+  "entity-american-founders": {
+    "wikidataId": "Q186539",
+    "wikipediaTitle": "Founding_Fathers_of_the_United_States",
+    "canonicalTitle": "American Founders",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-american-founders",
+        "nodeTitle": "American Founders"
+      }
+    ]
+  },
+  "entity-journal-savants": {
+    "wikidataId": "Q927072",
+    "wikipediaTitle": "Journal_des_sçavans",
+    "canonicalTitle": "Journal des savants",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-journal-savants",
+        "nodeTitle": "Journal des savants"
+      }
+    ]
+  },
+  "entity-ephemerides": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Éphémérides du citoyen",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-ephemerides",
+        "nodeTitle": "Éphémérides du citoyen"
+      }
+    ]
+  },
+  "entity-berlinische-monatsschrift": {
+    "wikidataId": "Q821914",
+    "wikipediaTitle": "Berlinische_Monatsschrift",
+    "canonicalTitle": "Berlinische Monatsschrift",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-berlinische-monatsschrift",
+        "nodeTitle": "Berlinische Monatsschrift"
+      }
+    ]
+  },
+  "entity-religious-toleration": {
+    "wikidataId": null,
+    "wikipediaTitle": "Religious_toleration",
+    "canonicalTitle": "Religious Toleration Movement",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-religious-toleration",
+        "nodeTitle": "Religious Toleration Movement"
+      }
+    ]
+  },
+  "entity-criminal-justice-reform": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Criminal Justice Reform Movement",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-criminal-justice-reform",
+        "nodeTitle": "Criminal Justice Reform Movement"
+      }
+    ]
+  },
+  "entity-enlightened-despotism": {
+    "wikidataId": "Q219934",
+    "wikipediaTitle": "Enlightened_absolutism",
+    "canonicalTitle": "Enlightened Despotism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-enlightened-despotism",
+        "nodeTitle": "Enlightened Despotism"
+      }
+    ]
+  },
+  "entity-deism": {
+    "wikidataId": "Q620629",
+    "wikipediaTitle": "Deism",
+    "canonicalTitle": "Deism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-deism",
+        "nodeTitle": "Deism"
+      }
+    ]
+  },
+  "entity-enlightenment-atheism": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Enlightenment Atheism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-enlightenment-atheism",
+        "nodeTitle": "Enlightenment Atheism"
+      }
+    ]
+  },
+  "entity-moderate-enlightenment": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Moderate Enlightenment",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-moderate-enlightenment",
+        "nodeTitle": "Moderate Enlightenment"
+      }
+    ]
+  },
+  "entity-united-states": {
+    "wikidataId": "Q30",
+    "wikipediaTitle": "United_States",
+    "canonicalTitle": "United States of America",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-united-states",
+        "nodeTitle": "United States of America"
+      }
+    ]
+  },
+  "entity-french-revolution": {
+    "wikidataId": "Q6534",
+    "wikipediaTitle": "French_Revolution",
+    "canonicalTitle": "French Revolution",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-french-revolution",
+        "nodeTitle": "French Revolution"
+      }
+    ]
+  },
+  "person-angelo-poliziano": {
+    "wikidataId": "Q166689",
+    "wikipediaTitle": "Poliziano",
+    "canonicalTitle": "Angelo Poliziano",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-angelo-poliziano",
+        "nodeTitle": "Angelo Poliziano"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-angelo-poliziano",
+        "nodeTitle": "Angelo Poliziano (Politian)"
+      }
+    ]
+  },
+  "person-cristoforo-landino": {
+    "wikidataId": "Q560436",
+    "wikipediaTitle": "Cristoforo_Landino",
+    "canonicalTitle": "Cristoforo Landino",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-cristoforo-landino",
+        "nodeTitle": "Cristoforo Landino"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-cristoforo-landino",
+        "nodeTitle": "Cristoforo Landino"
+      }
+    ]
+  },
+  "person-giovanni-cavalcanti": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Giovanni Cavalcanti",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-giovanni-cavalcanti",
+        "nodeTitle": "Giovanni Cavalcanti"
+      }
+    ]
+  },
+  "person-francesco-cattani-da-diacceto": {
+    "wikidataId": "Q1440694",
+    "wikipediaTitle": "Francesco_Cattani_da_Diacceto",
+    "canonicalTitle": "Francesco Cattani da Diacceto",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-francesco-cattani-da-diacceto",
+        "nodeTitle": "Francesco Cattani da Diacceto"
+      }
+    ]
+  },
+  "person-giovanni-corsi": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Giovanni Corsi",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-giovanni-corsi",
+        "nodeTitle": "Giovanni Corsi"
+      }
+    ]
+  },
+  "person-girolamo-benivieni": {
+    "wikidataId": "Q3765911",
+    "wikipediaTitle": "Girolamo_Benivieni",
+    "canonicalTitle": "Girolamo Benivieni",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-girolamo-benivieni",
+        "nodeTitle": "Girolamo Benivieni"
+      }
+    ]
+  },
+  "person-piero-di-cosimo-de-medici": {
+    "wikidataId": "Q313587",
+    "wikipediaTitle": "Piero_di_Cosimo_de'_Medici",
+    "canonicalTitle": "Piero di Cosimo de' Medici",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-piero-di-cosimo-de-medici",
+        "nodeTitle": "Piero di Cosimo de' Medici"
+      }
+    ]
+  },
+  "person-giuliano-de-medici": {
+    "wikidataId": "Q316650",
+    "wikipediaTitle": "Giuliano_de'_Medici",
+    "canonicalTitle": "Giuliano de' Medici",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-giuliano-de-medici",
+        "nodeTitle": "Giuliano de' Medici"
+      }
+    ]
+  },
+  "person-giovanni-de-medici-pope-leo-x": {
+    "wikidataId": "Q81994",
+    "wikipediaTitle": "Pope_Leo_X",
+    "canonicalTitle": "Giovanni de' Medici (Pope Leo X)",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-giovanni-de-medici-pope-leo-x",
+        "nodeTitle": "Giovanni de' Medici (Pope Leo X)"
+      }
+    ]
+  },
+  "person-piero-de-medici-the-unfortunate": {
+    "wikidataId": "Q310405",
+    "wikipediaTitle": "Piero_di_Lorenzo_de'_Medici",
+    "canonicalTitle": "Piero de' Medici",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-piero-de-medici-the-unfortunate",
+        "nodeTitle": "Piero de' Medici"
+      }
+    ]
+  },
+  "person-gemistus-pletho": {
+    "wikidataId": "Q310318",
+    "wikipediaTitle": "Gemistus_Pletho",
+    "canonicalTitle": "Gemistus Pletho",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-gemistus-pletho",
+        "nodeTitle": "Gemistus Pletho"
+      }
+    ]
+  },
+  "person-bessarion": {
+    "wikidataId": "Q352619",
+    "wikipediaTitle": "Basilios_Bessarion",
+    "canonicalTitle": "Cardinal Bessarion",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-bessarion",
+        "nodeTitle": "Cardinal Bessarion"
+      }
+    ]
+  },
+  "person-john-argyropoulos": {
+    "wikidataId": "Q720932",
+    "wikipediaTitle": "John_Argyropoulos",
+    "canonicalTitle": "John Argyropoulos",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-john-argyropoulos",
+        "nodeTitle": "John Argyropoulos"
+      }
+    ]
+  },
+  "person-manuel-chrysoloras": {
+    "wikidataId": "Q380417",
+    "wikipediaTitle": "Manuel_Chrysoloras",
+    "canonicalTitle": "Manuel Chrysoloras",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-manuel-chrysoloras",
+        "nodeTitle": "Manuel Chrysoloras"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-manuel-chrysoloras",
+        "nodeTitle": "Manuel Chrysoloras"
+      }
+    ]
+  },
+  "person-demetrios-chalkokondyles": {
+    "wikidataId": "Q561458",
+    "wikipediaTitle": "Demetrios_Chalkokondyles",
+    "canonicalTitle": "Demetrios Chalkokondyles",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-demetrios-chalkokondyles",
+        "nodeTitle": "Demetrios Chalkokondyles"
+      }
+    ]
+  },
+  "person-hermes-trismegistus": {
+    "wikidataId": "Q502592",
+    "wikipediaTitle": "Hermes_Trismegistus",
+    "canonicalTitle": "Hermes Trismegistus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-hermes-trismegistus",
+        "nodeTitle": "Hermes Trismegistus"
+      }
+    ]
+  },
+  "person-plato": {
+    "wikidataId": "Q859",
+    "wikipediaTitle": "Plato",
+    "canonicalTitle": "Plato",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-plato",
+        "nodeTitle": "Plato"
+      }
+    ]
+  },
+  "person-plotinus": {
+    "wikidataId": "Q44032",
+    "wikipediaTitle": "Plotinus",
+    "canonicalTitle": "Plotinus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-plotinus",
+        "nodeTitle": "Plotinus"
+      }
+    ]
+  },
+  "person-proclus": {
+    "wikidataId": "Q188847",
+    "wikipediaTitle": "Proclus",
+    "canonicalTitle": "Proclus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-proclus",
+        "nodeTitle": "Proclus"
+      }
+    ]
+  },
+  "person-iamblichus": {
+    "wikidataId": "Q42247",
+    "wikipediaTitle": "Iamblichus",
+    "canonicalTitle": "Iamblichus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-iamblichus",
+        "nodeTitle": "Iamblichus"
+      }
+    ]
+  },
+  "person-pseudo-dionysius": {
+    "wikidataId": "Q179742",
+    "wikipediaTitle": "Pseudo-Dionysius_the_Areopagite",
+    "canonicalTitle": "Pseudo-Dionysius the Areopagite",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-pseudo-dionysius",
+        "nodeTitle": "Pseudo-Dionysius the Areopagite"
+      }
+    ]
+  },
+  "person-orpheus": {
+    "wikidataId": "Q43395",
+    "wikipediaTitle": "Orpheus",
+    "canonicalTitle": "Orpheus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-orpheus",
+        "nodeTitle": "Orpheus"
+      }
+    ]
+  },
+  "person-zoroaster": {
+    "wikidataId": "Q4848",
+    "wikipediaTitle": "Zoroaster",
+    "canonicalTitle": "Zoroaster",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-zoroaster",
+        "nodeTitle": "Zoroaster"
+      }
+    ]
+  },
+  "person-pythagoras": {
+    "wikidataId": "Q10261",
+    "wikipediaTitle": "Pythagoras",
+    "canonicalTitle": "Pythagoras",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-pythagoras",
+        "nodeTitle": "Pythagoras"
+      }
+    ]
+  },
+  "object-corpus-hermeticum": {
+    "wikidataId": "Q499851",
+    "wikipediaTitle": "Corpus_Hermeticum",
+    "canonicalTitle": "Corpus Hermeticum",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-corpus-hermeticum",
+        "nodeTitle": "Corpus Hermeticum"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-corpus-hermeticum",
+        "nodeTitle": "Corpus Hermeticum Translation"
+      }
+    ]
+  },
+  "object-platonis-opera-omnia": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Platonis Opera Omnia (Complete Works of Plato)",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-platonis-opera-omnia",
+        "nodeTitle": "Platonis Opera Omnia (Complete Works of Plato)"
+      }
+    ]
+  },
+  "object-de-amore": {
+    "wikidataId": "Q5154756",
+    "wikipediaTitle": "Commentary_on_Plato%27s_Symposium_on_Love",
+    "canonicalTitle": "De Amore (Commentary on Plato's Symposium)",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-de-amore",
+        "nodeTitle": "De Amore (Commentary on Plato's Symposium)"
+      }
+    ]
+  },
+  "object-oration-dignity-of-man": {
+    "wikidataId": "Q944027",
+    "wikipediaTitle": "Oration_on_the_Dignity_of_Man",
+    "canonicalTitle": "Oration on the Dignity of Man",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-oration-dignity-of-man",
+        "nodeTitle": "Oration on the Dignity of Man"
+      }
+    ]
+  },
+  "object-heptaplus": {
+    "wikidataId": "Q5732857",
+    "wikipediaTitle": "Heptaplus",
+    "canonicalTitle": "Heptaplus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-heptaplus",
+        "nodeTitle": "Heptaplus"
+      }
+    ]
+  },
+  "object-enneads": {
+    "wikidataId": "Q606879",
+    "wikipediaTitle": "Enneads",
+    "canonicalTitle": "Enneads",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-enneads",
+        "nodeTitle": "Enneads"
+      }
+    ]
+  },
+  "object-asclepius": {
+    "wikidataId": "Q787046",
+    "wikipediaTitle": "Asclepius_(treatise)",
+    "canonicalTitle": "Asclepius",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-asclepius",
+        "nodeTitle": "Asclepius"
+      }
+    ]
+  },
+  "object-pimander": {
+    "wikidataId": "Q921618",
+    "wikipediaTitle": "Poimandres",
+    "canonicalTitle": "Pimander",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-pimander",
+        "nodeTitle": "Pimander"
+      }
+    ]
+  },
+  "object-comento-sopra-divina-commedia": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Comento sopra la Divina Commedia",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-comento-sopra-divina-commedia",
+        "nodeTitle": "Comento sopra la Divina Commedia"
+      }
+    ]
+  },
+  "object-orphic-hymns": {
+    "wikidataId": "Q1626866",
+    "wikipediaTitle": "Orphic_Hymns",
+    "canonicalTitle": "Orphic Hymns",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-orphic-hymns",
+        "nodeTitle": "Orphic Hymns"
+      }
+    ]
+  },
+  "person-cornelius-agrippa": {
+    "wikidataId": "Q315466",
+    "wikipediaTitle": "Heinrich_Cornelius_Agrippa",
+    "canonicalTitle": "Heinrich Cornelius Agrippa",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-cornelius-agrippa",
+        "nodeTitle": "Heinrich Cornelius Agrippa"
+      }
+    ]
+  },
+  "person-giordano-bruno": {
+    "wikidataId": "Q36330",
+    "wikipediaTitle": "Giordano_Bruno",
+    "canonicalTitle": "Giordano Bruno",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-giordano-bruno",
+        "nodeTitle": "Giordano Bruno"
+      }
+    ]
+  },
+  "person-francesco-patrizi": {
+    "wikidataId": "Q364945",
+    "wikipediaTitle": "Francesco_Patrizi_(philosopher)",
+    "canonicalTitle": "Francesco Patrizi",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-francesco-patrizi",
+        "nodeTitle": "Francesco Patrizi"
+      }
+    ]
+  },
+  "person-girolamo-savonarola": {
+    "wikidataId": "Q45027",
+    "wikipediaTitle": "Girolamo_Savonarola",
+    "canonicalTitle": "Girolamo Savonarola",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-girolamo-savonarola",
+        "nodeTitle": "Girolamo Savonarola"
+      }
+    ]
+  },
+  "location-villa-careggi": {
+    "wikidataId": "Q579476",
+    "wikipediaTitle": "Villa_Medici_at_Careggi",
+    "canonicalTitle": "Villa Medici at Careggi",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "location-villa-careggi",
+        "nodeTitle": "Villa Medici at Careggi"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-villa-careggi",
+        "nodeTitle": "Medici Villa at Careggi"
+      }
+    ]
+  },
+  "entity-platonic-academy": {
+    "wikidataId": "Q1210631",
+    "wikipediaTitle": "Platonic_Academy_(Florence)",
+    "canonicalTitle": "Platonic Academy of Florence",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "entity-platonic-academy",
+        "nodeTitle": "Platonic Academy of Florence"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-platonic-academy",
+        "nodeTitle": "Florentine Platonic Academy"
+      }
+    ]
+  },
+  "location-council-of-florence": {
+    "wikidataId": "Q83017",
+    "wikipediaTitle": "Council_of_Florence",
+    "canonicalTitle": "Council of Florence",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "location-council-of-florence",
+        "nodeTitle": "Council of Florence"
+      }
+    ]
+  },
+  "person-martin-luther": {
+    "wikidataId": "Q9554",
+    "wikipediaTitle": "Martin_Luther",
+    "canonicalTitle": "Martin Luther",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-martin-luther",
+        "nodeTitle": "Martin Luther"
+      }
+    ]
+  },
+  "person-john-calvin": {
+    "wikidataId": "Q37577",
+    "wikipediaTitle": "John_Calvin",
+    "canonicalTitle": "John Calvin",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-calvin",
+        "nodeTitle": "John Calvin"
+      }
+    ]
+  },
+  "person-huldrych-zwingli": {
+    "wikidataId": "Q123034",
+    "wikipediaTitle": "Huldrych_Zwingli",
+    "canonicalTitle": "Huldrych Zwingli",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-huldrych-zwingli",
+        "nodeTitle": "Huldrych Zwingli"
+      }
+    ]
+  },
+  "person-erasmus-of-rotterdam": {
+    "wikidataId": "Q43499",
+    "wikipediaTitle": "Erasmus",
+    "canonicalTitle": "Erasmus of Rotterdam",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-erasmus-of-rotterdam",
+        "nodeTitle": "Erasmus of Rotterdam"
+      }
+    ]
+  },
+  "person-william-tyndale": {
+    "wikidataId": "Q219639",
+    "wikipediaTitle": "William_Tyndale",
+    "canonicalTitle": "William Tyndale",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-william-tyndale",
+        "nodeTitle": "William Tyndale"
+      }
+    ]
+  },
+  "person-thomas-cranmer": {
+    "wikidataId": "Q199894",
+    "wikipediaTitle": "Thomas_Cranmer",
+    "canonicalTitle": "Thomas Cranmer",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-thomas-cranmer",
+        "nodeTitle": "Thomas Cranmer"
+      }
+    ]
+  },
+  "person-philip-melanchthon": {
+    "wikidataId": "Q76325",
+    "wikipediaTitle": "Philip_Melanchthon",
+    "canonicalTitle": "Philip Melanchthon",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-philip-melanchthon",
+        "nodeTitle": "Philip Melanchthon"
+      }
+    ]
+  },
+  "person-johannes-bugenhagen": {
+    "wikidataId": "Q77260",
+    "wikipediaTitle": "Johannes_Bugenhagen",
+    "canonicalTitle": "Johannes Bugenhagen",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-johannes-bugenhagen",
+        "nodeTitle": "Johannes Bugenhagen"
+      }
+    ]
+  },
+  "person-justus-jonas": {
+    "wikidataId": "Q38294",
+    "wikipediaTitle": "Justus_Jonas",
+    "canonicalTitle": "Justus Jonas",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-justus-jonas",
+        "nodeTitle": "Justus Jonas"
+      }
+    ]
+  },
+  "person-caspar-cruciger": {
+    "wikidataId": null,
+    "wikipediaTitle": "Caspar_Cruciger_the_Elder",
+    "canonicalTitle": "Caspar Cruciger the Elder",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-caspar-cruciger",
+        "nodeTitle": "Caspar Cruciger the Elder"
+      }
+    ]
+  },
+  "person-georg-spalatin": {
+    "wikidataId": null,
+    "wikipediaTitle": "Georg_Spalatin",
+    "canonicalTitle": "Georg Spalatin",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-georg-spalatin",
+        "nodeTitle": "Georg Spalatin"
+      }
+    ]
+  },
+  "person-andreas-karlstadt": {
+    "wikidataId": "Q60589",
+    "wikipediaTitle": "Andreas_Karlstadt",
+    "canonicalTitle": "Andreas Karlstadt",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-andreas-karlstadt",
+        "nodeTitle": "Andreas Karlstadt"
+      }
+    ]
+  },
+  "person-katharina-von-bora": {
+    "wikidataId": "Q77239",
+    "wikipediaTitle": "Katharina_von_Bora",
+    "canonicalTitle": "Katharina von Bora",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-katharina-von-bora",
+        "nodeTitle": "Katharina von Bora"
+      }
+    ]
+  },
+  "person-lucas-cranach": {
+    "wikidataId": "Q191748",
+    "wikipediaTitle": "Lucas_Cranach_the_Elder",
+    "canonicalTitle": "Lucas Cranach the Elder",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-lucas-cranach",
+        "nodeTitle": "Lucas Cranach the Elder"
+      }
+    ]
+  },
+  "person-johann-agricola": {
+    "wikidataId": null,
+    "wikipediaTitle": "Johann_Agricola",
+    "canonicalTitle": "Johann Agricola",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-johann-agricola",
+        "nodeTitle": "Johann Agricola"
+      }
+    ]
+  },
+  "person-thomas-muntzer": {
+    "wikidataId": "Q153981",
+    "wikipediaTitle": "Thomas_Müntzer",
+    "canonicalTitle": "Thomas Müntzer",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-thomas-muntzer",
+        "nodeTitle": "Thomas Müntzer"
+      }
+    ]
+  },
+  "person-heinrich-bullinger": {
+    "wikidataId": "Q123839",
+    "wikipediaTitle": "Heinrich_Bullinger",
+    "canonicalTitle": "Heinrich Bullinger",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-heinrich-bullinger",
+        "nodeTitle": "Heinrich Bullinger"
+      }
+    ]
+  },
+  "person-leo-jud": {
+    "wikidataId": "Q1345599",
+    "wikipediaTitle": "Leo_Jud",
+    "canonicalTitle": "Leo Jud",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-leo-jud",
+        "nodeTitle": "Leo Jud"
+      }
+    ]
+  },
+  "person-johannes-oecolampadius": {
+    "wikidataId": "Q123450",
+    "wikipediaTitle": "Johannes_Oecolampadius",
+    "canonicalTitle": "Johannes Oecolampadius",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-johannes-oecolampadius",
+        "nodeTitle": "Johannes Oecolampadius"
+      }
+    ]
+  },
+  "person-rudolf-gwalther": {
+    "wikidataId": "Q120138",
+    "wikipediaTitle": "Rudolf_Gwalther",
+    "canonicalTitle": "Rudolf Gwalther",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-rudolf-gwalther",
+        "nodeTitle": "Rudolf Gwalther"
+      }
+    ]
+  },
+  "person-kaspar-megander": {
+    "wikidataId": "Q1735077",
+    "wikipediaTitle": "Kaspar_Megander",
+    "canonicalTitle": "Kaspar Megander",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-kaspar-megander",
+        "nodeTitle": "Kaspar Megander"
+      }
+    ]
+  },
+  "person-guillaume-farel": {
+    "wikidataId": "Q435456",
+    "wikipediaTitle": "William_Farel",
+    "canonicalTitle": "Guillaume Farel",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-guillaume-farel",
+        "nodeTitle": "Guillaume Farel"
+      }
+    ]
+  },
+  "person-pierre-viret": {
+    "wikidataId": "Q123337",
+    "wikipediaTitle": "Pierre_Viret",
+    "canonicalTitle": "Pierre Viret",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-pierre-viret",
+        "nodeTitle": "Pierre Viret"
+      }
+    ]
+  },
+  "person-theodore-beza": {
+    "wikidataId": "Q314981",
+    "wikipediaTitle": "Theodore_Beza",
+    "canonicalTitle": "Theodore Beza",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-theodore-beza",
+        "nodeTitle": "Theodore Beza"
+      }
+    ]
+  },
+  "person-pierre-robert-olivetan": {
+    "wikidataId": null,
+    "wikipediaTitle": "Olivétan",
+    "canonicalTitle": "Pierre Robert Olivétan",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-pierre-robert-olivetan",
+        "nodeTitle": "Pierre Robert Olivétan"
+      }
+    ]
+  },
+  "person-martin-bucer": {
+    "wikidataId": "Q318622",
+    "wikipediaTitle": "Martin_Bucer",
+    "canonicalTitle": "Martin Bucer",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-martin-bucer",
+        "nodeTitle": "Martin Bucer"
+      }
+    ]
+  },
+  "person-wolfgang-capito": {
+    "wikidataId": "Q1368362",
+    "wikipediaTitle": "Wolfgang_Capito",
+    "canonicalTitle": "Wolfgang Capito",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-wolfgang-capito",
+        "nodeTitle": "Wolfgang Capito"
+      }
+    ]
+  },
+  "person-katharina-schutz-zell": {
+    "wikidataId": "Q118998",
+    "wikipediaTitle": "Katharina_Zell",
+    "canonicalTitle": "Katharina Schütz Zell",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-katharina-schutz-zell",
+        "nodeTitle": "Katharina Schütz Zell"
+      }
+    ]
+  },
+  "person-matthew-zell": {
+    "wikidataId": "Q85810",
+    "wikipediaTitle": "Matthew_Zell",
+    "canonicalTitle": "Matthew Zell",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-matthew-zell",
+        "nodeTitle": "Matthew Zell"
+      }
+    ]
+  },
+  "person-thomas-cromwell": {
+    "wikidataId": "Q294435",
+    "wikipediaTitle": "Thomas_Cromwell",
+    "canonicalTitle": "Thomas Cromwell",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-thomas-cromwell",
+        "nodeTitle": "Thomas Cromwell"
+      }
+    ]
+  },
+  "person-hugh-latimer": {
+    "wikidataId": "Q710046",
+    "wikipediaTitle": "Hugh_Latimer",
+    "canonicalTitle": "Hugh Latimer",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-hugh-latimer",
+        "nodeTitle": "Hugh Latimer"
+      }
+    ]
+  },
+  "person-nicholas-ridley": {
+    "wikidataId": "Q741030",
+    "wikipediaTitle": "Nicholas_Ridley_(martyr)",
+    "canonicalTitle": "Nicholas Ridley",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-nicholas-ridley",
+        "nodeTitle": "Nicholas Ridley"
+      }
+    ]
+  },
+  "person-miles-coverdale": {
+    "wikidataId": null,
+    "wikipediaTitle": "Miles_Coverdale",
+    "canonicalTitle": "Miles Coverdale",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-miles-coverdale",
+        "nodeTitle": "Miles Coverdale"
+      }
+    ]
+  },
+  "person-john-foxe": {
+    "wikidataId": "Q380961",
+    "wikipediaTitle": "John_Foxe",
+    "canonicalTitle": "John Foxe",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-foxe",
+        "nodeTitle": "John Foxe"
+      }
+    ]
+  },
+  "person-thomas-bilney": {
+    "wikidataId": "Q1756294",
+    "wikipediaTitle": "Thomas_Bilney",
+    "canonicalTitle": "Thomas Bilney",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-thomas-bilney",
+        "nodeTitle": "Thomas Bilney"
+      }
+    ]
+  },
+  "person-robert-barnes": {
+    "wikidataId": "Q1237075",
+    "wikipediaTitle": "Robert_Barnes_(martyr)",
+    "canonicalTitle": "Robert Barnes",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-robert-barnes",
+        "nodeTitle": "Robert Barnes"
+      }
+    ]
+  },
+  "person-john-frith": {
+    "wikidataId": "Q11772588",
+    "wikipediaTitle": "John_Frith",
+    "canonicalTitle": "John Frith",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-frith",
+        "nodeTitle": "John Frith"
+      }
+    ]
+  },
+  "person-john-hooper": {
+    "wikidataId": "Q647264",
+    "wikipediaTitle": "John_Hooper_(bishop)",
+    "canonicalTitle": "John Hooper",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-hooper",
+        "nodeTitle": "John Hooper"
+      }
+    ]
+  },
+  "person-matthew-parker": {
+    "wikidataId": "Q711332",
+    "wikipediaTitle": "Matthew_Parker",
+    "canonicalTitle": "Matthew Parker",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-matthew-parker",
+        "nodeTitle": "Matthew Parker"
+      }
+    ]
+  },
+  "person-john-colet": {
+    "wikidataId": "Q957527",
+    "wikipediaTitle": "John_Colet",
+    "canonicalTitle": "John Colet",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-colet",
+        "nodeTitle": "John Colet"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-john-colet",
+        "nodeTitle": "John Colet"
+      }
+    ]
+  },
+  "person-thomas-more": {
+    "wikidataId": "Q42544",
+    "wikipediaTitle": "Thomas_More",
+    "canonicalTitle": "Thomas More",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-thomas-more",
+        "nodeTitle": "Thomas More"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-thomas-more",
+        "nodeTitle": "Thomas More"
+      }
+    ]
+  },
+  "person-guillaume-briconnet": {
+    "wikidataId": "Q967700",
+    "wikipediaTitle": "Guillaume_Briçonnet_(cardinal)",
+    "canonicalTitle": "Guillaume Briçonnet",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-guillaume-briconnet",
+        "nodeTitle": "Guillaume Briçonnet"
+      }
+    ]
+  },
+  "person-conrad-grebel": {
+    "wikidataId": "Q115638",
+    "wikipediaTitle": "Conrad_Grebel",
+    "canonicalTitle": "Conrad Grebel",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-conrad-grebel",
+        "nodeTitle": "Conrad Grebel"
+      }
+    ]
+  },
+  "person-felix-manz": {
+    "wikidataId": "Q124188",
+    "wikipediaTitle": "Felix_Manz",
+    "canonicalTitle": "Felix Manz",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-felix-manz",
+        "nodeTitle": "Felix Manz"
+      }
+    ]
+  },
+  "person-george-blaurock": {
+    "wikidataId": "Q124175",
+    "wikipediaTitle": "George_Blaurock",
+    "canonicalTitle": "George Blaurock",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-george-blaurock",
+        "nodeTitle": "George Blaurock"
+      }
+    ]
+  },
+  "person-balthasar-hubmaier": {
+    "wikidataId": "Q62532",
+    "wikipediaTitle": "Balthasar_Hubmaier",
+    "canonicalTitle": "Balthasar Hubmaier",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-balthasar-hubmaier",
+        "nodeTitle": "Balthasar Hubmaier"
+      }
+    ]
+  },
+  "person-menno-simons": {
+    "wikidataId": "Q335171",
+    "wikipediaTitle": "Menno_Simons",
+    "canonicalTitle": "Menno Simons",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-menno-simons",
+        "nodeTitle": "Menno Simons"
+      }
+    ]
+  },
+  "person-michael-sattler": {
+    "wikidataId": "Q142309",
+    "wikipediaTitle": "Michael_Sattler",
+    "canonicalTitle": "Michael Sattler",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-michael-sattler",
+        "nodeTitle": "Michael Sattler"
+      }
+    ]
+  },
+  "person-marguerite-of-navarre": {
+    "wikidataId": "Q190058",
+    "wikipediaTitle": "Marguerite_de_Navarre",
+    "canonicalTitle": "Marguerite of Navarre",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-marguerite-of-navarre",
+        "nodeTitle": "Marguerite of Navarre"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-marguerite-of-navarre",
+        "nodeTitle": "Marguerite of Navarre"
+      }
+    ]
+  },
+  "person-clement-marot": {
+    "wikidataId": "Q108926",
+    "wikipediaTitle": "Clément_Marot",
+    "canonicalTitle": "Clément Marot",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-clement-marot",
+        "nodeTitle": "Clément Marot"
+      }
+    ]
+  },
+  "person-antoine-froment": {
+    "wikidataId": "Q388199",
+    "wikipediaTitle": "Antoine_Froment",
+    "canonicalTitle": "Antoine Froment",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-antoine-froment",
+        "nodeTitle": "Antoine Froment"
+      }
+    ]
+  },
+  "person-marie-dentiere": {
+    "wikidataId": "Q447170",
+    "wikipediaTitle": "Marie_Dentière",
+    "canonicalTitle": "Marie Dentière",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-marie-dentiere",
+        "nodeTitle": "Marie Dentière"
+      }
+    ]
+  },
+  "person-frederick-the-wise": {
+    "wikidataId": "Q77233",
+    "wikipediaTitle": "Frederick_III,_Elector_of_Saxony",
+    "canonicalTitle": "Frederick the Wise",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-frederick-the-wise",
+        "nodeTitle": "Frederick the Wise"
+      }
+    ]
+  },
+  "person-john-the-steadfast": {
+    "wikidataId": "Q61277",
+    "wikipediaTitle": "John,_Elector_of_Saxony",
+    "canonicalTitle": "John the Steadfast",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-the-steadfast",
+        "nodeTitle": "John the Steadfast"
+      }
+    ]
+  },
+  "person-john-frederick-i": {
+    "wikidataId": "Q506182",
+    "wikipediaTitle": "John_Frederick_I,_Elector_of_Saxony",
+    "canonicalTitle": "John Frederick I",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-frederick-i",
+        "nodeTitle": "John Frederick I"
+      }
+    ]
+  },
+  "person-philip-of-hesse": {
+    "wikidataId": "Q169319",
+    "wikipediaTitle": "Philip_I,_Landgrave_of_Hesse",
+    "canonicalTitle": "Philip of Hesse",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-philip-of-hesse",
+        "nodeTitle": "Philip of Hesse"
+      }
+    ]
+  },
+  "person-henry-viii": {
+    "wikidataId": "Q38370",
+    "wikipediaTitle": "Henry_VIII",
+    "canonicalTitle": "Henry VIII",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-henry-viii",
+        "nodeTitle": "Henry VIII"
+      }
+    ]
+  },
+  "person-charles-v": {
+    "wikidataId": "Q32500",
+    "wikipediaTitle": "Charles_V,_Holy_Roman_Emperor",
+    "canonicalTitle": "Charles V",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-charles-v",
+        "nodeTitle": "Charles V"
+      }
+    ]
+  },
+  "person-johann-eck": {
+    "wikidataId": "Q60298",
+    "wikipediaTitle": "Johann_Eck",
+    "canonicalTitle": "Johann Eck",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-johann-eck",
+        "nodeTitle": "Johann Eck"
+      }
+    ]
+  },
+  "person-cardinal-thomas-cajetan": {
+    "wikidataId": "Q435853",
+    "wikipediaTitle": "Thomas_Cajetan",
+    "canonicalTitle": "Cardinal Thomas Cajetan",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-cardinal-thomas-cajetan",
+        "nodeTitle": "Cardinal Thomas Cajetan"
+      }
+    ]
+  },
+  "person-john-knox": {
+    "wikidataId": "Q189937",
+    "wikipediaTitle": "John_Knox",
+    "canonicalTitle": "John Knox",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-knox",
+        "nodeTitle": "John Knox"
+      }
+    ]
+  },
+  "person-george-wishart": {
+    "wikidataId": "Q1367426",
+    "wikipediaTitle": "George_Wishart",
+    "canonicalTitle": "George Wishart",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-george-wishart",
+        "nodeTitle": "George Wishart"
+      }
+    ]
+  },
+  "person-patrick-hamilton": {
+    "wikidataId": "Q708980",
+    "wikipediaTitle": "Patrick_Hamilton_(martyr)",
+    "canonicalTitle": "Patrick Hamilton",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-patrick-hamilton",
+        "nodeTitle": "Patrick Hamilton"
+      }
+    ]
+  },
+  "object-ninety-five-theses": {
+    "wikidataId": "Q157506",
+    "wikipediaTitle": "Ninety-five_Theses",
+    "canonicalTitle": "Ninety-Five Theses",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-ninety-five-theses",
+        "nodeTitle": "Ninety-Five Theses"
+      }
+    ]
+  },
+  "object-address-christian-nobility": {
+    "wikidataId": "Q2492149",
+    "wikipediaTitle": "To_the_Christian_Nobility_of_the_German_Nation",
+    "canonicalTitle": "Address to the Christian Nobility of the German Nation",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-address-christian-nobility",
+        "nodeTitle": "Address to the Christian Nobility of the German Nation"
+      }
+    ]
+  },
+  "object-babylonian-captivity": {
+    "wikidataId": "Q282497",
+    "wikipediaTitle": "On_the_Babylonian_Captivity_of_the_Church",
+    "canonicalTitle": "On the Babylonian Captivity of the Church",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-babylonian-captivity",
+        "nodeTitle": "On the Babylonian Captivity of the Church"
+      }
+    ]
+  },
+  "object-freedom-christian": {
+    "wikidataId": "Q569330",
+    "wikipediaTitle": "On_the_Freedom_of_a_Christian",
+    "canonicalTitle": "On the Freedom of a Christian",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-freedom-christian",
+        "nodeTitle": "On the Freedom of a Christian"
+      }
+    ]
+  },
+  "object-bondage-of-will": {
+    "wikidataId": "Q1180745",
+    "wikipediaTitle": "On_the_Bondage_of_the_Will",
+    "canonicalTitle": "The Bondage of the Will",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-bondage-of-will",
+        "nodeTitle": "The Bondage of the Will"
+      }
+    ]
+  },
+  "object-free-will-erasmus": {
+    "wikidataId": "Q846306",
+    "wikipediaTitle": "De_libero_arbitrio_diatribe_sive_collatio",
+    "canonicalTitle": "On Free Will",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-free-will-erasmus",
+        "nodeTitle": "On Free Will"
+      }
+    ]
+  },
+  "object-institutes": {
+    "wikidataId": "Q371558",
+    "wikipediaTitle": "Institutes_of_the_Christian_Religion",
+    "canonicalTitle": "Institutes of the Christian Religion",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-institutes",
+        "nodeTitle": "Institutes of the Christian Religion"
+      }
+    ]
+  },
+  "object-sixty-seven-articles": {
+    "wikidataId": null,
+    "wikipediaTitle": "Sixty-seven_Articles",
+    "canonicalTitle": "Sixty-Seven Articles",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-sixty-seven-articles",
+        "nodeTitle": "Sixty-Seven Articles"
+      }
+    ]
+  },
+  "object-true-false-religion": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Commentary on True and False Religion",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-true-false-religion",
+        "nodeTitle": "Commentary on True and False Religion"
+      }
+    ]
+  },
+  "object-loci-communes": {
+    "wikidataId": null,
+    "wikipediaTitle": "Loci_Communes",
+    "canonicalTitle": "Loci Communes",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-loci-communes",
+        "nodeTitle": "Loci Communes"
+      }
+    ]
+  },
+  "object-obedience-christian-man": {
+    "wikidataId": "Q7754622",
+    "wikipediaTitle": "The_Obedience_of_a_Christian_Man",
+    "canonicalTitle": "The Obedience of a Christian Man",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-obedience-christian-man",
+        "nodeTitle": "The Obedience of a Christian Man"
+      }
+    ]
+  },
+  "object-luther-bible": {
+    "wikidataId": "Q1571095",
+    "wikipediaTitle": "Luther_Bible",
+    "canonicalTitle": "Luther's German Bible",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-luther-bible",
+        "nodeTitle": "Luther's German Bible"
+      }
+    ]
+  },
+  "object-novum-instrumentum": {
+    "wikidataId": "Q1526516",
+    "wikipediaTitle": "Novum_Instrumentum_omne",
+    "canonicalTitle": "Erasmus's Greek New Testament",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-novum-instrumentum",
+        "nodeTitle": "Erasmus's Greek New Testament"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-novum-instrumentum",
+        "nodeTitle": "Novum Instrumentum (Greek New Testament)"
+      }
+    ]
+  },
+  "object-tyndale-nt": {
+    "wikidataId": "Q2462802",
+    "wikipediaTitle": "Tyndale_Bible",
+    "canonicalTitle": "Tyndale's New Testament",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-tyndale-nt",
+        "nodeTitle": "Tyndale's New Testament"
+      }
+    ]
+  },
+  "object-tyndale-pentateuch": {
+    "wikidataId": "Q2462802",
+    "wikipediaTitle": "Tyndale_Bible",
+    "canonicalTitle": "Tyndale's Pentateuch",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-tyndale-pentateuch",
+        "nodeTitle": "Tyndale's Pentateuch"
+      }
+    ]
+  },
+  "object-coverdale-bible": {
+    "wikidataId": "Q1138103",
+    "wikipediaTitle": "Coverdale_Bible",
+    "canonicalTitle": "Coverdale Bible",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-coverdale-bible",
+        "nodeTitle": "Coverdale Bible"
+      }
+    ]
+  },
+  "object-great-bible": {
+    "wikidataId": "Q1544227",
+    "wikipediaTitle": "Great_Bible",
+    "canonicalTitle": "Great Bible",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-great-bible",
+        "nodeTitle": "Great Bible"
+      }
+    ]
+  },
+  "object-geneva-bible": {
+    "wikidataId": "Q1502139",
+    "wikipediaTitle": "Geneva_Bible",
+    "canonicalTitle": "Geneva Bible",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-geneva-bible",
+        "nodeTitle": "Geneva Bible"
+      }
+    ]
+  },
+  "object-olivetan-bible": {
+    "wikidataId": null,
+    "wikipediaTitle": "Olivétan_Bible",
+    "canonicalTitle": "Olivétan's French Bible",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-olivetan-bible",
+        "nodeTitle": "Olivétan's French Bible"
+      }
+    ]
+  },
+  "object-zurich-bible": {
+    "wikidataId": null,
+    "wikipediaTitle": "Froschauer_Bible",
+    "canonicalTitle": "Zurich Bible",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-zurich-bible",
+        "nodeTitle": "Zurich Bible"
+      }
+    ]
+  },
+  "object-augsburg-confession": {
+    "wikidataId": "Q154483",
+    "wikipediaTitle": "Augsburg_Confession",
+    "canonicalTitle": "Augsburg Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-augsburg-confession",
+        "nodeTitle": "Augsburg Confession"
+      }
+    ]
+  },
+  "object-apology-augsburg": {
+    "wikidataId": "Q619586",
+    "wikipediaTitle": "Apology_of_the_Augsburg_Confession",
+    "canonicalTitle": "Apology of the Augsburg Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-apology-augsburg",
+        "nodeTitle": "Apology of the Augsburg Confession"
+      }
+    ]
+  },
+  "object-small-catechism": {
+    "wikidataId": null,
+    "wikipediaTitle": "Luther%27s_Small_Catechism",
+    "canonicalTitle": "Small Catechism",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-small-catechism",
+        "nodeTitle": "Small Catechism"
+      }
+    ]
+  },
+  "object-large-catechism": {
+    "wikidataId": null,
+    "wikipediaTitle": "Luther%27s_Large_Catechism",
+    "canonicalTitle": "Large Catechism",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-large-catechism",
+        "nodeTitle": "Large Catechism"
+      }
+    ]
+  },
+  "object-tetrapolitan-confession": {
+    "wikidataId": "Q319300",
+    "wikipediaTitle": "Tetrapolitan_Confession",
+    "canonicalTitle": "Tetrapolitan Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-tetrapolitan-confession",
+        "nodeTitle": "Tetrapolitan Confession"
+      }
+    ]
+  },
+  "object-first-helvetic-confession": {
+    "wikidataId": null,
+    "wikipediaTitle": "First_Helvetic_Confession",
+    "canonicalTitle": "First Helvetic Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-first-helvetic-confession",
+        "nodeTitle": "First Helvetic Confession"
+      }
+    ]
+  },
+  "object-second-helvetic-confession": {
+    "wikidataId": "Q676162",
+    "wikipediaTitle": "Second_Helvetic_Confession",
+    "canonicalTitle": "Second Helvetic Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-second-helvetic-confession",
+        "nodeTitle": "Second Helvetic Confession"
+      }
+    ]
+  },
+  "object-genevan-catechism": {
+    "wikidataId": null,
+    "wikipediaTitle": "Genevan_Catechism",
+    "canonicalTitle": "Genevan Catechism",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-genevan-catechism",
+        "nodeTitle": "Genevan Catechism"
+      }
+    ]
+  },
+  "object-heidelberg-catechism": {
+    "wikidataId": "Q327152",
+    "wikipediaTitle": "Heidelberg_Catechism",
+    "canonicalTitle": "Heidelberg Catechism",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-heidelberg-catechism",
+        "nodeTitle": "Heidelberg Catechism"
+      }
+    ]
+  },
+  "object-schleitheim-confession": {
+    "wikidataId": "Q265613",
+    "wikipediaTitle": "Schleitheim_Confession",
+    "canonicalTitle": "Schleitheim Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-schleitheim-confession",
+        "nodeTitle": "Schleitheim Confession"
+      }
+    ]
+  },
+  "object-scots-confession": {
+    "wikidataId": "Q1125192",
+    "wikipediaTitle": "Scots_Confession",
+    "canonicalTitle": "Scots Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-scots-confession",
+        "nodeTitle": "Scots Confession"
+      }
+    ]
+  },
+  "object-thirty-nine-articles": {
+    "wikidataId": "Q937617",
+    "wikipediaTitle": "Thirty-nine_Articles",
+    "canonicalTitle": "Thirty-Nine Articles",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-thirty-nine-articles",
+        "nodeTitle": "Thirty-Nine Articles"
+      }
+    ]
+  },
+  "object-bcp-1549": {
+    "wikidataId": "Q85748229",
+    "wikipediaTitle": "Book_of_Common_Prayer_(1549)",
+    "canonicalTitle": "Book of Common Prayer (1549)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-bcp-1549",
+        "nodeTitle": "Book of Common Prayer (1549)"
+      }
+    ]
+  },
+  "object-bcp-1552": {
+    "wikidataId": "Q111955226",
+    "wikipediaTitle": "Book_of_Common_Prayer_(1552)",
+    "canonicalTitle": "Book of Common Prayer (1552)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-bcp-1552",
+        "nodeTitle": "Book of Common Prayer (1552)"
+      }
+    ]
+  },
+  "object-strasbourg-liturgy": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Strasbourg Liturgy",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-strasbourg-liturgy",
+        "nodeTitle": "Strasbourg Liturgy"
+      }
+    ]
+  },
+  "object-genevan-psalter": {
+    "wikidataId": "Q493726",
+    "wikipediaTitle": "Genevan_Psalter",
+    "canonicalTitle": "Genevan Psalter",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-genevan-psalter",
+        "nodeTitle": "Genevan Psalter"
+      }
+    ]
+  },
+  "object-luther-hymns": {
+    "wikidataId": "Q855575",
+    "wikipediaTitle": "A_Mighty_Fortress_Is_Our_God",
+    "canonicalTitle": "Luther's Hymns",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-luther-hymns",
+        "nodeTitle": "Luther's Hymns"
+      }
+    ]
+  },
+  "object-book-of-martyrs": {
+    "wikidataId": null,
+    "wikipediaTitle": "Foxe%27s_Book_of_Martyrs",
+    "canonicalTitle": "Actes and Monuments (Book of Martyrs)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-book-of-martyrs",
+        "nodeTitle": "Actes and Monuments (Book of Martyrs)"
+      }
+    ]
+  },
+  "object-praise-of-folly": {
+    "wikidataId": null,
+    "wikipediaTitle": "The_Praise_of_Folly",
+    "canonicalTitle": "The Praise of Folly",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-praise-of-folly",
+        "nodeTitle": "The Praise of Folly"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-praise-of-folly",
+        "nodeTitle": "Moriae encomium (Praise of Folly)"
+      }
+    ]
+  },
+  "object-enchiridion": {
+    "wikidataId": null,
+    "wikipediaTitle": "Enchiridion_militis_Christiani",
+    "canonicalTitle": "Enchiridion",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-enchiridion",
+        "nodeTitle": "Enchiridion"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-enchiridion",
+        "nodeTitle": "Enchiridion militis Christiani"
+      }
+    ]
+  },
+  "object-first-blast": {
+    "wikidataId": "Q7777000",
+    "wikipediaTitle": "The_First_Blast_of_the_Trumpet_Against_the_Monstrous_Regiment_of_Women",
+    "canonicalTitle": "First Blast of the Trumpet",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-first-blast",
+        "nodeTitle": "First Blast of the Trumpet"
+      }
+    ]
+  },
+  "object-erasmus-correspondence": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Erasmus's Correspondence",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-erasmus-correspondence",
+        "nodeTitle": "Erasmus's Correspondence"
+      }
+    ]
+  },
+  "object-luther-correspondence": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Luther's Correspondence",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-luther-correspondence",
+        "nodeTitle": "Luther's Correspondence"
+      }
+    ]
+  },
+  "object-bullinger-correspondence": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Bullinger's Correspondence",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-bullinger-correspondence",
+        "nodeTitle": "Bullinger's Correspondence"
+      }
+    ]
+  },
+  "location-wittenberg": {
+    "wikidataId": "Q6837",
+    "wikipediaTitle": "Wittenberg",
+    "canonicalTitle": "Wittenberg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-wittenberg",
+        "nodeTitle": "Wittenberg"
+      }
+    ]
+  },
+  "location-wittenberg-university": {
+    "wikidataId": null,
+    "wikipediaTitle": "University_of_Wittenberg",
+    "canonicalTitle": "University of Wittenberg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-wittenberg-university",
+        "nodeTitle": "University of Wittenberg"
+      }
+    ]
+  },
+  "location-castle-church-wittenberg": {
+    "wikidataId": null,
+    "wikipediaTitle": "All_Saints%27_Church,_Wittenberg",
+    "canonicalTitle": "Castle Church (Schlosskirche)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-castle-church-wittenberg",
+        "nodeTitle": "Castle Church (Schlosskirche)"
+      }
+    ]
+  },
+  "location-worms": {
+    "wikidataId": "Q3852",
+    "wikipediaTitle": "Worms,_Germany",
+    "canonicalTitle": "Worms",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-worms",
+        "nodeTitle": "Worms"
+      }
+    ]
+  },
+  "location-augsburg": {
+    "wikidataId": "Q2749",
+    "wikipediaTitle": "Augsburg",
+    "canonicalTitle": "Augsburg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-augsburg",
+        "nodeTitle": "Augsburg"
+      }
+    ]
+  },
+  "location-marburg": {
+    "wikidataId": "Q3869",
+    "wikipediaTitle": "Marburg",
+    "canonicalTitle": "Marburg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-marburg",
+        "nodeTitle": "Marburg"
+      }
+    ]
+  },
+  "location-marburg-university": {
+    "wikidataId": null,
+    "wikipediaTitle": "University_of_Marburg",
+    "canonicalTitle": "University of Marburg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-marburg-university",
+        "nodeTitle": "University of Marburg"
+      }
+    ]
+  },
+  "location-nuremberg": {
+    "wikidataId": "Q2090",
+    "wikipediaTitle": "Nuremberg",
+    "canonicalTitle": "Nuremberg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-nuremberg",
+        "nodeTitle": "Nuremberg"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-nuremberg",
+        "nodeTitle": "Nuremberg"
+      }
+    ]
+  },
+  "location-eisleben": {
+    "wikidataId": "Q484870",
+    "wikipediaTitle": "Eisleben",
+    "canonicalTitle": "Eisleben",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-eisleben",
+        "nodeTitle": "Eisleben"
+      }
+    ]
+  },
+  "location-wartburg": {
+    "wikidataId": "Q151545",
+    "wikipediaTitle": "Wartburg",
+    "canonicalTitle": "Wartburg Castle",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-wartburg",
+        "nodeTitle": "Wartburg Castle"
+      }
+    ]
+  },
+  "location-erfurt": {
+    "wikidataId": "Q1729",
+    "wikipediaTitle": "Erfurt",
+    "canonicalTitle": "Erfurt",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-erfurt",
+        "nodeTitle": "Erfurt"
+      }
+    ]
+  },
+  "location-muhlhausen": {
+    "wikidataId": "Q14925",
+    "wikipediaTitle": "Mühlhausen",
+    "canonicalTitle": "Mühlhausen",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-muhlhausen",
+        "nodeTitle": "Mühlhausen"
+      }
+    ]
+  },
+  "location-zurich": {
+    "wikidataId": null,
+    "wikipediaTitle": "Zürich",
+    "canonicalTitle": "Zurich",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-zurich",
+        "nodeTitle": "Zurich"
+      }
+    ]
+  },
+  "location-grossmunster": {
+    "wikidataId": "Q684948",
+    "wikipediaTitle": "Grossmünster",
+    "canonicalTitle": "Grossmünster",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-grossmunster",
+        "nodeTitle": "Grossmünster"
+      }
+    ]
+  },
+  "location-st-pierre-geneva": {
+    "wikidataId": null,
+    "wikipediaTitle": "St._Pierre_Cathedral,_Geneva",
+    "canonicalTitle": "St. Pierre Cathedral",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-st-pierre-geneva",
+        "nodeTitle": "St. Pierre Cathedral"
+      }
+    ]
+  },
+  "location-geneva-academy": {
+    "wikidataId": "Q503473",
+    "wikipediaTitle": "University_of_Geneva",
+    "canonicalTitle": "Geneva Academy",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-geneva-academy",
+        "nodeTitle": "Geneva Academy"
+      }
+    ]
+  },
+  "location-basel": {
+    "wikidataId": "Q78",
+    "wikipediaTitle": "Basel",
+    "canonicalTitle": "Basel",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-basel",
+        "nodeTitle": "Basel"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-basel",
+        "nodeTitle": "Basel"
+      }
+    ]
+  },
+  "location-basel-university": {
+    "wikidataId": "Q372608",
+    "wikipediaTitle": "University_of_Basel",
+    "canonicalTitle": "University of Basel",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-basel-university",
+        "nodeTitle": "University of Basel"
+      }
+    ]
+  },
+  "location-bern": {
+    "wikidataId": "Q70",
+    "wikipediaTitle": "Bern",
+    "canonicalTitle": "Bern",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-bern",
+        "nodeTitle": "Bern"
+      }
+    ]
+  },
+  "location-lausanne": {
+    "wikidataId": "Q807",
+    "wikipediaTitle": "Lausanne",
+    "canonicalTitle": "Lausanne",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-lausanne",
+        "nodeTitle": "Lausanne"
+      }
+    ]
+  },
+  "location-strasbourg": {
+    "wikidataId": "Q6602",
+    "wikipediaTitle": "Strasbourg",
+    "canonicalTitle": "Strasbourg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-strasbourg",
+        "nodeTitle": "Strasbourg"
+      }
+    ]
+  },
+  "location-canterbury": {
+    "wikidataId": "Q29303",
+    "wikipediaTitle": "Canterbury",
+    "canonicalTitle": "Canterbury",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-canterbury",
+        "nodeTitle": "Canterbury"
+      }
+    ]
+  },
+  "location-oxford": {
+    "wikidataId": "Q34217",
+    "wikipediaTitle": "Oxford",
+    "canonicalTitle": "Oxford",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-oxford",
+        "nodeTitle": "Oxford"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-oxford",
+        "nodeTitle": "Oxford"
+      }
+    ]
+  },
+  "location-oxford-university": {
+    "wikidataId": "Q34433",
+    "wikipediaTitle": "University_of_Oxford",
+    "canonicalTitle": "University of Oxford",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-oxford-university",
+        "nodeTitle": "University of Oxford"
+      }
+    ]
+  },
+  "location-cambridge-university": {
+    "wikidataId": "Q35794",
+    "wikipediaTitle": "University_of_Cambridge",
+    "canonicalTitle": "University of Cambridge",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-cambridge-university",
+        "nodeTitle": "University of Cambridge"
+      }
+    ]
+  },
+  "location-white-horse-tavern": {
+    "wikidataId": null,
+    "wikipediaTitle": "White_Horse_Inn,_Cambridge",
+    "canonicalTitle": "White Horse Tavern",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-white-horse-tavern",
+        "nodeTitle": "White Horse Tavern"
+      }
+    ]
+  },
+  "location-antwerp": {
+    "wikidataId": "Q12892",
+    "wikipediaTitle": "Antwerp",
+    "canonicalTitle": "Antwerp",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-antwerp",
+        "nodeTitle": "Antwerp"
+      }
+    ]
+  },
+  "location-vilvoorde": {
+    "wikidataId": "Q318418",
+    "wikipediaTitle": "Vilvoorde",
+    "canonicalTitle": "Vilvoorde",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-vilvoorde",
+        "nodeTitle": "Vilvoorde"
+      }
+    ]
+  },
+  "location-meaux": {
+    "wikidataId": "Q207620",
+    "wikipediaTitle": "Meaux",
+    "canonicalTitle": "Meaux",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-meaux",
+        "nodeTitle": "Meaux"
+      }
+    ]
+  },
+  "location-ingolstadt": {
+    "wikidataId": "Q3004",
+    "wikipediaTitle": "Ingolstadt",
+    "canonicalTitle": "Ingolstadt",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-ingolstadt",
+        "nodeTitle": "Ingolstadt"
+      }
+    ]
+  },
+  "location-st-andrews": {
+    "wikidataId": "Q207736",
+    "wikipediaTitle": "St_Andrews",
+    "canonicalTitle": "St. Andrews",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-st-andrews",
+        "nodeTitle": "St. Andrews"
+      }
+    ]
+  },
+  "location-st-andrews-university": {
+    "wikidataId": "Q216273",
+    "wikipediaTitle": "University_of_St_Andrews",
+    "canonicalTitle": "University of St. Andrews",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-st-andrews-university",
+        "nodeTitle": "University of St. Andrews"
+      }
+    ]
+  },
+  "location-st-giles-edinburgh": {
+    "wikidataId": null,
+    "wikipediaTitle": "St_Giles%27_Cathedral",
+    "canonicalTitle": "St. Giles' Cathedral",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-st-giles-edinburgh",
+        "nodeTitle": "St. Giles' Cathedral"
+      }
+    ]
+  },
+  "location-kappel": {
+    "wikidataId": null,
+    "wikipediaTitle": "Battle_of_Kappel",
+    "canonicalTitle": "Kappel am Albis",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-kappel",
+        "nodeTitle": "Kappel am Albis"
+      }
+    ]
+  },
+  "location-schleitheim": {
+    "wikidataId": "Q69111",
+    "wikipediaTitle": "Schleitheim",
+    "canonicalTitle": "Schleitheim",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-schleitheim",
+        "nodeTitle": "Schleitheim"
+      }
+    ]
+  },
+  "location-frankenhausen": {
+    "wikidataId": "Q703363",
+    "wikipediaTitle": "Battle_of_Frankenhausen",
+    "canonicalTitle": "Frankenhausen",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-frankenhausen",
+        "nodeTitle": "Frankenhausen"
+      }
+    ]
+  },
+  "entity-lutheran-churches": {
+    "wikidataId": "Q75809",
+    "wikipediaTitle": "Lutheranism",
+    "canonicalTitle": "Lutheran Territorial Churches",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-lutheran-churches",
+        "nodeTitle": "Lutheran Territorial Churches"
+      }
+    ]
+  },
+  "entity-church-of-england": {
+    "wikidataId": "Q82708",
+    "wikipediaTitle": "Church_of_England",
+    "canonicalTitle": "Church of England",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-church-of-england",
+        "nodeTitle": "Church of England"
+      }
+    ]
+  },
+  "entity-zurich-church": {
+    "wikidataId": null,
+    "wikipediaTitle": "Reformed_Church_in_Zürich",
+    "canonicalTitle": "Reformed Church of Zurich",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-zurich-church",
+        "nodeTitle": "Reformed Church of Zurich"
+      }
+    ]
+  },
+  "entity-geneva-church": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Genevan Reformed Church",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-geneva-church",
+        "nodeTitle": "Genevan Reformed Church"
+      }
+    ]
+  },
+  "entity-company-of-pastors": {
+    "wikidataId": "Q16950662",
+    "wikipediaTitle": "Venerable_Company_of_Pastors",
+    "canonicalTitle": "Company of Pastors",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-company-of-pastors",
+        "nodeTitle": "Company of Pastors"
+      }
+    ]
+  },
+  "entity-geneva-consistory": {
+    "wikidataId": null,
+    "wikipediaTitle": "Consistory_of_Geneva",
+    "canonicalTitle": "Geneva Consistory",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-geneva-consistory",
+        "nodeTitle": "Geneva Consistory"
+      }
+    ]
+  },
+  "entity-church-of-scotland": {
+    "wikidataId": "Q922480",
+    "wikipediaTitle": "Church_of_Scotland",
+    "canonicalTitle": "Church of Scotland (The Kirk)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-church-of-scotland",
+        "nodeTitle": "Church of Scotland (The Kirk)"
+      }
+    ]
+  },
+  "entity-lutheran-reformation": {
+    "wikidataId": "Q12562",
+    "wikipediaTitle": "Reformation",
+    "canonicalTitle": "Lutheran Reformation",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-lutheran-reformation",
+        "nodeTitle": "Lutheran Reformation"
+      }
+    ]
+  },
+  "entity-swiss-reformed": {
+    "wikidataId": null,
+    "wikipediaTitle": "Swiss_Reformed_Church",
+    "canonicalTitle": "Swiss Reformed Movement",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-swiss-reformed",
+        "nodeTitle": "Swiss Reformed Movement"
+      }
+    ]
+  },
+  "entity-radical-reformation": {
+    "wikidataId": "Q1786655",
+    "wikipediaTitle": "Radical_Reformation",
+    "canonicalTitle": "Radical Reformation",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-radical-reformation",
+        "nodeTitle": "Radical Reformation"
+      }
+    ]
+  },
+  "entity-swiss-brethren": {
+    "wikidataId": "Q474889",
+    "wikipediaTitle": "Swiss_Brethren",
+    "canonicalTitle": "Swiss Brethren",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-swiss-brethren",
+        "nodeTitle": "Swiss Brethren"
+      }
+    ]
+  },
+  "entity-mennonites": {
+    "wikidataId": "Q110223",
+    "wikipediaTitle": "Mennonites",
+    "canonicalTitle": "Mennonite Movement",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-mennonites",
+        "nodeTitle": "Mennonite Movement"
+      }
+    ]
+  },
+  "entity-christian-humanism": {
+    "wikidataId": "Q2327432",
+    "wikipediaTitle": "Christian_humanism",
+    "canonicalTitle": "Christian Humanism",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-christian-humanism",
+        "nodeTitle": "Christian Humanism"
+      }
+    ]
+  },
+  "entity-english-reformation": {
+    "wikidataId": "Q1645505",
+    "wikipediaTitle": "English_Reformation",
+    "canonicalTitle": "English Reformation",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-english-reformation",
+        "nodeTitle": "English Reformation"
+      }
+    ]
+  },
+  "entity-meaux-circle": {
+    "wikidataId": null,
+    "wikipediaTitle": "Circle_of_Meaux",
+    "canonicalTitle": "Meaux Circle",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-meaux-circle",
+        "nodeTitle": "Meaux Circle"
+      }
+    ]
+  },
+  "entity-schmalkaldic-league": {
+    "wikidataId": "Q155024",
+    "wikipediaTitle": "Schmalkaldic_League",
+    "canonicalTitle": "Schmalkaldic League",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-schmalkaldic-league",
+        "nodeTitle": "Schmalkaldic League"
+      }
+    ]
+  },
+  "entity-swiss-confederacy": {
+    "wikidataId": "Q435583",
+    "wikipediaTitle": "Old_Swiss_Confederacy",
+    "canonicalTitle": "Swiss Confederacy",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-swiss-confederacy",
+        "nodeTitle": "Swiss Confederacy"
+      }
+    ]
+  },
+  "entity-augustinian-order": {
+    "wikidataId": "Q29075",
+    "wikipediaTitle": "Order_of_Saint_Augustine",
+    "canonicalTitle": "Augustinian Order",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-augustinian-order",
+        "nodeTitle": "Augustinian Order"
+      }
+    ]
+  },
+  "entity-diet-of-worms": {
+    "wikidataId": "Q536822",
+    "wikipediaTitle": "Diet_of_Worms",
+    "canonicalTitle": "Diet of Worms (1521)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-diet-of-worms",
+        "nodeTitle": "Diet of Worms (1521)"
+      }
+    ]
+  },
+  "entity-diet-of-augsburg": {
+    "wikidataId": "Q828750",
+    "wikipediaTitle": "Diet_of_Augsburg",
+    "canonicalTitle": "Diet of Augsburg (1530)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-diet-of-augsburg",
+        "nodeTitle": "Diet of Augsburg (1530)"
+      }
+    ]
+  },
+  "entity-marburg-colloquy": {
+    "wikidataId": "Q672138",
+    "wikipediaTitle": "Marburg_Colloquy",
+    "canonicalTitle": "Marburg Colloquy",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-marburg-colloquy",
+        "nodeTitle": "Marburg Colloquy"
+      }
+    ]
+  },
+  "entity-zurich-disputation-1523": {
+    "wikidataId": null,
+    "wikipediaTitle": "First_Disputation_of_Zurich",
+    "canonicalTitle": "First Zurich Disputation",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-zurich-disputation-1523",
+        "nodeTitle": "First Zurich Disputation"
+      }
+    ]
+  },
+  "entity-leipzig-debate": {
+    "wikidataId": "Q688998",
+    "wikipediaTitle": "Leipzig_Debate",
+    "canonicalTitle": "Leipzig Debate",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-leipzig-debate",
+        "nodeTitle": "Leipzig Debate"
+      }
+    ]
+  },
+  "entity-peace-of-augsburg": {
+    "wikidataId": "Q154577",
+    "wikipediaTitle": "Peace_of_Augsburg",
+    "canonicalTitle": "Peace of Augsburg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-peace-of-augsburg",
+        "nodeTitle": "Peace of Augsburg"
+      }
+    ]
+  },
+  "entity-froben-press": {
+    "wikidataId": "Q116611",
+    "wikipediaTitle": "Johann_Froben",
+    "canonicalTitle": "Froben Press",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-froben-press",
+        "nodeTitle": "Froben Press"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-froben-press",
+        "nodeTitle": "Froben Press"
+      }
+    ]
+  },
+  "entity-wittenberg-printers": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Wittenberg Printing Network",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-wittenberg-printers",
+        "nodeTitle": "Wittenberg Printing Network"
+      }
+    ]
+  },
+  "entity-geneva-printers": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Geneva Printing Network",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-geneva-printers",
+        "nodeTitle": "Geneva Printing Network"
+      }
+    ]
+  },
+  "person-francesco-petrarca": {
+    "wikidataId": "Q1401",
+    "wikipediaTitle": "Petrarch",
+    "canonicalTitle": "Francesco Petrarca (Petrarch)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-francesco-petrarca",
+        "nodeTitle": "Francesco Petrarca (Petrarch)"
+      }
+    ]
+  },
+  "person-giovanni-boccaccio": {
+    "wikidataId": "Q1402",
+    "wikipediaTitle": "Giovanni_Boccaccio",
+    "canonicalTitle": "Giovanni Boccaccio",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giovanni-boccaccio",
+        "nodeTitle": "Giovanni Boccaccio"
+      }
+    ]
+  },
+  "person-coluccio-salutati": {
+    "wikidataId": "Q93113",
+    "wikipediaTitle": "Coluccio_Salutati",
+    "canonicalTitle": "Coluccio Salutati",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-coluccio-salutati",
+        "nodeTitle": "Coluccio Salutati"
+      }
+    ]
+  },
+  "person-leonardo-bruni": {
+    "wikidataId": "Q314488",
+    "wikipediaTitle": "Leonardo_Bruni",
+    "canonicalTitle": "Leonardo Bruni",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-leonardo-bruni",
+        "nodeTitle": "Leonardo Bruni"
+      }
+    ]
+  },
+  "person-poggio-bracciolini": {
+    "wikidataId": "Q318254",
+    "wikipediaTitle": "Poggio_Bracciolini",
+    "canonicalTitle": "Poggio Bracciolini",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-poggio-bracciolini",
+        "nodeTitle": "Poggio Bracciolini"
+      }
+    ]
+  },
+  "person-niccolo-niccoli": {
+    "wikidataId": "Q730505",
+    "wikipediaTitle": "Niccolò_Niccoli",
+    "canonicalTitle": "Niccolò Niccoli",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-niccolo-niccoli",
+        "nodeTitle": "Niccolò Niccoli"
+      }
+    ]
+  },
+  "person-pier-paolo-vergerio": {
+    "wikidataId": "Q668134",
+    "wikipediaTitle": "Pier_Paolo_Vergerio",
+    "canonicalTitle": "Pier Paolo Vergerio the Elder",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-pier-paolo-vergerio",
+        "nodeTitle": "Pier Paolo Vergerio the Elder"
+      }
+    ]
+  },
+  "person-gasparino-barzizza": {
+    "wikidataId": "Q1236187",
+    "wikipediaTitle": "Gasparino_Barzizza",
+    "canonicalTitle": "Gasparino Barzizza",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-gasparino-barzizza",
+        "nodeTitle": "Gasparino Barzizza"
+      }
+    ]
+  },
+  "person-giovanni-aurispa": {
+    "wikidataId": "Q770787",
+    "wikipediaTitle": "Giovanni_Aurispa",
+    "canonicalTitle": "Giovanni Aurispa",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giovanni-aurispa",
+        "nodeTitle": "Giovanni Aurispa"
+      }
+    ]
+  },
+  "person-giovanni-pico": {
+    "wikidataId": "Q182128",
+    "wikipediaTitle": "Giovanni_Pico_della_Mirandola",
+    "canonicalTitle": "Giovanni Pico della Mirandola",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giovanni-pico",
+        "nodeTitle": "Giovanni Pico della Mirandola"
+      }
+    ]
+  },
+  "person-francesco-diacceto": {
+    "wikidataId": "Q3749759",
+    "wikipediaTitle": "Francesco_Cattani_da_Diacceto",
+    "canonicalTitle": "Francesco Cattani da Diacceto",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-francesco-diacceto",
+        "nodeTitle": "Francesco Cattani da Diacceto"
+      }
+    ]
+  },
+  "person-giovanni-nesi": {
+    "wikidataId": "Q125461951",
+    "wikipediaTitle": "Giovanni_Nesi",
+    "canonicalTitle": "Giovanni Nesi",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giovanni-nesi",
+        "nodeTitle": "Giovanni Nesi"
+      }
+    ]
+  },
+  "person-leon-battista-alberti": {
+    "wikidataId": "Q182046",
+    "wikipediaTitle": "Leon_Battista_Alberti",
+    "canonicalTitle": "Leon Battista Alberti",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-leon-battista-alberti",
+        "nodeTitle": "Leon Battista Alberti"
+      }
+    ]
+  },
+  "person-niccolo-machiavelli": {
+    "wikidataId": "Q1399",
+    "wikipediaTitle": "Niccolò_Machiavelli",
+    "canonicalTitle": "Niccolò Machiavelli",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-niccolo-machiavelli",
+        "nodeTitle": "Niccolò Machiavelli"
+      }
+    ]
+  },
+  "person-francesco-guicciardini": {
+    "wikidataId": "Q44601",
+    "wikipediaTitle": "Francesco_Guicciardini",
+    "canonicalTitle": "Francesco Guicciardini",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-francesco-guicciardini",
+        "nodeTitle": "Francesco Guicciardini"
+      }
+    ]
+  },
+  "person-matteo-palmieri": {
+    "wikidataId": "Q1229872",
+    "wikipediaTitle": "Matteo_Palmieri",
+    "canonicalTitle": "Matteo Palmieri",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-matteo-palmieri",
+        "nodeTitle": "Matteo Palmieri"
+      }
+    ]
+  },
+  "person-donato-acciaiuoli": {
+    "wikidataId": null,
+    "wikipediaTitle": "Donato_Acciaiuoli",
+    "canonicalTitle": "Donato Acciaiuoli",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-donato-acciaiuoli",
+        "nodeTitle": "Donato Acciaiuoli"
+      }
+    ]
+  },
+  "person-giannozzo-manetti": {
+    "wikidataId": "Q1234681",
+    "wikipediaTitle": "Giannozzo_Manetti",
+    "canonicalTitle": "Giannozzo Manetti",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giannozzo-manetti",
+        "nodeTitle": "Giannozzo Manetti"
+      }
+    ]
+  },
+  "person-lorenzo-valla": {
+    "wikidataId": "Q214115",
+    "wikipediaTitle": "Lorenzo_Valla",
+    "canonicalTitle": "Lorenzo Valla",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-lorenzo-valla",
+        "nodeTitle": "Lorenzo Valla"
+      }
+    ]
+  },
+  "person-flavio-biondo": {
+    "wikidataId": "Q434834",
+    "wikipediaTitle": "Flavio_Biondo",
+    "canonicalTitle": "Flavio Biondo",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-flavio-biondo",
+        "nodeTitle": "Flavio Biondo"
+      }
+    ]
+  },
+  "person-pomponio-leto": {
+    "wikidataId": null,
+    "wikipediaTitle": "Giulio_Pomponio_Leto",
+    "canonicalTitle": "Pomponio Leto",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-pomponio-leto",
+        "nodeTitle": "Pomponio Leto"
+      }
+    ]
+  },
+  "person-bartolomeo-platina": {
+    "wikidataId": "Q455140",
+    "wikipediaTitle": "Bartolomeo_Platina",
+    "canonicalTitle": "Bartolomeo Platina",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-bartolomeo-platina",
+        "nodeTitle": "Bartolomeo Platina"
+      }
+    ]
+  },
+  "person-giovanni-pontano": {
+    "wikidataId": "Q714946",
+    "wikipediaTitle": "Giovanni_Pontano",
+    "canonicalTitle": "Giovanni Pontano",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giovanni-pontano",
+        "nodeTitle": "Giovanni Pontano"
+      }
+    ]
+  },
+  "person-jacopo-sannazaro": {
+    "wikidataId": "Q510621",
+    "wikipediaTitle": "Jacopo_Sannazaro",
+    "canonicalTitle": "Jacopo Sannazaro",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-jacopo-sannazaro",
+        "nodeTitle": "Jacopo Sannazaro"
+      }
+    ]
+  },
+  "person-enea-silvio-piccolomini": {
+    "wikidataId": "Q101437",
+    "wikipediaTitle": "Pope_Pius_II",
+    "canonicalTitle": "Enea Silvio Piccolomini (Pope Pius II)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-enea-silvio-piccolomini",
+        "nodeTitle": "Enea Silvio Piccolomini (Pope Pius II)"
+      }
+    ]
+  },
+  "person-pietro-bembo": {
+    "wikidataId": "Q334188",
+    "wikipediaTitle": "Pietro_Bembo",
+    "canonicalTitle": "Pietro Bembo",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-pietro-bembo",
+        "nodeTitle": "Pietro Bembo"
+      }
+    ]
+  },
+  "person-aldo-manuzio": {
+    "wikidataId": "Q213220",
+    "wikipediaTitle": "Aldus_Manutius",
+    "canonicalTitle": "Aldo Manuzio (Aldus Manutius)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-aldo-manuzio",
+        "nodeTitle": "Aldo Manuzio (Aldus Manutius)"
+      }
+    ]
+  },
+  "person-ermolao-barbaro": {
+    "wikidataId": null,
+    "wikipediaTitle": "Ermolao_Barbaro_the_Younger",
+    "canonicalTitle": "Ermolao Barbaro the Younger",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-ermolao-barbaro",
+        "nodeTitle": "Ermolao Barbaro the Younger"
+      }
+    ]
+  },
+  "person-pietro-pomponazzi": {
+    "wikidataId": "Q318787",
+    "wikipediaTitle": "Pietro_Pomponazzi",
+    "canonicalTitle": "Pietro Pomponazzi",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-pietro-pomponazzi",
+        "nodeTitle": "Pietro Pomponazzi"
+      }
+    ]
+  },
+  "person-niccolo-leonico-tomeo": {
+    "wikidataId": null,
+    "wikipediaTitle": "Niccolò_Leonico_Tomeo",
+    "canonicalTitle": "Niccolò Leonico Tomeo",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-niccolo-leonico-tomeo",
+        "nodeTitle": "Niccolò Leonico Tomeo"
+      }
+    ]
+  },
+  "person-giorgio-valla": {
+    "wikidataId": "Q1525570",
+    "wikipediaTitle": "Giorgio_Valla",
+    "canonicalTitle": "Giorgio Valla",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giorgio-valla",
+        "nodeTitle": "Giorgio Valla"
+      }
+    ]
+  },
+  "person-desiderius-erasmus": {
+    "wikidataId": "Q43499",
+    "wikipediaTitle": "Erasmus",
+    "canonicalTitle": "Desiderius Erasmus of Rotterdam",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-desiderius-erasmus",
+        "nodeTitle": "Desiderius Erasmus of Rotterdam"
+      }
+    ]
+  },
+  "person-william-grocyn": {
+    "wikidataId": "Q731879",
+    "wikipediaTitle": "William_Grocyn",
+    "canonicalTitle": "William Grocyn",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-william-grocyn",
+        "nodeTitle": "William Grocyn"
+      }
+    ]
+  },
+  "person-thomas-linacre": {
+    "wikidataId": "Q730540",
+    "wikipediaTitle": "Thomas_Linacre",
+    "canonicalTitle": "Thomas Linacre",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-thomas-linacre",
+        "nodeTitle": "Thomas Linacre"
+      }
+    ]
+  },
+  "person-john-fisher": {
+    "wikidataId": null,
+    "wikipediaTitle": "John_Fisher_(cardinal)",
+    "canonicalTitle": "John Fisher",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-john-fisher",
+        "nodeTitle": "John Fisher"
+      }
+    ]
+  },
+  "person-cuthbert-tunstall": {
+    "wikidataId": "Q725592",
+    "wikipediaTitle": "Cuthbert_Tunstall",
+    "canonicalTitle": "Cuthbert Tunstall",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-cuthbert-tunstall",
+        "nodeTitle": "Cuthbert Tunstall"
+      }
+    ]
+  },
+  "person-juan-luis-vives": {
+    "wikidataId": "Q316357",
+    "wikipediaTitle": "Juan_Luis_Vives",
+    "canonicalTitle": "Juan Luis Vives",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-juan-luis-vives",
+        "nodeTitle": "Juan Luis Vives"
+      }
+    ]
+  },
+  "person-guillaume-bude": {
+    "wikidataId": "Q353668",
+    "wikipediaTitle": "Guillaume_Budé",
+    "canonicalTitle": "Guillaume Budé",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-guillaume-bude",
+        "nodeTitle": "Guillaume Budé"
+      }
+    ]
+  },
+  "person-robert-estienne": {
+    "wikidataId": "Q260921",
+    "wikipediaTitle": "Robert_Estienne",
+    "canonicalTitle": "Robert Estienne (Stephanus)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-robert-estienne",
+        "nodeTitle": "Robert Estienne (Stephanus)"
+      }
+    ]
+  },
+  "person-rudolf-agricola": {
+    "wikidataId": null,
+    "wikipediaTitle": "Rudolf_Agricola",
+    "canonicalTitle": "Rudolf Agricola",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-rudolf-agricola",
+        "nodeTitle": "Rudolf Agricola"
+      }
+    ]
+  },
+  "person-conrad-celtis": {
+    "wikidataId": "Q60625",
+    "wikipediaTitle": "Conrad_Celtes",
+    "canonicalTitle": "Conrad Celtis",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-conrad-celtis",
+        "nodeTitle": "Conrad Celtis"
+      }
+    ]
+  },
+  "person-willibald-pirckheimer": {
+    "wikidataId": "Q62663",
+    "wikipediaTitle": "Willibald_Pirckheimer",
+    "canonicalTitle": "Willibald Pirckheimer",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-willibald-pirckheimer",
+        "nodeTitle": "Willibald Pirckheimer"
+      }
+    ]
+  },
+  "person-jakob-wimpfeling": {
+    "wikidataId": "Q71848",
+    "wikipediaTitle": "Jakob_Wimpfeling",
+    "canonicalTitle": "Jakob Wimpfeling",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-jakob-wimpfeling",
+        "nodeTitle": "Jakob Wimpfeling"
+      }
+    ]
+  },
+  "person-beatus-rhenanus": {
+    "wikidataId": "Q646092",
+    "wikipediaTitle": "Beatus_Rhenanus",
+    "canonicalTitle": "Beatus Rhenanus",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-beatus-rhenanus",
+        "nodeTitle": "Beatus Rhenanus"
+      }
+    ]
+  },
+  "person-johann-froben": {
+    "wikidataId": "Q116611",
+    "wikipediaTitle": "Johann_Froben",
+    "canonicalTitle": "Johann Froben",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-johann-froben",
+        "nodeTitle": "Johann Froben"
+      }
+    ]
+  },
+  "person-alexander-hegius": {
+    "wikidataId": "Q706796",
+    "wikipediaTitle": "Alexander_Hegius",
+    "canonicalTitle": "Alexander Hegius",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-alexander-hegius",
+        "nodeTitle": "Alexander Hegius"
+      }
+    ]
+  },
+  "person-antonio-nebrija": {
+    "wikidataId": "Q380804",
+    "wikipediaTitle": "Antonio_de_Nebrija",
+    "canonicalTitle": "Antonio de Nebrija",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-antonio-nebrija",
+        "nodeTitle": "Antonio de Nebrija"
+      }
+    ]
+  },
+  "person-cardinal-cisneros": {
+    "wikidataId": "Q342392",
+    "wikipediaTitle": "Francisco_Jiménez_de_Cisneros",
+    "canonicalTitle": "Cardinal Francisco Jiménez de Cisneros",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-cardinal-cisneros",
+        "nodeTitle": "Cardinal Francisco Jiménez de Cisneros"
+      }
+    ]
+  },
+  "person-juan-de-valdes": {
+    "wikidataId": "Q666687",
+    "wikipediaTitle": "Juan_de_Valdés",
+    "canonicalTitle": "Juan de Valdés",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-juan-de-valdes",
+        "nodeTitle": "Juan de Valdés"
+      }
+    ]
+  },
+  "person-hernan-nunez": {
+    "wikidataId": null,
+    "wikipediaTitle": "Hernán_Núñez_de_Toledo",
+    "canonicalTitle": "Hernán Núñez de Toledo",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-hernan-nunez",
+        "nodeTitle": "Hernán Núñez de Toledo"
+      }
+    ]
+  },
+  "person-michel-de-montaigne": {
+    "wikidataId": "Q41568",
+    "wikipediaTitle": "Michel_de_Montaigne",
+    "canonicalTitle": "Michel de Montaigne",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-michel-de-montaigne",
+        "nodeTitle": "Michel de Montaigne"
+      }
+    ]
+  },
+  "person-etienne-de-la-boetie": {
+    "wikidataId": "Q290227",
+    "wikipediaTitle": "Étienne_de_La_Boétie",
+    "canonicalTitle": "Étienne de La Boétie",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-etienne-de-la-boetie",
+        "nodeTitle": "Étienne de La Boétie"
+      }
+    ]
+  },
+  "person-jean-dorat": {
+    "wikidataId": null,
+    "wikipediaTitle": "Jean_Dorat",
+    "canonicalTitle": "Jean Dorat",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-jean-dorat",
+        "nodeTitle": "Jean Dorat"
+      }
+    ]
+  },
+  "person-guarino-da-verona": {
+    "wikidataId": "Q539577",
+    "wikipediaTitle": "Guarino_da_Verona",
+    "canonicalTitle": "Guarino da Verona",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-guarino-da-verona",
+        "nodeTitle": "Guarino da Verona"
+      }
+    ]
+  },
+  "person-vittorino-da-feltre": {
+    "wikidataId": "Q725843",
+    "wikipediaTitle": "Vittorino_da_Feltre",
+    "canonicalTitle": "Vittorino da Feltre",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-vittorino-da-feltre",
+        "nodeTitle": "Vittorino da Feltre"
+      }
+    ]
+  },
+  "person-battista-guarino": {
+    "wikidataId": "Q810966",
+    "wikipediaTitle": "Battista_Guarino",
+    "canonicalTitle": "Battista Guarino",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-battista-guarino",
+        "nodeTitle": "Battista Guarino"
+      }
+    ]
+  },
+  "person-johannes-sturm": {
+    "wikidataId": "Q66382",
+    "wikipediaTitle": "Johannes_Sturm",
+    "canonicalTitle": "Johannes Sturm",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-johannes-sturm",
+        "nodeTitle": "Johannes Sturm"
+      }
+    ]
+  },
+  "person-demetrius-chalcondyles": {
+    "wikidataId": null,
+    "wikipediaTitle": "Demetrius_Chalcondyles",
+    "canonicalTitle": "Demetrius Chalcondyles",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-demetrius-chalcondyles",
+        "nodeTitle": "Demetrius Chalcondyles"
+      }
+    ]
+  },
+  "person-johannes-argyropoulos": {
+    "wikidataId": "Q26648",
+    "wikipediaTitle": "John_Argyropoulos",
+    "canonicalTitle": "Johannes Argyropoulos",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-johannes-argyropoulos",
+        "nodeTitle": "Johannes Argyropoulos"
+      }
+    ]
+  },
+  "person-george-of-trebizond": {
+    "wikidataId": "Q533514",
+    "wikipediaTitle": "George_of_Trebizond",
+    "canonicalTitle": "George of Trebizond",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-george-of-trebizond",
+        "nodeTitle": "George of Trebizond"
+      }
+    ]
+  },
+  "person-cardinal-bessarion": {
+    "wikidataId": "Q299446",
+    "wikipediaTitle": "Bessarion",
+    "canonicalTitle": "Cardinal Bessarion",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-cardinal-bessarion",
+        "nodeTitle": "Cardinal Bessarion"
+      }
+    ]
+  },
+  "person-theodore-gaza": {
+    "wikidataId": null,
+    "wikipediaTitle": "Theodore_Gaza",
+    "canonicalTitle": "Theodore Gaza",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-theodore-gaza",
+        "nodeTitle": "Theodore Gaza"
+      }
+    ]
+  },
+  "person-francesco-filelfo": {
+    "wikidataId": "Q4622",
+    "wikipediaTitle": "Francesco_Filelfo",
+    "canonicalTitle": "Francesco Filelfo",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-francesco-filelfo",
+        "nodeTitle": "Francesco Filelfo"
+      }
+    ]
+  },
+  "person-paolo-giovio": {
+    "wikidataId": "Q437543",
+    "wikipediaTitle": "Paolo_Giovio",
+    "canonicalTitle": "Paolo Giovio",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-paolo-giovio",
+        "nodeTitle": "Paolo Giovio"
+      }
+    ]
+  },
+  "person-pietro-aretino": {
+    "wikidataId": "Q296272",
+    "wikipediaTitle": "Pietro_Aretino",
+    "canonicalTitle": "Pietro Aretino",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-pietro-aretino",
+        "nodeTitle": "Pietro Aretino"
+      }
+    ]
+  },
+  "person-baldassare-castiglione": {
+    "wikidataId": "Q211133",
+    "wikipediaTitle": "Baldassare_Castiglione",
+    "canonicalTitle": "Baldassare Castiglione",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-baldassare-castiglione",
+        "nodeTitle": "Baldassare Castiglione"
+      }
+    ]
+  },
+  "object-epistolae-familiares": {
+    "wikidataId": "Q995950",
+    "wikipediaTitle": "Epistolae_familiares",
+    "canonicalTitle": "Epistolae familiares",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-epistolae-familiares",
+        "nodeTitle": "Epistolae familiares"
+      }
+    ]
+  },
+  "object-de-viris-illustribus": {
+    "wikidataId": "Q425606",
+    "wikipediaTitle": "De_viris_illustribus_(Petrarch)",
+    "canonicalTitle": "De viris illustribus",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-viris-illustribus",
+        "nodeTitle": "De viris illustribus"
+      }
+    ]
+  },
+  "object-decameron": {
+    "wikidataId": "Q16438",
+    "wikipediaTitle": "The_Decameron",
+    "canonicalTitle": "Decameron",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-decameron",
+        "nodeTitle": "Decameron"
+      }
+    ]
+  },
+  "object-genealogia-deorum": {
+    "wikidataId": "Q3759459",
+    "wikipediaTitle": "Genealogia_Deorum_Gentilium",
+    "canonicalTitle": "Genealogia deorum gentilium",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-genealogia-deorum",
+        "nodeTitle": "Genealogia deorum gentilium"
+      }
+    ]
+  },
+  "object-elegantiae": {
+    "wikidataId": null,
+    "wikipediaTitle": "Elegantiae_linguae_Latinae",
+    "canonicalTitle": "Elegantiae linguae Latinae",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-elegantiae",
+        "nodeTitle": "Elegantiae linguae Latinae"
+      }
+    ]
+  },
+  "object-donation-constantine": {
+    "wikidataId": null,
+    "wikipediaTitle": "Discourse_on_the_Forgery_of_the_Alleged_Donation_of_Constantine",
+    "canonicalTitle": "De falso credita et ementita Constantini donatione",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-donation-constantine",
+        "nodeTitle": "De falso credita et ementita Constantini donatione"
+      }
+    ]
+  },
+  "object-erotemata": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Erotemata",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-erotemata",
+        "nodeTitle": "Erotemata"
+      }
+    ]
+  },
+  "object-ficino-plato": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Complete Plato Translations",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-ficino-plato",
+        "nodeTitle": "Complete Plato Translations"
+      }
+    ]
+  },
+  "object-de-amore-ficino": {
+    "wikidataId": null,
+    "wikipediaTitle": "Commentarium_in_Convivium_Platonis_de_Amore",
+    "canonicalTitle": "De amore",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-amore-ficino",
+        "nodeTitle": "De amore"
+      }
+    ]
+  },
+  "object-de-ente-et-uno": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "De ente et uno",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-ente-et-uno",
+        "nodeTitle": "De ente et uno"
+      }
+    ]
+  },
+  "object-ficino-plotinus": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Plotinus Translation (Enneads)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-ficino-plotinus",
+        "nodeTitle": "Plotinus Translation (Enneads)"
+      }
+    ]
+  },
+  "object-laudatio-florentinae": {
+    "wikidataId": null,
+    "wikipediaTitle": "Laudatio_Florentinae_urbis",
+    "canonicalTitle": "Laudatio Florentinae urbis",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-laudatio-florentinae",
+        "nodeTitle": "Laudatio Florentinae urbis"
+      }
+    ]
+  },
+  "object-bruni-history-florence": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Historiarum Florentini populi libri XII",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-bruni-history-florence",
+        "nodeTitle": "Historiarum Florentini populi libri XII"
+      }
+    ]
+  },
+  "object-il-principe": {
+    "wikidataId": "Q131719",
+    "wikipediaTitle": "The_Prince",
+    "canonicalTitle": "Il Principe (The Prince)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-il-principe",
+        "nodeTitle": "Il Principe (The Prince)"
+      }
+    ]
+  },
+  "object-discorsi-livy": {
+    "wikidataId": "Q924424",
+    "wikipediaTitle": "Discourses_on_Livy",
+    "canonicalTitle": "Discorsi sopra la prima deca di Tito Livio",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-discorsi-livy",
+        "nodeTitle": "Discorsi sopra la prima deca di Tito Livio"
+      }
+    ]
+  },
+  "object-istorie-fiorentine": {
+    "wikidataId": "Q691766",
+    "wikipediaTitle": "Florentine_Histories",
+    "canonicalTitle": "Istorie fiorentine",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-istorie-fiorentine",
+        "nodeTitle": "Istorie fiorentine"
+      }
+    ]
+  },
+  "object-storia-italia": {
+    "wikidataId": null,
+    "wikipediaTitle": "Storia_d%27Italia_(Guicciardini)",
+    "canonicalTitle": "Storia d'Italia",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-storia-italia",
+        "nodeTitle": "Storia d'Italia"
+      }
+    ]
+  },
+  "object-ricordi": {
+    "wikidataId": null,
+    "wikipediaTitle": "Ricordi_(Guicciardini)",
+    "canonicalTitle": "Ricordi",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-ricordi",
+        "nodeTitle": "Ricordi"
+      }
+    ]
+  },
+  "object-book-courtier": {
+    "wikidataId": "Q1517519",
+    "wikipediaTitle": "The_Book_of_the_Courtier",
+    "canonicalTitle": "Il libro del cortegiano (The Book of the Courtier)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-book-courtier",
+        "nodeTitle": "Il libro del cortegiano (The Book of the Courtier)"
+      }
+    ]
+  },
+  "object-della-vita-civile": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Della vita civile",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-della-vita-civile",
+        "nodeTitle": "Della vita civile"
+      }
+    ]
+  },
+  "object-de-dignitate-manetti": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "De dignitate et excellentia hominis",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-dignitate-manetti",
+        "nodeTitle": "De dignitate et excellentia hominis"
+      }
+    ]
+  },
+  "object-de-ingenuis-moribus": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "De ingenuis moribus et liberalibus adulescentiae studiis",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-ingenuis-moribus",
+        "nodeTitle": "De ingenuis moribus et liberalibus adulescentiae studiis"
+      }
+    ]
+  },
+  "object-de-ordine-docendi": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "De ordine docendi et studendi",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-ordine-docendi",
+        "nodeTitle": "De ordine docendi et studendi"
+      }
+    ]
+  },
+  "object-de-inventione-dialectica": {
+    "wikidataId": null,
+    "wikipediaTitle": "De_inventione_dialectica",
+    "canonicalTitle": "De inventione dialectica",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-inventione-dialectica",
+        "nodeTitle": "De inventione dialectica"
+      }
+    ]
+  },
+  "object-de-tradendis": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "De tradendis disciplinis",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-tradendis",
+        "nodeTitle": "De tradendis disciplinis"
+      }
+    ]
+  },
+  "object-de-copia": {
+    "wikidataId": null,
+    "wikipediaTitle": "De_Copia",
+    "canonicalTitle": "De copia",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-copia",
+        "nodeTitle": "De copia"
+      }
+    ]
+  },
+  "object-valla-annotations-nt": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Annotations on the New Testament",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-valla-annotations-nt",
+        "nodeTitle": "Annotations on the New Testament"
+      }
+    ]
+  },
+  "object-complutensian-polyglot": {
+    "wikidataId": "Q1121746",
+    "wikipediaTitle": "Complutensian_Polyglot_Bible",
+    "canonicalTitle": "Complutensian Polyglot Bible",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-complutensian-polyglot",
+        "nodeTitle": "Complutensian Polyglot Bible"
+      }
+    ]
+  },
+  "object-french-bible-lefevre": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "French Bible Translation",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-french-bible-lefevre",
+        "nodeTitle": "French Bible Translation"
+      }
+    ]
+  },
+  "object-colloquia": {
+    "wikidataId": "Q19020085",
+    "wikipediaTitle": "Colloquies",
+    "canonicalTitle": "Colloquia familiaria",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-colloquia",
+        "nodeTitle": "Colloquia familiaria"
+      }
+    ]
+  },
+  "object-utopia": {
+    "wikidataId": "Q404158",
+    "wikipediaTitle": "Utopia_(book)",
+    "canonicalTitle": "Utopia",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-utopia",
+        "nodeTitle": "Utopia"
+      }
+    ]
+  },
+  "object-arcadia": {
+    "wikidataId": null,
+    "wikipediaTitle": "Arcadia_(Sannazaro)",
+    "canonicalTitle": "Arcadia",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-arcadia",
+        "nodeTitle": "Arcadia"
+      }
+    ]
+  },
+  "object-stanze-giostra": {
+    "wikidataId": null,
+    "wikipediaTitle": "Stanze_per_la_giostra",
+    "canonicalTitle": "Stanze per la giostra",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-stanze-giostra",
+        "nodeTitle": "Stanze per la giostra"
+      }
+    ]
+  },
+  "object-miscellanea": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Miscellanea",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-miscellanea",
+        "nodeTitle": "Miscellanea"
+      }
+    ]
+  },
+  "object-essais": {
+    "wikidataId": "Q624852",
+    "wikipediaTitle": "Essays_(Montaigne)",
+    "canonicalTitle": "Essais",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-essais",
+        "nodeTitle": "Essais"
+      }
+    ]
+  },
+  "object-servitude-volontaire": {
+    "wikidataId": "Q3030191",
+    "wikipediaTitle": "Discourse_on_Voluntary_Servitude",
+    "canonicalTitle": "Discours de la servitude volontaire",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-servitude-volontaire",
+        "nodeTitle": "Discours de la servitude volontaire"
+      }
+    ]
+  },
+  "object-adages": {
+    "wikidataId": "Q346677",
+    "wikipediaTitle": "Adagia",
+    "canonicalTitle": "Adagiorum chiliades (Adages)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-adages",
+        "nodeTitle": "Adagiorum chiliades (Adages)"
+      }
+    ]
+  },
+  "object-bruni-aristotle-ethics": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Aristotle's Ethics Translation",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-bruni-aristotle-ethics",
+        "nodeTitle": "Aristotle's Ethics Translation"
+      }
+    ]
+  },
+  "object-bruni-aristotle-politics": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Aristotle's Politics Translation",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-bruni-aristotle-politics",
+        "nodeTitle": "Aristotle's Politics Translation"
+      }
+    ]
+  },
+  "object-homer-editio-princeps": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Homer's Iliad (editio princeps)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-homer-editio-princeps",
+        "nodeTitle": "Homer's Iliad (editio princeps)"
+      }
+    ]
+  },
+  "object-thesaurus-linguae-latinae": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Thesaurus linguae Latinae",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-thesaurus-linguae-latinae",
+        "nodeTitle": "Thesaurus linguae Latinae"
+      }
+    ]
+  },
+  "object-commentarii-graecae": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Commentarii linguae Graecae",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-commentarii-graecae",
+        "nodeTitle": "Commentarii linguae Graecae"
+      }
+    ]
+  },
+  "object-de-pictura": {
+    "wikidataId": "Q3020472",
+    "wikipediaTitle": "De_pictura",
+    "canonicalTitle": "De pictura",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-pictura",
+        "nodeTitle": "De pictura"
+      }
+    ]
+  },
+  "object-de-re-aedificatoria": {
+    "wikidataId": "Q1077624",
+    "wikipediaTitle": "De_re_aedificatoria",
+    "canonicalTitle": "De re aedificatoria",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-re-aedificatoria",
+        "nodeTitle": "De re aedificatoria"
+      }
+    ]
+  },
+  "object-de-statua": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "De statua",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-statua",
+        "nodeTitle": "De statua"
+      }
+    ]
+  },
+  "object-della-famiglia": {
+    "wikidataId": null,
+    "wikipediaTitle": "I_Libri_della_Famiglia",
+    "canonicalTitle": "Della famiglia",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-della-famiglia",
+        "nodeTitle": "Della famiglia"
+      }
+    ]
+  },
+  "object-roma-instaurata": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Roma instaurata",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-roma-instaurata",
+        "nodeTitle": "Roma instaurata"
+      }
+    ]
+  },
+  "object-italia-illustrata": {
+    "wikidataId": null,
+    "wikipediaTitle": "Italia_Illustrata",
+    "canonicalTitle": "Italia illustrata",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-italia-illustrata",
+        "nodeTitle": "Italia illustrata"
+      }
+    ]
+  },
+  "object-rerum-germanicarum": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Rerum Germanicarum libri tres",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-rerum-germanicarum",
+        "nodeTitle": "Rerum Germanicarum libri tres"
+      }
+    ]
+  },
+  "object-pius-commentarii": {
+    "wikidataId": null,
+    "wikipediaTitle": "Commentaries_(Pius_II)",
+    "canonicalTitle": "Commentarii",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-pius-commentarii",
+        "nodeTitle": "Commentarii"
+      }
+    ]
+  },
+  "object-erasmus-letters": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Opus Epistolarum Des. Erasmi",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-erasmus-letters",
+        "nodeTitle": "Opus Epistolarum Des. Erasmi"
+      }
+    ]
+  },
+  "location-naples": {
+    "wikidataId": "Q2634",
+    "wikipediaTitle": "Naples",
+    "canonicalTitle": "Naples",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-naples",
+        "nodeTitle": "Naples"
+      }
+    ]
+  },
+  "location-ferrara": {
+    "wikidataId": "Q13362",
+    "wikipediaTitle": "Ferrara",
+    "canonicalTitle": "Ferrara",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-ferrara",
+        "nodeTitle": "Ferrara"
+      }
+    ]
+  },
+  "location-padua": {
+    "wikidataId": "Q617",
+    "wikipediaTitle": "Padua",
+    "canonicalTitle": "Padua",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-padua",
+        "nodeTitle": "Padua"
+      }
+    ]
+  },
+  "location-mantua": {
+    "wikidataId": "Q6247",
+    "wikipediaTitle": "Mantua",
+    "canonicalTitle": "Mantua",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-mantua",
+        "nodeTitle": "Mantua"
+      }
+    ]
+  },
+  "location-urbino": {
+    "wikidataId": "Q2759",
+    "wikipediaTitle": "Urbino",
+    "canonicalTitle": "Urbino",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-urbino",
+        "nodeTitle": "Urbino"
+      }
+    ]
+  },
+  "location-studio-fiorentino": {
+    "wikidataId": "Q820887",
+    "wikipediaTitle": "University_of_Florence",
+    "canonicalTitle": "University of Florence (Studio Fiorentino)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-studio-fiorentino",
+        "nodeTitle": "University of Florence (Studio Fiorentino)"
+      }
+    ]
+  },
+  "location-university-padua": {
+    "wikidataId": "Q193510",
+    "wikipediaTitle": "University_of_Padua",
+    "canonicalTitle": "University of Padua",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-padua",
+        "nodeTitle": "University of Padua"
+      }
+    ]
+  },
+  "location-university-bologna": {
+    "wikidataId": "Q131262",
+    "wikipediaTitle": "University_of_Bologna",
+    "canonicalTitle": "University of Bologna",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-bologna",
+        "nodeTitle": "University of Bologna"
+      }
+    ]
+  },
+  "location-university-alcala": {
+    "wikidataId": "Q1243904",
+    "wikipediaTitle": "University_of_Alcalá",
+    "canonicalTitle": "University of Alcalá de Henares",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-alcala",
+        "nodeTitle": "University of Alcalá de Henares"
+      }
+    ]
+  },
+  "location-university-paris": {
+    "wikidataId": "Q209842",
+    "wikipediaTitle": "University_of_Paris",
+    "canonicalTitle": "University of Paris",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-paris",
+        "nodeTitle": "University of Paris"
+      }
+    ]
+  },
+  "location-college-de-france": {
+    "wikidataId": "Q202660",
+    "wikipediaTitle": "Collège_de_France",
+    "canonicalTitle": "Collège de France",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-college-de-france",
+        "nodeTitle": "Collège de France"
+      }
+    ]
+  },
+  "location-university-cambridge": {
+    "wikidataId": "Q35794",
+    "wikipediaTitle": "University_of_Cambridge",
+    "canonicalTitle": "University of Cambridge",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-cambridge",
+        "nodeTitle": "University of Cambridge"
+      }
+    ]
+  },
+  "location-university-oxford": {
+    "wikidataId": "Q34433",
+    "wikipediaTitle": "University_of_Oxford",
+    "canonicalTitle": "University of Oxford",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-oxford",
+        "nodeTitle": "University of Oxford"
+      }
+    ]
+  },
+  "location-university-heidelberg": {
+    "wikidataId": "Q151510",
+    "wikipediaTitle": "Heidelberg_University",
+    "canonicalTitle": "University of Heidelberg",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-heidelberg",
+        "nodeTitle": "University of Heidelberg"
+      }
+    ]
+  },
+  "location-university-vienna": {
+    "wikidataId": "Q165980",
+    "wikipediaTitle": "University_of_Vienna",
+    "canonicalTitle": "University of Vienna",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-vienna",
+        "nodeTitle": "University of Vienna"
+      }
+    ]
+  },
+  "location-st-pauls-school": {
+    "wikidataId": null,
+    "wikipediaTitle": "St_Paul%27s_School,_London",
+    "canonicalTitle": "St. Paul's School (London)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-st-pauls-school",
+        "nodeTitle": "St. Paul's School (London)"
+      }
+    ]
+  },
+  "location-deventer-school": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Deventer School",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-deventer-school",
+        "nodeTitle": "Deventer School"
+      }
+    ]
+  },
+  "location-strasbourg-gymnasium": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Strasbourg Gymnasium",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-strasbourg-gymnasium",
+        "nodeTitle": "Strasbourg Gymnasium"
+      }
+    ]
+  },
+  "location-selestat-school": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Sélestat School",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-selestat-school",
+        "nodeTitle": "Sélestat School"
+      }
+    ]
+  },
+  "location-aldine-press": {
+    "wikidataId": "Q567488",
+    "wikipediaTitle": "Aldine_Press",
+    "canonicalTitle": "Aldine Press",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-aldine-press",
+        "nodeTitle": "Aldine Press"
+      }
+    ]
+  },
+  "location-froben-press": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Froben Press",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-froben-press",
+        "nodeTitle": "Froben Press"
+      }
+    ]
+  },
+  "location-estienne-press": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Estienne Press",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-estienne-press",
+        "nodeTitle": "Estienne Press"
+      }
+    ]
+  },
+  "location-vatican": {
+    "wikidataId": "Q159583",
+    "wikipediaTitle": "Holy_See",
+    "canonicalTitle": "Papal Court (Vatican)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-vatican",
+        "nodeTitle": "Papal Court (Vatican)"
+      }
+    ]
+  },
+  "location-court-francis-i": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Court of Francis I",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-court-francis-i",
+        "nodeTitle": "Court of Francis I"
+      }
+    ]
+  },
+  "location-english-court": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "English Court (Henry VIII)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-english-court",
+        "nodeTitle": "English Court (Henry VIII)"
+      }
+    ]
+  },
+  "location-bruges": {
+    "wikidataId": "Q12994",
+    "wikipediaTitle": "Bruges",
+    "canonicalTitle": "Bruges",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-bruges",
+        "nodeTitle": "Bruges"
+      }
+    ]
+  },
+  "location-rotterdam": {
+    "wikidataId": "Q34370",
+    "wikipediaTitle": "Rotterdam",
+    "canonicalTitle": "Rotterdam",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-rotterdam",
+        "nodeTitle": "Rotterdam"
+      }
+    ]
+  },
+  "entity-roman-academy": {
+    "wikidataId": null,
+    "wikipediaTitle": "Roman_Academy",
+    "canonicalTitle": "Roman Academy (Accademia Romana)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-roman-academy",
+        "nodeTitle": "Roman Academy (Accademia Romana)"
+      }
+    ]
+  },
+  "entity-accademia-pontaniana": {
+    "wikidataId": "Q143886",
+    "wikipediaTitle": "Accademia_Pontaniana",
+    "canonicalTitle": "Accademia Pontaniana",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-accademia-pontaniana",
+        "nodeTitle": "Accademia Pontaniana"
+      }
+    ]
+  },
+  "entity-aldine-academy": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Aldine Academy (New Academy)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-aldine-academy",
+        "nodeTitle": "Aldine Academy (New Academy)"
+      }
+    ]
+  },
+  "entity-collegium-poetarum": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Collegium poetarum (Vienna)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-collegium-poetarum",
+        "nodeTitle": "Collegium poetarum (Vienna)"
+      }
+    ]
+  },
+  "entity-german-sodalities": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "German Humanist Sodalities",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-german-sodalities",
+        "nodeTitle": "German Humanist Sodalities"
+      }
+    ]
+  },
+  "entity-civic-humanism": {
+    "wikidataId": "Q5128354",
+    "wikipediaTitle": "Civic_humanism",
+    "canonicalTitle": "Civic Humanism",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-civic-humanism",
+        "nodeTitle": "Civic Humanism"
+      }
+    ]
+  },
+  "entity-renaissance-neoplatonism": {
+    "wikidataId": null,
+    "wikipediaTitle": "Renaissance_Neoplatonism",
+    "canonicalTitle": "Renaissance Neoplatonism",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-renaissance-neoplatonism",
+        "nodeTitle": "Renaissance Neoplatonism"
+      }
+    ]
+  },
+  "entity-northern-humanism": {
+    "wikidataId": "Q2327432",
+    "wikipediaTitle": "Christian_humanism",
+    "canonicalTitle": "Northern (Christian) Humanism",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-northern-humanism",
+        "nodeTitle": "Northern (Christian) Humanism"
+      }
+    ]
+  },
+  "entity-philological-humanism": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Philological Humanism",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-philological-humanism",
+        "nodeTitle": "Philological Humanism"
+      }
+    ]
+  },
+  "entity-humanist-aristotelianism": {
+    "wikidataId": null,
+    "wikipediaTitle": "Renaissance_Aristotelianism",
+    "canonicalTitle": "Humanist Aristotelianism",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-humanist-aristotelianism",
+        "nodeTitle": "Humanist Aristotelianism"
+      }
+    ]
+  },
+  "entity-christian-kabbalah": {
+    "wikidataId": "Q1084061",
+    "wikipediaTitle": "Christian_Kabbalah",
+    "canonicalTitle": "Christian Kabbalah",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-christian-kabbalah",
+        "nodeTitle": "Christian Kabbalah"
+      }
+    ]
+  },
+  "entity-aldine-press": {
+    "wikidataId": "Q567488",
+    "wikipediaTitle": "Aldine_Press",
+    "canonicalTitle": "Aldine Press",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-aldine-press",
+        "nodeTitle": "Aldine Press"
+      }
+    ]
+  },
+  "entity-estienne-press": {
+    "wikidataId": null,
+    "wikipediaTitle": "Estienne_family",
+    "canonicalTitle": "Estienne Press",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-estienne-press",
+        "nodeTitle": "Estienne Press"
+      }
+    ]
+  },
+  "entity-casa-giocosa": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Casa Giocosa (Mantua)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-casa-giocosa",
+        "nodeTitle": "Casa Giocosa (Mantua)"
+      }
+    ]
+  },
+  "entity-guarino-school-ferrara": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Guarino's School (Ferrara)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-guarino-school-ferrara",
+        "nodeTitle": "Guarino's School (Ferrara)"
+      }
+    ]
+  },
+  "entity-medici-patronage": {
+    "wikidataId": null,
+    "wikipediaTitle": "Medici",
+    "canonicalTitle": "Medici Patronage Network",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-medici-patronage",
+        "nodeTitle": "Medici Patronage Network"
+      }
+    ]
+  },
+  "entity-papal-patronage": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Papal Patronage",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-papal-patronage",
+        "nodeTitle": "Papal Patronage"
+      }
+    ]
+  },
+  "entity-french-royal-patronage": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "French Royal Patronage",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-french-royal-patronage",
+        "nodeTitle": "French Royal Patronage"
+      }
+    ]
+  },
+  "entity-este-patronage": {
+    "wikidataId": "Q677173",
+    "wikipediaTitle": "House_of_Este",
+    "canonicalTitle": "Este Patronage (Ferrara)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-este-patronage",
+        "nodeTitle": "Este Patronage (Ferrara)"
+      }
+    ]
+  },
+  "entity-aragonese-patronage": {
+    "wikidataId": "Q173065",
+    "wikipediaTitle": "Kingdom_of_Naples",
+    "canonicalTitle": "Aragonese Patronage (Naples)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-aragonese-patronage",
+        "nodeTitle": "Aragonese Patronage (Naples)"
+      }
+    ]
+  },
+  "entity-devotio-moderna": {
+    "wikidataId": "Q756170",
+    "wikipediaTitle": "Devotio_Moderna",
+    "canonicalTitle": "Devotio Moderna",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-devotio-moderna",
+        "nodeTitle": "Devotio Moderna"
+      }
+    ]
+  },
+  "person-jacob-boehme": {
+    "wikidataId": "Q77017",
+    "wikipediaTitle": "Jakob_Böhme",
+    "canonicalTitle": "Jacob Boehme",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-jacob-boehme",
+        "nodeTitle": "Jacob Boehme"
+      }
+    ]
+  },
+  "person-jv-andreae": {
+    "wikidataId": "Q60854",
+    "wikipediaTitle": "Johann_Valentin_Andreae",
+    "canonicalTitle": "Johann Valentin Andreae",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-jv-andreae",
+        "nodeTitle": "Johann Valentin Andreae"
+      }
+    ]
+  },
+  "person-tobias-hess": {
+    "wikidataId": "Q3530141",
+    "wikipediaTitle": "Tobias_Hess",
+    "canonicalTitle": "Tobias Hess",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-tobias-hess",
+        "nodeTitle": "Tobias Hess"
+      }
+    ]
+  },
+  "person-christoph-besold": {
+    "wikidataId": "Q99371",
+    "wikipediaTitle": "Christopher_Besoldus",
+    "canonicalTitle": "Christoph Besold",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-christoph-besold",
+        "nodeTitle": "Christoph Besold"
+      }
+    ]
+  },
+  "person-johann-arndt": {
+    "wikidataId": "Q61359",
+    "wikipediaTitle": "Johann_Arndt",
+    "canonicalTitle": "Johann Arndt",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-johann-arndt",
+        "nodeTitle": "Johann Arndt"
+      }
+    ]
+  },
+  "person-michael-maier": {
+    "wikidataId": "Q901303",
+    "wikipediaTitle": "Michael_Maier",
+    "canonicalTitle": "Michael Maier",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-michael-maier",
+        "nodeTitle": "Michael Maier"
+      }
+    ]
+  },
+  "person-daniel-mogling": {
+    "wikidataId": "Q55416434",
+    "wikipediaTitle": "Daniel_Mögling",
+    "canonicalTitle": "Daniel Mögling",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-daniel-mogling",
+        "nodeTitle": "Daniel Mögling"
+      }
+    ]
+  },
+  "person-adam-haslmayr": {
+    "wikidataId": "Q4679195",
+    "wikipediaTitle": "Adam_Haslmayr",
+    "canonicalTitle": "Adam Haslmayr",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-adam-haslmayr",
+        "nodeTitle": "Adam Haslmayr"
+      }
+    ]
+  },
+  "person-valentin-weigel": {
+    "wikidataId": "Q77397",
+    "wikipediaTitle": "Valentin_Weigel",
+    "canonicalTitle": "Valentin Weigel",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-valentin-weigel",
+        "nodeTitle": "Valentin Weigel"
+      }
+    ]
+  },
+  "person-sebastian-franck": {
+    "wikidataId": "Q63170",
+    "wikipediaTitle": "Sebastian_Franck",
+    "canonicalTitle": "Sebastian Franck",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-sebastian-franck",
+        "nodeTitle": "Sebastian Franck"
+      }
+    ]
+  },
+  "person-caspar-schwenckfeld": {
+    "wikidataId": "Q64137",
+    "wikipediaTitle": "Caspar_Schwenckfeld",
+    "canonicalTitle": "Caspar Schwenckfeld",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-caspar-schwenckfeld",
+        "nodeTitle": "Caspar Schwenckfeld"
+      }
+    ]
+  },
+  "person-jg-gichtel": {
+    "wikidataId": "Q75093",
+    "wikipediaTitle": "Johann_Georg_Gichtel",
+    "canonicalTitle": "Johann Georg Gichtel",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-jg-gichtel",
+        "nodeTitle": "Johann Georg Gichtel"
+      }
+    ]
+  },
+  "person-adam-bodenstein": {
+    "wikidataId": "Q91466",
+    "wikipediaTitle": "Adam_von_Bodenstein",
+    "canonicalTitle": "Adam von Bodenstein",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-adam-bodenstein",
+        "nodeTitle": "Adam von Bodenstein"
+      }
+    ]
+  },
+  "person-heinrich-khunrath": {
+    "wikidataId": "Q73366",
+    "wikipediaTitle": "Heinrich_Khunrath",
+    "canonicalTitle": "Heinrich Khunrath",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-heinrich-khunrath",
+        "nodeTitle": "Heinrich Khunrath"
+      }
+    ]
+  },
+  "person-conrad-khunrath": {
+    "wikidataId": "Q1126858",
+    "wikipediaTitle": "Conrad_Khunrath",
+    "canonicalTitle": "Conrad Khunrath",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-conrad-khunrath",
+        "nodeTitle": "Conrad Khunrath"
+      }
+    ]
+  },
+  "person-oswald-croll": {
+    "wikidataId": "Q899007",
+    "wikipediaTitle": "Oswald_Croll",
+    "canonicalTitle": "Oswald Croll",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-oswald-croll",
+        "nodeTitle": "Oswald Croll"
+      }
+    ]
+  },
+  "person-andreas-libavius": {
+    "wikidataId": "Q31161",
+    "wikipediaTitle": "Andreas_Libavius",
+    "canonicalTitle": "Andreas Libavius",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-andreas-libavius",
+        "nodeTitle": "Andreas Libavius"
+      }
+    ]
+  },
+  "person-petrus-severinus": {
+    "wikidataId": null,
+    "wikipediaTitle": "Petrus_Severinus",
+    "canonicalTitle": "Petrus Severinus",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-petrus-severinus",
+        "nodeTitle": "Petrus Severinus"
+      }
+    ]
+  },
+  "person-daniel-sennert": {
+    "wikidataId": "Q75164",
+    "wikipediaTitle": "Daniel_Sennert",
+    "canonicalTitle": "Daniel Sennert",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-daniel-sennert",
+        "nodeTitle": "Daniel Sennert"
+      }
+    ]
+  },
+  "person-johannes-hartmann": {
+    "wikidataId": null,
+    "wikipediaTitle": "Johannes_Hartmann_(chemist)",
+    "canonicalTitle": "Johannes Hartmann",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-johannes-hartmann",
+        "nodeTitle": "Johannes Hartmann"
+      }
+    ]
+  },
+  "person-benedictus-figulus": {
+    "wikidataId": "Q109400",
+    "wikipediaTitle": "Benedictus_Figulus",
+    "canonicalTitle": "Benedictus Figulus",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-benedictus-figulus",
+        "nodeTitle": "Benedictus Figulus"
+      }
+    ]
+  },
+  "person-karl-widemann": {
+    "wikidataId": "Q42378114",
+    "wikipediaTitle": "Karl_Widemann",
+    "canonicalTitle": "Karl Widemann",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-karl-widemann",
+        "nodeTitle": "Karl Widemann"
+      }
+    ]
+  },
+  "person-raphael-eglin": {
+    "wikidataId": null,
+    "wikipediaTitle": "Raphael_Egli",
+    "canonicalTitle": "Raphael Eglin",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-raphael-eglin",
+        "nodeTitle": "Raphael Eglin"
+      }
+    ]
+  },
+  "person-rudolf-ii": {
+    "wikidataId": "Q150586",
+    "wikipediaTitle": "Rudolf_II,_Holy_Roman_Emperor",
+    "canonicalTitle": "Rudolf II",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-rudolf-ii",
+        "nodeTitle": "Rudolf II"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-rudolf-ii",
+        "nodeTitle": "Rudolf II"
+      }
+    ]
+  },
+  "person-john-dee": {
+    "wikidataId": "Q201484",
+    "wikipediaTitle": "John_Dee",
+    "canonicalTitle": "John Dee",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-john-dee",
+        "nodeTitle": "John Dee"
+      }
+    ]
+  },
+  "person-edward-kelley": {
+    "wikidataId": "Q127080",
+    "wikipediaTitle": "Edward_Kelley",
+    "canonicalTitle": "Edward Kelley",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-edward-kelley",
+        "nodeTitle": "Edward Kelley"
+      }
+    ]
+  },
+  "person-tycho-brahe": {
+    "wikidataId": "Q36620",
+    "wikipediaTitle": "Tycho_Brahe",
+    "canonicalTitle": "Tycho Brahe",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-tycho-brahe",
+        "nodeTitle": "Tycho Brahe"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-tycho-brahe",
+        "nodeTitle": "Tycho Brahe"
+      }
+    ]
+  },
+  "person-johannes-kepler": {
+    "wikidataId": "Q8963",
+    "wikipediaTitle": "Johannes_Kepler",
+    "canonicalTitle": "Johannes Kepler",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-johannes-kepler",
+        "nodeTitle": "Johannes Kepler"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-johannes-kepler",
+        "nodeTitle": "Johannes Kepler"
+      }
+    ]
+  },
+  "person-michael-mastlin": {
+    "wikidataId": null,
+    "wikipediaTitle": "Michael_Mästlin",
+    "canonicalTitle": "Michael Mästlin",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-michael-mastlin",
+        "nodeTitle": "Michael Mästlin"
+      }
+    ]
+  },
+  "person-vilem-rozmberk": {
+    "wikidataId": null,
+    "wikipediaTitle": "Vilém_of_Rosenberg",
+    "canonicalTitle": "Vilém of Rožmberk",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-vilem-rozmberk",
+        "nodeTitle": "Vilém of Rožmberk"
+      }
+    ]
+  },
+  "person-robert-fludd": {
+    "wikidataId": "Q453697",
+    "wikipediaTitle": "Robert_Fludd",
+    "canonicalTitle": "Robert Fludd",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-robert-fludd",
+        "nodeTitle": "Robert Fludd"
+      }
+    ]
+  },
+  "person-thomas-vaughan": {
+    "wikidataId": "Q3397209",
+    "wikipediaTitle": "Thomas_Vaughan_(philosopher)",
+    "canonicalTitle": "Thomas Vaughan",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-thomas-vaughan",
+        "nodeTitle": "Thomas Vaughan"
+      }
+    ]
+  },
+  "person-elias-ashmole": {
+    "wikidataId": "Q471406",
+    "wikipediaTitle": "Elias_Ashmole",
+    "canonicalTitle": "Elias Ashmole",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-elias-ashmole",
+        "nodeTitle": "Elias Ashmole"
+      },
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-elias-ashmole",
+        "nodeTitle": "Elias Ashmole"
+      }
+    ]
+  },
+  "person-william-backhouse": {
+    "wikidataId": "Q8004902",
+    "wikipediaTitle": "William_Backhouse",
+    "canonicalTitle": "William Backhouse",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-william-backhouse",
+        "nodeTitle": "William Backhouse"
+      }
+    ]
+  },
+  "person-francis-bacon": {
+    "wikidataId": "Q37388",
+    "wikipediaTitle": "Francis_Bacon",
+    "canonicalTitle": "Francis Bacon",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-francis-bacon",
+        "nodeTitle": "Francis Bacon"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-francis-bacon",
+        "nodeTitle": "Francis Bacon"
+      }
+    ]
+  },
+  "person-frederick-v": {
+    "wikidataId": "Q57195",
+    "wikipediaTitle": "Frederick_V_of_the_Palatinate",
+    "canonicalTitle": "Frederick V, Elector Palatine",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-frederick-v",
+        "nodeTitle": "Frederick V, Elector Palatine"
+      }
+    ]
+  },
+  "person-elizabeth-stuart": {
+    "wikidataId": "Q158252",
+    "wikipediaTitle": "Elizabeth_Stuart,_Queen_of_Bohemia",
+    "canonicalTitle": "Elizabeth Stuart",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-elizabeth-stuart",
+        "nodeTitle": "Elizabeth Stuart"
+      }
+    ]
+  },
+  "person-moritz-hesse-kassel": {
+    "wikidataId": "Q551420",
+    "wikipediaTitle": "Maurice,_Landgrave_of_Hesse-Kassel",
+    "canonicalTitle": "Moritz of Hesse-Kassel",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-moritz-hesse-kassel",
+        "nodeTitle": "Moritz of Hesse-Kassel"
+      }
+    ]
+  },
+  "person-salomon-de-caus": {
+    "wikidataId": "Q385092",
+    "wikipediaTitle": "Salomon_de_Caus",
+    "canonicalTitle": "Salomon de Caus",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-salomon-de-caus",
+        "nodeTitle": "Salomon de Caus"
+      }
+    ]
+  },
+  "object-fama-fraternitatis": {
+    "wikidataId": "Q3643696",
+    "wikipediaTitle": "Fama_Fraternitatis",
+    "canonicalTitle": "Fama Fraternitatis",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-fama-fraternitatis",
+        "nodeTitle": "Fama Fraternitatis"
+      }
+    ]
+  },
+  "object-confessio-fraternitatis": {
+    "wikidataId": "Q3643674",
+    "wikipediaTitle": "Confessio_Fraternitatis",
+    "canonicalTitle": "Confessio Fraternitatis",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-confessio-fraternitatis",
+        "nodeTitle": "Confessio Fraternitatis"
+      }
+    ]
+  },
+  "object-chymical-wedding": {
+    "wikidataId": "Q2456034",
+    "wikipediaTitle": "Chymical_Wedding_of_Christian_Rosenkreutz",
+    "canonicalTitle": "Chymical Wedding of Christian Rosenkreutz",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-chymical-wedding",
+        "nodeTitle": "Chymical Wedding of Christian Rosenkreutz"
+      }
+    ]
+  },
+  "object-aurora": {
+    "wikidataId": null,
+    "wikipediaTitle": "Aurora_(Boehme)",
+    "canonicalTitle": "Aurora",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-aurora",
+        "nodeTitle": "Aurora"
+      }
+    ]
+  },
+  "object-mysterium-magnum": {
+    "wikidataId": "Q6948791",
+    "wikipediaTitle": "Mysterium_Magnum",
+    "canonicalTitle": "Mysterium Magnum",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-mysterium-magnum",
+        "nodeTitle": "Mysterium Magnum"
+      }
+    ]
+  },
+  "object-true-christianity": {
+    "wikidataId": null,
+    "wikipediaTitle": "True_Christianity_(book)",
+    "canonicalTitle": "True Christianity",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-true-christianity",
+        "nodeTitle": "True Christianity"
+      }
+    ]
+  },
+  "object-amphitheatrum": {
+    "wikidataId": null,
+    "wikipediaTitle": "Amphitheatrum_Sapientiae_Aeternae",
+    "canonicalTitle": "Amphitheatrum Sapientiae Aeternae",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-amphitheatrum",
+        "nodeTitle": "Amphitheatrum Sapientiae Aeternae"
+      }
+    ]
+  },
+  "object-atalanta-fugiens": {
+    "wikidataId": "Q3627850",
+    "wikipediaTitle": "Atalanta_Fugiens",
+    "canonicalTitle": "Atalanta Fugiens",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-atalanta-fugiens",
+        "nodeTitle": "Atalanta Fugiens"
+      }
+    ]
+  },
+  "object-basilica-chymica": {
+    "wikidataId": null,
+    "wikipediaTitle": "Basilica_chymica",
+    "canonicalTitle": "Basilica Chymica",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-basilica-chymica",
+        "nodeTitle": "Basilica Chymica"
+      }
+    ]
+  },
+  "object-utriusque-cosmi": {
+    "wikidataId": null,
+    "wikipediaTitle": "Utriusque_Cosmi",
+    "canonicalTitle": "Utriusque Cosmi Historia",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-utriusque-cosmi",
+        "nodeTitle": "Utriusque Cosmi Historia"
+      }
+    ]
+  },
+  "object-apologia-compendiaria": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Apologia Compendiaria",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-apologia-compendiaria",
+        "nodeTitle": "Apologia Compendiaria"
+      }
+    ]
+  },
+  "object-monas-hieroglyphica": {
+    "wikidataId": "Q908061",
+    "wikipediaTitle": "Monas_Hieroglyphica",
+    "canonicalTitle": "Monas Hieroglyphica",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-monas-hieroglyphica",
+        "nodeTitle": "Monas Hieroglyphica"
+      }
+    ]
+  },
+  "object-alchymia": {
+    "wikidataId": null,
+    "wikipediaTitle": "Alchymia_(Libavius)",
+    "canonicalTitle": "Alchymia",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-alchymia",
+        "nodeTitle": "Alchymia"
+      }
+    ]
+  },
+  "object-analysis-confessionis": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Analysis Confessionis Fraternitatis de Rosea Cruce",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-analysis-confessionis",
+        "nodeTitle": "Analysis Confessionis Fraternitatis de Rosea Cruce"
+      }
+    ]
+  },
+  "object-theatrum-chemicum-britannicum": {
+    "wikidataId": "Q4356652",
+    "wikipediaTitle": "Theatrum_Chemicum_Britannicum",
+    "canonicalTitle": "Theatrum Chemicum Britannicum",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-theatrum-chemicum-britannicum",
+        "nodeTitle": "Theatrum Chemicum Britannicum"
+      }
+    ]
+  },
+  "object-christianopolis": {
+    "wikidataId": null,
+    "wikipediaTitle": "Christianopolis",
+    "canonicalTitle": "Christianopolis",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-christianopolis",
+        "nodeTitle": "Christianopolis"
+      }
+    ]
+  },
+  "object-idea-medicinae": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Idea Medicinae Philosophicae",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-idea-medicinae",
+        "nodeTitle": "Idea Medicinae Philosophicae"
+      }
+    ]
+  },
+  "loc-tubingen": {
+    "wikidataId": "Q3806",
+    "wikipediaTitle": "Tübingen",
+    "canonicalTitle": "Tübingen",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-tubingen",
+        "nodeTitle": "Tübingen"
+      }
+    ]
+  },
+  "loc-prague": {
+    "wikidataId": "Q1085",
+    "wikipediaTitle": "Prague",
+    "canonicalTitle": "Prague",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-prague",
+        "nodeTitle": "Prague"
+      }
+    ]
+  },
+  "loc-heidelberg": {
+    "wikidataId": "Q2966",
+    "wikipediaTitle": "Heidelberg",
+    "canonicalTitle": "Heidelberg",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-heidelberg",
+        "nodeTitle": "Heidelberg"
+      }
+    ]
+  },
+  "loc-marburg": {
+    "wikidataId": "Q3869",
+    "wikipediaTitle": "Marburg",
+    "canonicalTitle": "Marburg",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-marburg",
+        "nodeTitle": "Marburg"
+      }
+    ]
+  },
+  "loc-gorlitz": {
+    "wikidataId": "Q4077",
+    "wikipediaTitle": "Görlitz",
+    "canonicalTitle": "Görlitz",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-gorlitz",
+        "nodeTitle": "Görlitz"
+      }
+    ]
+  },
+  "loc-kassel": {
+    "wikidataId": "Q2865",
+    "wikipediaTitle": "Kassel",
+    "canonicalTitle": "Kassel",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-kassel",
+        "nodeTitle": "Kassel"
+      }
+    ]
+  },
+  "loc-basel": {
+    "wikidataId": "Q78",
+    "wikipediaTitle": "Basel",
+    "canonicalTitle": "Basel",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-basel",
+        "nodeTitle": "Basel"
+      }
+    ]
+  },
+  "loc-augsburg": {
+    "wikidataId": "Q2749",
+    "wikipediaTitle": "Augsburg",
+    "canonicalTitle": "Augsburg",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-augsburg",
+        "nodeTitle": "Augsburg"
+      }
+    ]
+  },
+  "loc-the-hague": {
+    "wikidataId": "Q36600",
+    "wikipediaTitle": "The_Hague",
+    "canonicalTitle": "The Hague",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-the-hague",
+        "nodeTitle": "The Hague"
+      }
+    ]
+  },
+  "loc-trebon": {
+    "wikidataId": "Q773312",
+    "wikipediaTitle": "Třeboň",
+    "canonicalTitle": "Třeboň",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-trebon",
+        "nodeTitle": "Třeboň"
+      }
+    ]
+  },
+  "person-abraham-holzel": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Abraham Hölzel",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-abraham-holzel",
+        "nodeTitle": "Abraham Hölzel"
+      }
+    ]
+  },
+  "person-wilhelm-von-wense": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Wilhelm von Wense",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-wilhelm-von-wense",
+        "nodeTitle": "Wilhelm von Wense"
+      }
+    ]
+  },
+  "person-heinrich-petraeus": {
+    "wikidataId": "Q5700295",
+    "wikipediaTitle": "Heinrich_Petraeus",
+    "canonicalTitle": "Heinrich Petraeus",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-heinrich-petraeus",
+        "nodeTitle": "Heinrich Petraeus"
+      }
+    ]
+  },
+  "entity-tubingen-circle": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Tübingen Circle",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-tubingen-circle",
+        "nodeTitle": "Tübingen Circle"
+      }
+    ]
+  },
+  "entity-boehme-circle": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Boehme Circle (Görlitz)",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-boehme-circle",
+        "nodeTitle": "Boehme Circle (Görlitz)"
+      }
+    ]
+  },
+  "entity-manuscript-collector-network": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Manuscript Collector Network",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-manuscript-collector-network",
+        "nodeTitle": "Manuscript Collector Network"
+      }
+    ]
+  },
+  "entity-heidelberg-circle": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Heidelberg Intellectual Circle",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-heidelberg-circle",
+        "nodeTitle": "Heidelberg Intellectual Circle"
+      }
+    ]
+  },
+  "entity-hague-exile-court": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "The Hague Exile Court",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-hague-exile-court",
+        "nodeTitle": "The Hague Exile Court"
+      }
+    ]
+  },
+  "entity-rosicrucian-brotherhood": {
+    "wikidataId": "Q194267",
+    "wikipediaTitle": "Rosicrucianism",
+    "canonicalTitle": "Rosicrucian Brotherhood",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-rosicrucian-brotherhood",
+        "nodeTitle": "Rosicrucian Brotherhood"
+      }
+    ]
+  },
+  "entity-christian-rosenkreutz": {
+    "wikidataId": "Q841173",
+    "wikipediaTitle": "Christian_Rosenkreuz",
+    "canonicalTitle": "Christian Rosenkreutz",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-christian-rosenkreutz",
+        "nodeTitle": "Christian Rosenkreutz"
+      }
+    ]
+  },
+  "entity-paracelsianism": {
+    "wikidataId": "Q7133818",
+    "wikipediaTitle": "Paracelsianism",
+    "canonicalTitle": "Paracelsianism",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-paracelsianism",
+        "nodeTitle": "Paracelsianism"
+      }
+    ]
+  },
+  "entity-christian-theosophy": {
+    "wikidataId": "Q55635660",
+    "wikipediaTitle": "Christian_theosophy",
+    "canonicalTitle": "Christian Theosophy",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-christian-theosophy",
+        "nodeTitle": "Christian Theosophy"
+      }
+    ]
+  },
+  "entity-weigelianism": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Weigelianism",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-weigelianism",
+        "nodeTitle": "Weigelianism"
+      }
+    ]
+  },
+  "entity-schwenckfelder-movement": {
+    "wikidataId": "Q672023",
+    "wikipediaTitle": "Schwenkfelder_Church",
+    "canonicalTitle": "Schwenckfelder Movement",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-schwenckfelder-movement",
+        "nodeTitle": "Schwenckfelder Movement"
+      }
+    ]
+  },
+  "entity-severinian-school": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Severinian Paracelsianism",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-severinian-school",
+        "nodeTitle": "Severinian Paracelsianism"
+      }
+    ]
+  },
+  "entity-rosicrucian-furor": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "The Rosicrucian Furor",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-rosicrucian-furor",
+        "nodeTitle": "The Rosicrucian Furor"
+      }
+    ]
+  },
+  "entity-hermeticism": {
+    "wikidataId": "Q192933",
+    "wikipediaTitle": "Hermeticism",
+    "canonicalTitle": "Hermeticism (Early Modern)",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-hermeticism",
+        "nodeTitle": "Hermeticism (Early Modern)"
+      }
+    ]
+  },
+  "entity-university-tubingen": {
+    "wikidataId": "Q153978",
+    "wikipediaTitle": "University_of_Tübingen",
+    "canonicalTitle": "University of Tübingen",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-university-tubingen",
+        "nodeTitle": "University of Tübingen"
+      }
+    ]
+  },
+  "entity-university-marburg": {
+    "wikidataId": null,
+    "wikipediaTitle": "University_of_Marburg",
+    "canonicalTitle": "University of Marburg",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-university-marburg",
+        "nodeTitle": "University of Marburg"
+      }
+    ]
+  },
+  "entity-marburg-laboratory": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Marburg Chemical Laboratory",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-marburg-laboratory",
+        "nodeTitle": "Marburg Chemical Laboratory"
+      }
+    ]
+  },
+  "entity-court-rudolf-ii": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Court of Rudolf II",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-court-rudolf-ii",
+        "nodeTitle": "Court of Rudolf II"
+      }
+    ]
+  },
+  "entity-court-moritz": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Court of Moritz of Hesse-Kassel",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-court-moritz",
+        "nodeTitle": "Court of Moritz of Hesse-Kassel"
+      }
+    ]
+  },
+  "entity-court-frederick-v": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Palatine Court (Heidelberg)",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-court-frederick-v",
+        "nodeTitle": "Palatine Court (Heidelberg)"
+      }
+    ]
+  },
+  "entity-rozmberk-court": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Rožmberk Court (Třeboň)",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-rozmberk-court",
+        "nodeTitle": "Rožmberk Court (Třeboň)"
+      }
+    ]
+  },
+  "entity-de-bry-publishing": {
+    "wikidataId": "Q1696381",
+    "wikipediaTitle": "Johann_Theodor_de_Bry",
+    "canonicalTitle": "Johann Theodor de Bry Publishing House",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-de-bry-publishing",
+        "nodeTitle": "Johann Theodor de Bry Publishing House"
+      }
+    ]
+  },
+  "entity-lucas-jennis": {
+    "wikidataId": "Q1873081",
+    "wikipediaTitle": "Lucas_Jennis",
+    "canonicalTitle": "Lucas Jennis Publishing House",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-lucas-jennis",
+        "nodeTitle": "Lucas Jennis Publishing House"
+      }
+    ]
+  },
+  "entity-leibarzt": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Imperial Court Physician",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-leibarzt",
+        "nodeTitle": "Imperial Court Physician"
+      }
+    ]
+  },
+  "entity-professor-chymiatrie": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Professor of Chymiatrie",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-professor-chymiatrie",
+        "nodeTitle": "Professor of Chymiatrie"
+      }
+    ]
+  },
+  "person-daniel-cramer": {
+    "wikidataId": "Q95479",
+    "wikipediaTitle": "Daniel_Cramer",
+    "canonicalTitle": "Daniel Cramer",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-daniel-cramer",
+        "nodeTitle": "Daniel Cramer"
+      }
+    ]
+  },
+  "object-rosicrucian-emblems-cramer": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "The Rosicrucian Emblems of Daniel Cramer",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-rosicrucian-emblems-cramer",
+        "nodeTitle": "The Rosicrucian Emblems of Daniel Cramer"
+      }
+    ]
+  },
+  "person-jan-amos-comenius": {
+    "wikidataId": "Q12735",
+    "wikipediaTitle": "John_Amos_Comenius",
+    "canonicalTitle": "Jan Amos Comenius",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-jan-amos-comenius",
+        "nodeTitle": "Jan Amos Comenius"
+      }
+    ]
+  },
+  "person-samuel-hartlib": {
+    "wikidataId": "Q71033",
+    "wikipediaTitle": "Samuel_Hartlib",
+    "canonicalTitle": "Samuel Hartlib",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-samuel-hartlib",
+        "nodeTitle": "Samuel Hartlib"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-samuel-hartlib",
+        "nodeTitle": "Samuel Hartlib"
+      }
+    ]
+  },
+  "person-john-dury": {
+    "wikidataId": "Q710665",
+    "wikipediaTitle": "John_Dury",
+    "canonicalTitle": "John Dury",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-john-dury",
+        "nodeTitle": "John Dury"
+      }
+    ]
+  },
+  "person-john-heydon": {
+    "wikidataId": "Q1700457",
+    "wikipediaTitle": "John_Heydon_(astrologer)",
+    "canonicalTitle": "John Heydon",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-john-heydon",
+        "nodeTitle": "John Heydon"
+      }
+    ]
+  },
+  "person-thomas-henshaw": {
+    "wikidataId": "Q7790627",
+    "wikipediaTitle": "Thomas_Henshaw_(alchemist)",
+    "canonicalTitle": "Thomas Henshaw",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-thomas-henshaw",
+        "nodeTitle": "Thomas Henshaw"
+      }
+    ]
+  },
+  "entity-hartlib-circle": {
+    "wikidataId": "Q604837",
+    "wikipediaTitle": "Hartlib_Circle",
+    "canonicalTitle": "Hartlib Circle",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-hartlib-circle",
+        "nodeTitle": "Hartlib Circle"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-hartlib-circle",
+        "nodeTitle": "Hartlib Circle"
+      }
+    ]
+  },
+  "object-pansophiae-prodromus": {
+    "wikidataId": "Q771349",
+    "wikipediaTitle": "Pansophism",
+    "canonicalTitle": "Pansophiae Prodromus",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-pansophiae-prodromus",
+        "nodeTitle": "Pansophiae Prodromus"
+      }
+    ]
+  },
+  "object-via-lucis": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Via Lucis",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-via-lucis",
+        "nodeTitle": "Via Lucis"
+      }
+    ]
+  },
+  "object-didactica-magna": {
+    "wikidataId": null,
+    "wikipediaTitle": "Didactica_Magna",
+    "canonicalTitle": "Didactica Magna",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-didactica-magna",
+        "nodeTitle": "Didactica Magna"
+      }
+    ]
+  },
+  "object-holy-guide": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "The Holy Guide",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-holy-guide",
+        "nodeTitle": "The Holy Guide"
+      }
+    ]
+  },
+  "object-reformed-school": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "The Reformed School",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-reformed-school",
+        "nodeTitle": "The Reformed School"
+      }
+    ]
+  },
+  "object-reformed-librarie-keeper": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "The Reformed Librarie-Keeper",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-reformed-librarie-keeper",
+        "nodeTitle": "The Reformed Librarie-Keeper"
+      }
+    ]
+  },
+  "loc-elbing": {
+    "wikidataId": "Q104712",
+    "wikipediaTitle": "Elbląg",
+    "canonicalTitle": "Elbing",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-elbing",
+        "nodeTitle": "Elbing"
+      }
+    ]
+  },
+  "loc-amsterdam": {
+    "wikidataId": "Q727",
+    "wikipediaTitle": "Amsterdam",
+    "canonicalTitle": "Amsterdam",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-amsterdam",
+        "nodeTitle": "Amsterdam"
+      }
+    ]
+  },
+  "person-nicolaus-copernicus": {
+    "wikidataId": "Q619",
+    "wikipediaTitle": "Nicolaus_Copernicus",
+    "canonicalTitle": "Nicolaus Copernicus",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-nicolaus-copernicus",
+        "nodeTitle": "Nicolaus Copernicus"
+      }
+    ]
+  },
+  "person-galileo-galilei": {
+    "wikidataId": "Q307",
+    "wikipediaTitle": "Galileo_Galilei",
+    "canonicalTitle": "Galileo Galilei",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-galileo-galilei",
+        "nodeTitle": "Galileo Galilei"
+      }
+    ]
+  },
+  "person-robert-boyle": {
+    "wikidataId": "Q43393",
+    "wikipediaTitle": "Robert_Boyle",
+    "canonicalTitle": "Robert Boyle",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-robert-boyle",
+        "nodeTitle": "Robert Boyle"
+      }
+    ]
+  },
+  "person-robert-hooke": {
+    "wikidataId": "Q47081",
+    "wikipediaTitle": "Robert_Hooke",
+    "canonicalTitle": "Robert Hooke",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-robert-hooke",
+        "nodeTitle": "Robert Hooke"
+      }
+    ]
+  },
+  "person-gottfried-leibniz": {
+    "wikidataId": "Q9047",
+    "wikipediaTitle": "Gottfried_Wilhelm_Leibniz",
+    "canonicalTitle": "Gottfried Wilhelm Leibniz",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-gottfried-leibniz",
+        "nodeTitle": "Gottfried Wilhelm Leibniz"
+      }
+    ]
+  },
+  "person-edmond-halley": {
+    "wikidataId": "Q41790",
+    "wikipediaTitle": "Edmond_Halley",
+    "canonicalTitle": "Edmond Halley",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-edmond-halley",
+        "nodeTitle": "Edmond Halley"
+      }
+    ]
+  },
+  "person-christiaan-huygens": {
+    "wikidataId": "Q39599",
+    "wikipediaTitle": "Christiaan_Huygens",
+    "canonicalTitle": "Christiaan Huygens",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-christiaan-huygens",
+        "nodeTitle": "Christiaan Huygens"
+      }
+    ]
+  },
+  "person-john-wilkins": {
+    "wikidataId": "Q557652",
+    "wikipediaTitle": "John_Wilkins",
+    "canonicalTitle": "John Wilkins",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-john-wilkins",
+        "nodeTitle": "John Wilkins"
+      }
+    ]
+  },
+  "person-robert-bellarmine": {
+    "wikidataId": "Q298908",
+    "wikipediaTitle": "Robert_Bellarmine",
+    "canonicalTitle": "Robert Bellarmine",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-robert-bellarmine",
+        "nodeTitle": "Robert Bellarmine"
+      }
+    ]
+  },
+  "person-urban-viii": {
+    "wikidataId": "Q134556",
+    "wikipediaTitle": "Pope_Urban_VIII",
+    "canonicalTitle": "Pope Urban VIII",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-urban-viii",
+        "nodeTitle": "Pope Urban VIII"
+      }
+    ]
+  },
+  "person-maria-cunitz": {
+    "wikidataId": "Q72429",
+    "wikipediaTitle": "Maria_Cunitz",
+    "canonicalTitle": "Maria Cunitz",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-maria-cunitz",
+        "nodeTitle": "Maria Cunitz"
+      }
+    ]
+  },
+  "person-margaret-cavendish": {
+    "wikidataId": "Q234858",
+    "wikipediaTitle": "Margaret_Cavendish,_Duchess_of_Newcastle-upon-Tyne",
+    "canonicalTitle": "Margaret Cavendish",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-margaret-cavendish",
+        "nodeTitle": "Margaret Cavendish"
+      }
+    ]
+  },
+  "object-de-revolutionibus": {
+    "wikidataId": "Q211423",
+    "wikipediaTitle": "De_revolutionibus_orbium_coelestium",
+    "canonicalTitle": "De revolutionibus orbium coelestium",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-de-revolutionibus",
+        "nodeTitle": "De revolutionibus orbium coelestium"
+      }
+    ]
+  },
+  "object-astronomia-nova": {
+    "wikidataId": "Q720120",
+    "wikipediaTitle": "Astronomia_nova",
+    "canonicalTitle": "Astronomia nova",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-astronomia-nova",
+        "nodeTitle": "Astronomia nova"
+      }
+    ]
+  },
+  "object-sidereus-nuncius": {
+    "wikidataId": "Q652054",
+    "wikipediaTitle": "Sidereus_Nuncius",
+    "canonicalTitle": "Sidereus Nuncius",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-sidereus-nuncius",
+        "nodeTitle": "Sidereus Nuncius"
+      }
+    ]
+  },
+  "object-dialogo": {
+    "wikidataId": "Q1017439",
+    "wikipediaTitle": "Dialogue_Concerning_the_Two_Chief_World_Systems",
+    "canonicalTitle": "Dialogue Concerning the Two Chief World Systems",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-dialogo",
+        "nodeTitle": "Dialogue Concerning the Two Chief World Systems"
+      }
+    ]
+  },
+  "object-novum-organum": {
+    "wikidataId": "Q2657053",
+    "wikipediaTitle": "Novum_Organum",
+    "canonicalTitle": "Novum Organum",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-novum-organum",
+        "nodeTitle": "Novum Organum"
+      }
+    ]
+  },
+  "object-sceptical-chymist": {
+    "wikidataId": "Q2063476",
+    "wikipediaTitle": "The_Sceptical_Chymist",
+    "canonicalTitle": "The Sceptical Chymist",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-sceptical-chymist",
+        "nodeTitle": "The Sceptical Chymist"
+      }
+    ]
+  },
+  "object-principia": {
+    "wikidataId": "Q205934",
+    "wikipediaTitle": "Philosophiæ_Naturalis_Principia_Mathematica",
+    "canonicalTitle": "Philosophiæ Naturalis Principia Mathematica",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-principia",
+        "nodeTitle": "Philosophiæ Naturalis Principia Mathematica"
+      }
+    ]
+  },
+  "object-philosophical-transactions": {
+    "wikidataId": "Q2306608",
+    "wikipediaTitle": "Philosophical_Transactions_of_the_Royal_Society",
+    "canonicalTitle": "Philosophical Transactions of the Royal Society",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-philosophical-transactions",
+        "nodeTitle": "Philosophical Transactions of the Royal Society"
+      }
+    ]
+  },
+  "object-urania-propitia": {
+    "wikidataId": "Q7899795",
+    "wikipediaTitle": "Urania_propitia",
+    "canonicalTitle": "Urania Propitia",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-urania-propitia",
+        "nodeTitle": "Urania Propitia"
+      }
+    ]
+  },
+  "location-prague": {
+    "wikidataId": "Q1085",
+    "wikipediaTitle": "Prague",
+    "canonicalTitle": "Prague",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-prague",
+        "nodeTitle": "Prague"
+      }
+    ]
+  },
+  "entity-roman-inquisition": {
+    "wikidataId": "Q1046250",
+    "wikipediaTitle": "Roman_Inquisition",
+    "canonicalTitle": "Roman Inquisition",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-roman-inquisition",
+        "nodeTitle": "Roman Inquisition"
+      }
+    ]
+  },
+  "entity-medici-court": {
+    "wikidataId": "Q37317",
+    "wikipediaTitle": "House_of_Medici",
+    "canonicalTitle": "Medici Court",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-medici-court",
+        "nodeTitle": "Medici Court"
+      }
+    ]
+  },
+  "entity-habsburg-court": {
+    "wikidataId": "Q5765",
+    "wikipediaTitle": "Rudolf_II,_Holy_Roman_Emperor",
+    "canonicalTitle": "Habsburg Court (Prague)",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-habsburg-court",
+        "nodeTitle": "Habsburg Court (Prague)"
+      }
+    ]
+  },
+  "entity-academie-des-sciences": {
+    "wikidataId": "Q188771",
+    "wikipediaTitle": "French_Academy_of_Sciences",
+    "canonicalTitle": "Académie des Sciences",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-academie-des-sciences",
+        "nodeTitle": "Académie des Sciences"
+      }
+    ]
+  },
+  "person-rene-descartes": {
+    "wikidataId": "Q9191",
+    "wikipediaTitle": "René_Descartes",
+    "canonicalTitle": "René Descartes",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-rene-descartes",
+        "nodeTitle": "René Descartes"
+      }
+    ]
+  },
+  "person-marin-mersenne": {
+    "wikidataId": "Q101072",
+    "wikipediaTitle": "Marin_Mersenne",
+    "canonicalTitle": "Marin Mersenne",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-marin-mersenne",
+        "nodeTitle": "Marin Mersenne"
+      }
+    ]
+  },
+  "person-christopher-wren": {
+    "wikidataId": "Q41279",
+    "wikipediaTitle": "Christopher_Wren",
+    "canonicalTitle": "Christopher Wren",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-christopher-wren",
+        "nodeTitle": "Christopher Wren"
+      }
+    ]
+  },
+  "person-henry-oldenburg": {
+    "wikidataId": "Q60017",
+    "wikipediaTitle": "Henry_Oldenburg",
+    "canonicalTitle": "Henry Oldenburg",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-henry-oldenburg",
+        "nodeTitle": "Henry Oldenburg"
+      }
+    ]
+  },
+  "person-evangelista-torricelli": {
+    "wikidataId": "Q47159",
+    "wikipediaTitle": "Evangelista_Torricelli",
+    "canonicalTitle": "Evangelista Torricelli",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-evangelista-torricelli",
+        "nodeTitle": "Evangelista Torricelli"
+      }
+    ]
+  },
+  "person-blaise-pascal": {
+    "wikidataId": "Q1290",
+    "wikipediaTitle": "Blaise_Pascal",
+    "canonicalTitle": "Blaise Pascal",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-blaise-pascal",
+        "nodeTitle": "Blaise Pascal"
+      }
+    ]
+  },
+  "person-otto-von-guericke": {
+    "wikidataId": "Q60025",
+    "wikipediaTitle": "Otto_von_Guericke",
+    "canonicalTitle": "Otto von Guericke",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-otto-von-guericke",
+        "nodeTitle": "Otto von Guericke"
+      }
+    ]
+  },
+  "person-william-gilbert": {
+    "wikidataId": "Q192330",
+    "wikipediaTitle": "William_Gilbert_(physician)",
+    "canonicalTitle": "William Gilbert",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-william-gilbert",
+        "nodeTitle": "William Gilbert"
+      }
+    ]
+  },
+  "person-andreas-vesalius": {
+    "wikidataId": "Q142862",
+    "wikipediaTitle": "Andreas_Vesalius",
+    "canonicalTitle": "Andreas Vesalius",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-andreas-vesalius",
+        "nodeTitle": "Andreas Vesalius"
+      }
+    ]
+  },
+  "person-giovanni-borelli": {
+    "wikidataId": "Q328441",
+    "wikipediaTitle": "Giovanni_Alfonso_Borelli",
+    "canonicalTitle": "Giovanni Alfonso Borelli",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-giovanni-borelli",
+        "nodeTitle": "Giovanni Alfonso Borelli"
+      }
+    ]
+  },
+  "person-ole-romer": {
+    "wikidataId": "Q83371",
+    "wikipediaTitle": "Ole_Rømer",
+    "canonicalTitle": "Ole Rømer",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-ole-romer",
+        "nodeTitle": "Ole Rømer"
+      }
+    ]
+  },
+  "person-marcello-malpighi": {
+    "wikidataId": "Q185092",
+    "wikipediaTitle": "Marcello_Malpighi",
+    "canonicalTitle": "Marcello Malpighi",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-marcello-malpighi",
+        "nodeTitle": "Marcello Malpighi"
+      }
+    ]
+  },
+  "person-robert-moray": {
+    "wikidataId": "Q719623",
+    "wikipediaTitle": "Robert_Moray",
+    "canonicalTitle": "Sir Robert Moray",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-robert-moray",
+        "nodeTitle": "Sir Robert Moray"
+      }
+    ]
+  },
+  "loc-warrington": {
+    "wikidataId": "Q215733",
+    "wikipediaTitle": "Warrington",
+    "canonicalTitle": "Warrington",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "loc-warrington",
+        "nodeTitle": "Warrington"
+      }
+    ]
+  },
+  "loc-newcastle-upon-tyne": {
+    "wikidataId": "Q1425428",
+    "wikipediaTitle": "Newcastle_upon_Tyne",
+    "canonicalTitle": "Newcastle upon Tyne",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "loc-newcastle-upon-tyne",
+        "nodeTitle": "Newcastle upon Tyne"
+      }
+    ]
+  },
+  "loc-edinburgh": {
+    "wikidataId": "Q23436",
+    "wikipediaTitle": "Edinburgh",
+    "canonicalTitle": "Edinburgh",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "loc-edinburgh",
+        "nodeTitle": "Edinburgh"
+      }
+    ]
+  },
+  "entity-premier-grand-lodge-england": {
+    "wikipediaTitle": "Premier_Grand_Lodge_of_England",
+    "canonicalTitle": "Premier Grand Lodge of England",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "entity-premier-grand-lodge-england",
+        "nodeTitle": "Premier Grand Lodge of England"
+      }
+    ]
+  },
+  "entity-lodge-edinburgh": {
+    "wikipediaTitle": "Lodge_of_Edinburgh_(Mary's_Chapel)_No._1",
+    "canonicalTitle": "Lodge of Edinburgh (Mary's Chapel) No. 1",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "entity-lodge-edinburgh",
+        "nodeTitle": "Lodge of Edinburgh (Mary's Chapel) No. 1"
+      }
+    ]
+  },
+  "person-anthony-sayer": {
+    "wikidataId": "Q3618535",
+    "wikipediaTitle": "Anthony_Sayer",
+    "canonicalTitle": "Anthony Sayer",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-anthony-sayer",
+        "nodeTitle": "Anthony Sayer"
+      }
+    ]
+  },
+  "person-george-payne": {
+    "wikidataId": "Q1508044",
+    "wikipediaTitle": "George_Payne_(Freemason)",
+    "canonicalTitle": "George Payne",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-george-payne",
+        "nodeTitle": "George Payne"
+      }
+    ]
+  },
+  "loc-goose-gridiron-tavern": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Goose and Gridiron Ale-house",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "loc-goose-gridiron-tavern",
+        "nodeTitle": "Goose and Gridiron Ale-house"
+      }
+    ]
+  },
+  "loc-apple-tree-tavern": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Apple Tree Tavern",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "loc-apple-tree-tavern",
+        "nodeTitle": "Apple Tree Tavern"
+      }
+    ]
+  },
+  "entity-lodge-antiquity": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Lodge of Antiquity No. 2",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "entity-lodge-antiquity",
+        "nodeTitle": "Lodge of Antiquity No. 2"
+      }
+    ]
+  },
+  "entity-lodge-fortitude-cumberland": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Lodge of Fortitude and Old Cumberland No. 12",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "entity-lodge-fortitude-cumberland",
+        "nodeTitle": "Lodge of Fortitude and Old Cumberland No. 12"
+      }
+    ]
+  },
+  "entity-lodge-royal-somerset-inverness": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Royal Somerset House and Inverness Lodge No. 4",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "entity-lodge-royal-somerset-inverness",
+        "nodeTitle": "Royal Somerset House and Inverness Lodge No. 4"
+      }
+    ]
+  },
+  "person-john-desaguliers": {
+    "wikidataId": "Q658008",
+    "wikipediaTitle": "John_Theophilus_Desaguliers",
+    "canonicalTitle": "John Theophilus Desaguliers",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-john-desaguliers",
+        "nodeTitle": "John Theophilus Desaguliers"
+      }
+    ]
+  },
+  "person-james-anderson": {
+    "wikidataId": "Q3160845",
+    "wikipediaTitle": "James_Anderson_(Freemason)",
+    "canonicalTitle": "Rev. James Anderson",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-james-anderson",
+        "nodeTitle": "Rev. James Anderson"
+      }
+    ]
+  },
+  "object-constitutions-1723": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "The Constitutions of the Free-Masons (1723)",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "object-constitutions-1723",
+        "nodeTitle": "The Constitutions of the Free-Masons (1723)"
+      }
+    ]
+  },
+  "person-john-montagu": {
+    "wikidataId": "Q3062451",
+    "wikipediaTitle": "John_Montagu,_2nd_Duke_of_Montagu",
+    "canonicalTitle": "John Montagu, 2nd Duke of Montagu",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-john-montagu",
+        "nodeTitle": "John Montagu, 2nd Duke of Montagu"
+      }
+    ]
+  },
+  "person-john-pine": {
+    "wikidataId": "Q6252938",
+    "wikipediaTitle": "John_Pine",
+    "canonicalTitle": "John Pine",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-john-pine",
+        "nodeTitle": "John Pine"
+      }
+    ]
+  },
+  "person-william-stukeley": {
+    "wikidataId": "Q1381018",
+    "wikipediaTitle": "William_Stukeley",
+    "canonicalTitle": "William Stukeley",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-william-stukeley",
+        "nodeTitle": "William Stukeley"
+      }
+    ]
+  },
+  "person-philip-wharton": {
+    "wikidataId": "Q333527",
+    "wikipediaTitle": "Philip_Wharton,_1st_Duke_of_Wharton",
+    "canonicalTitle": "Philip Wharton, 1st Duke of Wharton",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-philip-wharton",
+        "nodeTitle": "Philip Wharton, 1st Duke of Wharton"
+      }
+    ]
+  },
+  "person-henry-mainwaring": {
+    "wikidataId": null,
+    "wikipediaTitle": null,
+    "canonicalTitle": "Colonel Henry Mainwaring",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-henry-mainwaring",
+        "nodeTitle": "Colonel Henry Mainwaring"
+      }
+    ]
+  },
+  "loc-rummer-grapes-tavern": {
+    "wikipediaTitle": null,
+    "canonicalTitle": "Rummer and Grapes Tavern",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "loc-rummer-grapes-tavern",
+        "nodeTitle": "Rummer and Grapes Tavern"
+      }
+    ]
+  },
+  "entity-society-antiquaries": {
+    "wikidataId": "Q653553",
+    "wikipediaTitle": "Society_of_Antiquaries_of_London",
+    "canonicalTitle": "Society of Antiquaries of London",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "entity-society-antiquaries",
+        "nodeTitle": "Society of Antiquaries of London"
+      }
+    ]
+  },
+  "person-pierre-simon-laplace": {
+    "wikidataId": "Q186596",
+    "wikipediaTitle": "Pierre-Simon_Laplace",
+    "canonicalTitle": "Pierre-Simon Laplace",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-pierre-simon-laplace",
+        "nodeTitle": "Pierre-Simon Laplace"
+      }
+    ]
+  },
+  "person-adolphe-quetelet": {
+    "wikidataId": "Q76584",
+    "wikipediaTitle": "Adolphe_Quetelet",
+    "canonicalTitle": "Adolphe Quetelet",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-adolphe-quetelet",
+        "nodeTitle": "Adolphe Quetelet"
+      }
+    ]
+  },
+  "person-ronald-fisher": {
+    "wikidataId": "Q216723",
+    "wikipediaTitle": "Ronald_Fisher",
+    "canonicalTitle": "Ronald A. Fisher",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-ronald-fisher",
+        "nodeTitle": "Ronald A. Fisher"
+      }
+    ]
+  },
+  "person-carl-friedrich-gauss": {
+    "wikidataId": "Q6722",
+    "wikipediaTitle": "Carl_Friedrich_Gauss",
+    "canonicalTitle": "Carl Friedrich Gauss",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-carl-friedrich-gauss",
+        "nodeTitle": "Carl Friedrich Gauss"
+      }
+    ]
+  },
+  "person-marquis-de-condorcet": {
+    "wikidataId": "Q37979",
+    "wikipediaTitle": "Marquis_de_Condorcet",
+    "canonicalTitle": "Marquis de Condorcet",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-marquis-de-condorcet",
+        "nodeTitle": "Marquis de Condorcet"
+      }
+    ]
+  },
+  "person-simeon-denis-poisson": {
+    "wikidataId": "Q49767",
+    "wikipediaTitle": "Siméon_Denis_Poisson",
+    "canonicalTitle": "Siméon Denis Poisson",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-simeon-denis-poisson",
+        "nodeTitle": "Siméon Denis Poisson"
+      }
+    ]
+  },
+  "person-thomas-bayes": {
+    "wikidataId": "Q318630",
+    "wikipediaTitle": "Thomas_Bayes",
+    "canonicalTitle": "Thomas Bayes",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-thomas-bayes",
+        "nodeTitle": "Thomas Bayes"
+      }
+    ]
+  },
+  "person-abraham-de-moivre": {
+    "wikidataId": "Q310551",
+    "wikipediaTitle": "Abraham_de_Moivre",
+    "canonicalTitle": "Abraham de Moivre",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-abraham-de-moivre",
+        "nodeTitle": "Abraham de Moivre"
+      }
+    ]
+  },
+  "person-francis-galton": {
+    "wikidataId": "Q131566",
+    "wikipediaTitle": "Francis_Galton",
+    "canonicalTitle": "Francis Galton",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-francis-galton",
+        "nodeTitle": "Francis Galton"
+      }
+    ]
+  },
+  "person-karl-pearson": {
+    "wikidataId": "Q180850",
+    "wikipediaTitle": "Karl_Pearson",
+    "canonicalTitle": "Karl Pearson",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-karl-pearson",
+        "nodeTitle": "Karl Pearson"
+      }
+    ]
+  },
+  "person-florence-nightingale": {
+    "wikidataId": "Q38348",
+    "wikipediaTitle": "Florence_Nightingale",
+    "canonicalTitle": "Florence Nightingale",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-florence-nightingale",
+        "nodeTitle": "Florence Nightingale"
+      }
+    ]
+  },
+  "person-jerzy-neyman": {
+    "wikidataId": "Q440568",
+    "wikipediaTitle": "Jerzy_Neyman",
+    "canonicalTitle": "Jerzy Neyman",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-jerzy-neyman",
+        "nodeTitle": "Jerzy Neyman"
+      }
+    ]
+  },
+  "person-egon-pearson": {
+    "wikidataId": "Q1302219",
+    "wikipediaTitle": "Egon_Pearson",
+    "canonicalTitle": "Egon Pearson",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-egon-pearson",
+        "nodeTitle": "Egon Pearson"
+      }
+    ]
+  },
+  "person-adrien-marie-legendre": {
+    "wikidataId": "Q191799",
+    "wikipediaTitle": "Adrien-Marie_Legendre",
+    "canonicalTitle": "Adrien-Marie Legendre",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-adrien-marie-legendre",
+        "nodeTitle": "Adrien-Marie Legendre"
+      }
+    ]
+  },
+  "person-jacob-bernoulli": {
+    "wikidataId": "Q122420",
+    "wikipediaTitle": "Jacob_Bernoulli",
+    "canonicalTitle": "Jacob Bernoulli",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-jacob-bernoulli",
+        "nodeTitle": "Jacob Bernoulli"
+      }
+    ]
+  },
+  "person-william-sealy-gosset": {
+    "wikidataId": "Q317584",
+    "wikipediaTitle": "William_Sealy_Gosset",
+    "canonicalTitle": "William Sealy Gosset",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-william-sealy-gosset",
+        "nodeTitle": "William Sealy Gosset"
+      }
+    ]
+  },
+  "person-andre-michel-guerry": {
+    "wikidataId": "Q2847710",
+    "wikipediaTitle": "André-Michel_Guerry",
+    "canonicalTitle": "André-Michel Guerry",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-andre-michel-guerry",
+        "nodeTitle": "André-Michel Guerry"
+      }
+    ]
+  },
+  "person-william-farr": {
+    "wikidataId": "Q317584",
+    "wikipediaTitle": "William_Farr",
+    "canonicalTitle": "William Farr",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-william-farr",
+        "nodeTitle": "William Farr"
+      }
+    ]
+  },
+  "person-charles-darwin": {
+    "wikidataId": "Q1035",
+    "wikipediaTitle": "Charles_Darwin",
+    "canonicalTitle": "Charles Darwin",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-charles-darwin",
+        "nodeTitle": "Charles Darwin"
+      }
+    ]
+  },
+  "person-andrey-markov": {
+    "wikidataId": "Q140282",
+    "wikipediaTitle": "Andrey_Markov",
+    "canonicalTitle": "Andrey Markov",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-andrey-markov",
+        "nodeTitle": "Andrey Markov"
+      }
+    ]
+  },
+  "person-emile-durkheim": {
+    "wikidataId": "Q44279",
+    "wikipediaTitle": "Émile_Durkheim",
+    "canonicalTitle": "Émile Durkheim",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-emile-durkheim",
+        "nodeTitle": "Émile Durkheim"
+      }
+    ]
+  },
+  "object-theorie-analytique-des-probabilites": {
+    "wikidataId": "Q3527157",
+    "wikipediaTitle": "Théorie_analytique_des_probabilités",
+    "canonicalTitle": "Théorie analytique des probabilités",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-theorie-analytique-des-probabilites",
+        "nodeTitle": "Théorie analytique des probabilités"
+      }
+    ]
+  },
+  "object-essai-philosophique-sur-les-probabilites": {
+    "wikidataId": "Q19169639",
+    "wikipediaTitle": "A_Philosophical_Essay_on_Probabilities",
+    "canonicalTitle": "Essai philosophique sur les probabilités",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-essai-philosophique-sur-les-probabilites",
+        "nodeTitle": "Essai philosophique sur les probabilités"
+      }
+    ]
+  },
+  "object-sur-l-homme": {
+    "wikidataId": null,
+    "wikipediaTitle": "A_Treatise_on_Man_and_the_Development_of_His_Faculties",
+    "canonicalTitle": "Sur l'homme et le développement de ses facultés",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-sur-l-homme",
+        "nodeTitle": "Sur l'homme et le développement de ses facultés"
+      }
+    ]
+  },
+  "object-statistical-methods-for-research-workers": {
+    "wikidataId": "Q25927621",
+    "wikipediaTitle": "Statistical_Methods_for_Research_Workers",
+    "canonicalTitle": "Statistical Methods for Research Workers",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-statistical-methods-for-research-workers",
+        "nodeTitle": "Statistical Methods for Research Workers"
+      }
+    ]
+  },
+  "object-design-of-experiments": {
+    "wikidataId": "Q7726887",
+    "wikipediaTitle": "The_Design_of_Experiments",
+    "canonicalTitle": "The Design of Experiments",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-design-of-experiments",
+        "nodeTitle": "The Design of Experiments"
+      }
+    ]
+  },
+  "object-essay-towards-solving-a-problem": {
+    "wikidataId": "Q4749933",
+    "wikipediaTitle": "An_Essay_towards_solving_a_Problem_in_the_Doctrine_of_Chances",
+    "canonicalTitle": "An Essay towards solving a Problem in the Doctrine of Chances",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-essay-towards-solving-a-problem",
+        "nodeTitle": "An Essay towards solving a Problem in the Doctrine of Chances"
+      }
+    ]
+  },
+  "object-ars-conjectandi": {
+    "wikidataId": "Q623586",
+    "wikipediaTitle": "Ars_Conjectandi",
+    "canonicalTitle": "Ars Conjectandi",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-ars-conjectandi",
+        "nodeTitle": "Ars Conjectandi"
+      }
+    ]
+  },
+  "object-doctrine-of-chances": {
+    "wikidataId": "Q1757843",
+    "wikipediaTitle": "The_Doctrine_of_Chances",
+    "canonicalTitle": "The Doctrine of Chances",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-doctrine-of-chances",
+        "nodeTitle": "The Doctrine of Chances"
+      }
+    ]
+  },
+  "object-hereditary-genius": {
+    "wikidataId": "Q5734888",
+    "wikipediaTitle": "Hereditary_Genius",
+    "canonicalTitle": "Hereditary Genius",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-hereditary-genius",
+        "nodeTitle": "Hereditary Genius"
+      }
+    ]
+  },
+  "object-natural-inheritance": {
+    "wikidataId": "Q51508521",
+    "wikipediaTitle": "Natural_Inheritance",
+    "canonicalTitle": "Natural Inheritance",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-natural-inheritance",
+        "nodeTitle": "Natural Inheritance"
+      }
+    ]
+  },
+  "object-grammar-of-science": {
+    "wikidataId": "Q7734628",
+    "wikipediaTitle": "The_Grammar_of_Science",
+    "canonicalTitle": "The Grammar of Science",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-grammar-of-science",
+        "nodeTitle": "The Grammar of Science"
+      }
+    ]
+  },
+  "object-le-suicide": {
+    "wikidataId": "Q2088170",
+    "wikipediaTitle": "Suicide_(Durkheim_book)",
+    "canonicalTitle": "Le Suicide",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-le-suicide",
+        "nodeTitle": "Le Suicide"
+      }
+    ]
+  },
+  "location-ecole-polytechnique": {
+    "wikidataId": "Q273626",
+    "wikipediaTitle": "École_Polytechnique",
+    "canonicalTitle": "École Polytechnique",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "location-ecole-polytechnique",
+        "nodeTitle": "École Polytechnique"
+      }
+    ]
+  },
+  "location-university-college-london": {
+    "wikidataId": "Q193196",
+    "wikipediaTitle": "University_College_London",
+    "canonicalTitle": "University College London",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "location-university-college-london",
+        "nodeTitle": "University College London"
+      }
+    ]
+  },
+  "location-rothamsted-experimental-station": {
+    "wikidataId": "Q2157227",
+    "wikipediaTitle": "Rothamsted_Research",
+    "canonicalTitle": "Rothamsted Experimental Station",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "location-rothamsted-experimental-station",
+        "nodeTitle": "Rothamsted Experimental Station"
+      }
+    ]
+  },
+  "entity-biometrika": {
+    "wikidataId": "Q673175",
+    "wikipediaTitle": "Biometrika",
+    "canonicalTitle": "Biometrika",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "entity-biometrika",
+        "nodeTitle": "Biometrika"
+      }
+    ]
+  },
+  "entity-royal-statistical-society": {
+    "wikidataId": "Q1423882",
+    "wikipediaTitle": "Royal_Statistical_Society",
+    "canonicalTitle": "Royal Statistical Society",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "entity-royal-statistical-society",
+        "nodeTitle": "Royal Statistical Society"
+      }
+    ]
+  },
+  "entity-eugenics-education-society": {
+    "wikidataId": "Q5407573",
+    "wikipediaTitle": "Eugenics_Society",
+    "canonicalTitle": "Eugenics Education Society",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "entity-eugenics-education-society",
+        "nodeTitle": "Eugenics Education Society"
+      }
+    ]
+  },
+  "person-johann-heinrich-lambert": {
+    "wikidataId": "Q76610",
+    "wikipediaTitle": "Johann_Heinrich_Lambert",
+    "canonicalTitle": "Johann Heinrich Lambert",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-johann-heinrich-lambert",
+        "nodeTitle": "Johann Heinrich Lambert"
+      }
+    ]
+  },
+  "person-friedrich-bessel": {
+    "wikidataId": "Q78247",
+    "wikipediaTitle": "Friedrich_Bessel",
+    "canonicalTitle": "Friedrich Wilhelm Bessel",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-friedrich-bessel",
+        "nodeTitle": "Friedrich Wilhelm Bessel"
+      }
+    ]
+  },
+  "person-johann-franz-encke": {
+    "wikidataId": "Q57330",
+    "wikipediaTitle": "Johann_Franz_Encke",
+    "canonicalTitle": "Johann Franz Encke",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-johann-franz-encke",
+        "nodeTitle": "Johann Franz Encke"
+      }
+    ]
+  },
+  "person-tobias-mayer": {
+    "wikidataId": "Q61071",
+    "wikipediaTitle": "Tobias_Mayer",
+    "canonicalTitle": "Tobias Mayer",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-tobias-mayer",
+        "nodeTitle": "Tobias Mayer"
+      }
+    ]
+  },
+  "object-theoria-motus": {
+    "wikidataId": "Q15989807",
+    "wikipediaTitle": "Theoria_motus_corporum_coelestium_in_sectionibus_conicis_solem_ambientium",
+    "canonicalTitle": "Theoria motus corporum coelestium",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-theoria-motus",
+        "nodeTitle": "Theoria motus corporum coelestium"
+      }
+    ]
+  },
+  "location-gottingen-observatory": {
+    "wikidataId": "Q896313",
+    "wikipediaTitle": "Göttingen_Observatory",
+    "canonicalTitle": "Göttingen Observatory",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "location-gottingen-observatory",
+        "nodeTitle": "Göttingen Observatory"
+      }
+    ]
+  },
+  "location-konigsberg-observatory": {
+    "wikidataId": "Q1796310",
+    "wikipediaTitle": "Königsberg_Observatory",
+    "canonicalTitle": "Königsberg Observatory",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "location-konigsberg-observatory",
+        "nodeTitle": "Königsberg Observatory"
+      }
+    ]
+  },
+  "person-pafnuty-chebyshev": {
+    "wikidataId": "Q206012",
+    "wikipediaTitle": "Pafnuty_Chebyshev",
+    "canonicalTitle": "Pafnuty Chebyshev",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-pafnuty-chebyshev",
+        "nodeTitle": "Pafnuty Chebyshev"
+      }
+    ]
+  },
+  "person-walter-frank-raphael-weldon": {
+    "wikidataId": "Q1573240",
+    "wikipediaTitle": "W._F._R._Weldon",
+    "canonicalTitle": "W.F.R. Weldon",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-walter-frank-raphael-weldon",
+        "nodeTitle": "W.F.R. Weldon"
+      }
+    ]
+  },
+  "person-george-udny-yule": {
+    "wikidataId": "Q991476",
+    "wikipediaTitle": "Udny_Yule",
+    "canonicalTitle": "George Udny Yule",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-george-udny-yule",
+        "nodeTitle": "George Udny Yule"
+      }
+    ]
+  },
+  "person-francis-ysidro-edgeworth": {
+    "wikidataId": "Q355607",
+    "wikipediaTitle": "Francis_Ysidro_Edgeworth",
+    "canonicalTitle": "Francis Ysidro Edgeworth",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-francis-ysidro-edgeworth",
+        "nodeTitle": "Francis Ysidro Edgeworth"
+      }
+    ]
+  },
+  "person-wilhelm-lexis": {
+    "wikidataId": "Q64383",
+    "wikipediaTitle": "Wilhelm_Lexis",
+    "canonicalTitle": "Wilhelm Lexis",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-wilhelm-lexis",
+        "nodeTitle": "Wilhelm Lexis"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q0-Q99999.json
+++ b/public/cross-scene-index/by-wikidata/Q0-Q99999.json
@@ -1,0 +1,3348 @@
+{
+  "Q60": {
+    "wikidataId": "Q60",
+    "wikipediaTitle": "New_York_City",
+    "canonicalTitle": "New York City, New York",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-new-york",
+        "nodeTitle": "New York City, New York"
+      },
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-new-york",
+        "nodeTitle": "New York City"
+      }
+    ]
+  },
+  "Q49210": {
+    "wikidataId": "Q49210",
+    "wikipediaTitle": "New_York_University",
+    "canonicalTitle": "New York University",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-nyu",
+        "nodeTitle": "New York University"
+      }
+    ]
+  },
+  "Q62": {
+    "wikidataId": "Q62",
+    "wikipediaTitle": "San_Francisco",
+    "canonicalTitle": "San Francisco, California",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-san-francisco",
+        "nodeTitle": "San Francisco, California"
+      }
+    ]
+  },
+  "Q84": {
+    "wikidataId": "Q84",
+    "wikipediaTitle": "London",
+    "canonicalTitle": "London, United Kingdom",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-london",
+        "nodeTitle": "London, United Kingdom"
+      },
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "loc-london",
+        "nodeTitle": "London"
+      }
+    ]
+  },
+  "Q90": {
+    "wikidataId": "Q90",
+    "wikipediaTitle": "Paris",
+    "canonicalTitle": "Paris, France",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris, France"
+      },
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-paris",
+        "nodeTitle": "Paris"
+      },
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris"
+      }
+    ]
+  },
+  "Q172": {
+    "wikidataId": "Q172",
+    "wikipediaTitle": "Toronto",
+    "canonicalTitle": "Toronto, Canada",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-toronto",
+        "nodeTitle": "Toronto, Canada"
+      }
+    ]
+  },
+  "Q340": {
+    "wikidataId": "Q340",
+    "wikipediaTitle": "Montreal",
+    "canonicalTitle": "Montreal, Canada",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-montreal",
+        "nodeTitle": "Montreal, Canada"
+      }
+    ]
+  },
+  "Q41506": {
+    "wikidataId": "Q41506",
+    "wikipediaTitle": "Stanford_University",
+    "canonicalTitle": "Stanford University",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-stanford",
+        "nodeTitle": "Stanford University"
+      },
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-stanford",
+        "nodeTitle": "Stanford University"
+      }
+    ]
+  },
+  "Q1490": {
+    "wikidataId": "Q1490",
+    "wikipediaTitle": "Tokyo",
+    "canonicalTitle": "Tokyo, Japan",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-tokyo",
+        "nodeTitle": "Tokyo, Japan"
+      },
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-tokyo",
+        "nodeTitle": "Tokyo"
+      }
+    ]
+  },
+  "Q2096": {
+    "wikidataId": "Q2096",
+    "wikipediaTitle": "Edmonton",
+    "canonicalTitle": "Edmonton, Canada",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-edmonton",
+        "nodeTitle": "Edmonton, Canada"
+      }
+    ]
+  },
+  "Q38948": {
+    "wikidataId": "Q38948",
+    "wikipediaTitle": "University_of_Alberta",
+    "canonicalTitle": "University of Alberta",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-ualberta",
+        "nodeTitle": "University of Alberta"
+      }
+    ]
+  },
+  "Q5083": {
+    "wikidataId": "Q5083",
+    "wikipediaTitle": "Seattle",
+    "canonicalTitle": "Seattle, Washington",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-seattle",
+        "nodeTitle": "Seattle, Washington"
+      }
+    ]
+  },
+  "Q29544": {
+    "wikidataId": "Q29544",
+    "wikipediaTitle": "Delia_Derbyshire",
+    "canonicalTitle": "Delia Derbyshire",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-delia-derbyshire",
+        "nodeTitle": "Delia Derbyshire"
+      }
+    ]
+  },
+  "Q61428": {
+    "wikidataId": "Q61428",
+    "wikipediaTitle": "Conny_Plank",
+    "canonicalTitle": "Conny Plank",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-conny-plank",
+        "nodeTitle": "Conny Plank"
+      },
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-conny-studio",
+        "nodeTitle": "Conny Plank's Studio"
+      }
+    ]
+  },
+  "Q61272": {
+    "wikidataId": "Q61272",
+    "wikipediaTitle": "Christopher_Franke",
+    "canonicalTitle": "Christopher Franke",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-christopher-franke",
+        "nodeTitle": "Christopher Franke"
+      }
+    ]
+  },
+  "Q44641": {
+    "wikidataId": "Q44641",
+    "wikipediaTitle": "Wendy_Carlos",
+    "canonicalTitle": "Wendy Carlos",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-wendy-carlos",
+        "nodeTitle": "Wendy Carlos"
+      }
+    ]
+  },
+  "Q12030": {
+    "wikidataId": "Q12030",
+    "wikipediaTitle": "4′33″",
+    "canonicalTitle": "4'33\"",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-cage-433",
+        "nodeTitle": "4'33\""
+      }
+    ]
+  },
+  "Q31595": {
+    "wikidataId": "Q31595",
+    "wikipediaTitle": "Zuckerzeit",
+    "canonicalTitle": "Zuckerzeit",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-cluster-zuckerzeit",
+        "nodeTitle": "Zuckerzeit"
+      }
+    ]
+  },
+  "Q31512": {
+    "wikidataId": "Q31512",
+    "wikipediaTitle": "Sowiesoso",
+    "canonicalTitle": "Sowiesoso",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-cluster-sowiesoso",
+        "nodeTitle": "Sowiesoso"
+      }
+    ]
+  },
+  "Q64": {
+    "wikidataId": "Q64",
+    "wikipediaTitle": "Berlin",
+    "canonicalTitle": "Berlin",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-berlin",
+        "nodeTitle": "Berlin"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-berlin",
+        "nodeTitle": "Berlin"
+      }
+    ]
+  },
+  "Q1718": {
+    "wikidataId": "Q1718",
+    "wikipediaTitle": "Düsseldorf",
+    "canonicalTitle": "Düsseldorf",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-dusseldorf",
+        "nodeTitle": "Düsseldorf"
+      }
+    ]
+  },
+  "Q365": {
+    "wikidataId": "Q365",
+    "wikipediaTitle": "Cologne",
+    "canonicalTitle": "Cologne",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-cologne",
+        "nodeTitle": "Cologne"
+      },
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-cologne",
+        "nodeTitle": "Cologne"
+      }
+    ]
+  },
+  "Q34692": {
+    "wikidataId": "Q34692",
+    "wikipediaTitle": "Kingston,_Jamaica",
+    "canonicalTitle": "Kingston",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-kingston",
+        "nodeTitle": "Kingston"
+      }
+    ]
+  },
+  "Q490": {
+    "wikidataId": "Q490",
+    "wikipediaTitle": "Milan",
+    "canonicalTitle": "Milan",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-milan",
+        "nodeTitle": "Milan"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-milan",
+        "nodeTitle": "Milan"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-milan",
+        "nodeTitle": "Milan"
+      }
+    ]
+  },
+  "Q44892": {
+    "wikidataId": "Q44892",
+    "wikipediaTitle": "Kraftwerk",
+    "canonicalTitle": "Kraftwerk",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-kraftwerk",
+        "nodeTitle": "Kraftwerk"
+      }
+    ]
+  },
+  "Q60637": {
+    "wikidataId": "Q60637",
+    "wikipediaTitle": "Johann_Reuchlin",
+    "canonicalTitle": "Johannes Reuchlin",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-johannes-reuchlin",
+        "nodeTitle": "Johannes Reuchlin"
+      }
+    ]
+  },
+  "Q60305": {
+    "wikidataId": "Q60305",
+    "wikipediaTitle": "Heinrich_Cornelius_Agrippa",
+    "canonicalTitle": "Heinrich Cornelius Agrippa",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-heinrich-cornelius-agrippa",
+        "nodeTitle": "Heinrich Cornelius Agrippa"
+      }
+    ]
+  },
+  "Q60373": {
+    "wikidataId": "Q60373",
+    "wikipediaTitle": "Johannes_Trithemius",
+    "canonicalTitle": "Johannes Trithemius",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-johannes-trithemius",
+        "nodeTitle": "Johannes Trithemius"
+      }
+    ]
+  },
+  "Q83428": {
+    "wikidataId": "Q83428",
+    "wikipediaTitle": "Paracelsus",
+    "canonicalTitle": "Paracelsus",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-paracelsus",
+        "nodeTitle": "Paracelsus"
+      },
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-paracelsus",
+        "nodeTitle": "Paracelsus"
+      }
+    ]
+  },
+  "Q63203": {
+    "wikidataId": "Q63203",
+    "wikipediaTitle": "Johannes_Pfefferkorn",
+    "canonicalTitle": "Johannes Pfefferkorn",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-johannes-pfefferkorn",
+        "nodeTitle": "Johannes Pfefferkorn"
+      }
+    ]
+  },
+  "Q2044": {
+    "wikidataId": "Q2044",
+    "wikipediaTitle": "Florence",
+    "canonicalTitle": "Florence",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-florence",
+        "nodeTitle": "Florence"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "location-florence",
+        "nodeTitle": "Florence"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-florence",
+        "nodeTitle": "Florence"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-florence",
+        "nodeTitle": "Florence"
+      }
+    ]
+  },
+  "Q641": {
+    "wikidataId": "Q641",
+    "wikipediaTitle": "Venice",
+    "canonicalTitle": "Venice",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-venice",
+        "nodeTitle": "Venice"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-venice",
+        "nodeTitle": "Venice"
+      }
+    ]
+  },
+  "Q220": {
+    "wikidataId": "Q220",
+    "wikipediaTitle": "Rome",
+    "canonicalTitle": "Rome",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-rome",
+        "nodeTitle": "Rome"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-rome",
+        "nodeTitle": "Rome"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-rome",
+        "nodeTitle": "Rome"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-rome",
+        "nodeTitle": "Rome"
+      }
+    ]
+  },
+  "Q1728": {
+    "wikidataId": "Q1728",
+    "wikipediaTitle": "Würzburg",
+    "canonicalTitle": "Würzburg",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-wuerzburg",
+        "nodeTitle": "Würzburg"
+      }
+    ]
+  },
+  "Q81520": {
+    "wikidataId": "Q81520",
+    "wikipediaTitle": "Pope_Leo_X",
+    "canonicalTitle": "Pope Leo X",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-pope-leo-x",
+        "nodeTitle": "Pope Leo X"
+      }
+    ]
+  },
+  "Q77107": {
+    "wikidataId": "Q77107",
+    "wikipediaTitle": "Ulrich_von_Hutten",
+    "canonicalTitle": "Ulrich von Hutten",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-ulrich-von-hutten",
+        "nodeTitle": "Ulrich von Hutten"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-ulrich-von-hutten",
+        "nodeTitle": "Ulrich von Hutten"
+      }
+    ]
+  },
+  "Q65521": {
+    "wikidataId": "Q65521",
+    "wikipediaTitle": "Crotus_Rubeanus",
+    "canonicalTitle": "Crotus Rubeanus",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-crotus-rubeanus",
+        "nodeTitle": "Crotus Rubeanus"
+      }
+    ]
+  },
+  "Q92760": {
+    "wikidataId": "Q92760",
+    "wikipediaTitle": "Claude_Shannon",
+    "canonicalTitle": "Claude Shannon",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-claude-shannon",
+        "nodeTitle": "Claude Shannon"
+      }
+    ]
+  },
+  "Q7251": {
+    "wikidataId": "Q7251",
+    "wikipediaTitle": "Alan_Turing",
+    "canonicalTitle": "Alan Turing",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-alan-turing",
+        "nodeTitle": "Alan Turing"
+      }
+    ]
+  },
+  "Q17455": {
+    "wikidataId": "Q17455",
+    "wikipediaTitle": "John_von_Neumann",
+    "canonicalTitle": "John von Neumann",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-john-von-neumann",
+        "nodeTitle": "John von Neumann"
+      }
+    ]
+  },
+  "Q92619": {
+    "wikidataId": "Q92619",
+    "wikipediaTitle": "Richard_Hamming",
+    "canonicalTitle": "Richard Hamming",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-richard-hamming",
+        "nodeTitle": "Richard Hamming"
+      }
+    ]
+  },
+  "Q92784": {
+    "wikidataId": "Q92784",
+    "wikipediaTitle": "David_A._Huffman",
+    "canonicalTitle": "David Huffman",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-david-huffman",
+        "nodeTitle": "David Huffman"
+      }
+    ]
+  },
+  "Q93052": {
+    "wikidataId": "Q93052",
+    "wikipediaTitle": "Robert_Fano",
+    "canonicalTitle": "Robert Fano",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-robert-fano",
+        "nodeTitle": "Robert Fano"
+      }
+    ]
+  },
+  "Q93005": {
+    "wikidataId": "Q93005",
+    "wikipediaTitle": "Herman_Goldstine",
+    "canonicalTitle": "Herman Goldstine",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-herman-goldstine",
+        "nodeTitle": "Herman Goldstine"
+      }
+    ]
+  },
+  "Q62857": {
+    "wikidataId": "Q62857",
+    "wikipediaTitle": "Maurice_Wilkes",
+    "canonicalTitle": "Maurice Wilkes",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-maurice-wilkes",
+        "nodeTitle": "Maurice Wilkes"
+      }
+    ]
+  },
+  "Q60093": {
+    "wikidataId": "Q60093",
+    "wikipediaTitle": "Konrad_Zuse",
+    "canonicalTitle": "Konrad Zuse",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-konrad-zuse",
+        "nodeTitle": "Konrad Zuse"
+      }
+    ]
+  },
+  "Q74829": {
+    "wikidataId": "Q74829",
+    "wikipediaTitle": "Heinrich_Klüver",
+    "canonicalTitle": "Heinrich Klüver",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-heinrich-kluver",
+        "nodeTitle": "Heinrich Klüver"
+      }
+    ]
+  },
+  "Q77106": {
+    "wikidataId": "Q77106",
+    "wikipediaTitle": "Kurt_Lewin",
+    "canonicalTitle": "Kurt Lewin",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-kurt-lewin",
+        "nodeTitle": "Kurt Lewin"
+      }
+    ]
+  },
+  "Q93018": {
+    "wikidataId": "Q93018",
+    "wikipediaTitle": "Frank_Rosenblatt",
+    "canonicalTitle": "Frank Rosenblatt",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-frank-rosenblatt",
+        "nodeTitle": "Frank Rosenblatt"
+      }
+    ]
+  },
+  "Q84345": {
+    "wikidataId": "Q84345",
+    "wikipediaTitle": "Ludwig_von_Bertalanffy",
+    "canonicalTitle": "Ludwig von Bertalanffy",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ludwig-von-bertalanffy",
+        "nodeTitle": "Ludwig von Bertalanffy"
+      }
+    ]
+  },
+  "Q92763": {
+    "wikidataId": "Q92763",
+    "wikipediaTitle": "Jay_Wright_Forrester",
+    "canonicalTitle": "Jay Forrester",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-jay-forrester",
+        "nodeTitle": "Jay Forrester"
+      }
+    ]
+  },
+  "Q78688": {
+    "wikidataId": "Q78688",
+    "wikipediaTitle": "Heinz_von_Foerster",
+    "canonicalTitle": "Heinz von Foerster",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-heinz-von-foerster",
+        "nodeTitle": "Heinz von Foerster"
+      }
+    ]
+  },
+  "Q92739": {
+    "wikidataId": "Q92739",
+    "wikipediaTitle": "John_McCarthy_(computer_scientist)",
+    "canonicalTitle": "John McCarthy",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-john-mccarthy",
+        "nodeTitle": "John McCarthy"
+      }
+    ]
+  },
+  "Q92778": {
+    "wikidataId": "Q92778",
+    "wikipediaTitle": "J._C._R._Licklider",
+    "canonicalTitle": "J.C.R. Licklider",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-j-c-r-licklider",
+        "nodeTitle": "J.C.R. Licklider"
+      }
+    ]
+  },
+  "Q92614": {
+    "wikidataId": "Q92614",
+    "wikipediaTitle": "Douglas_Engelbart",
+    "canonicalTitle": "Douglas Engelbart",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-douglas-engelbart",
+        "nodeTitle": "Douglas Engelbart"
+      }
+    ]
+  },
+  "Q33760": {
+    "wikidataId": "Q33760",
+    "wikipediaTitle": "Bertrand_Russell",
+    "canonicalTitle": "Bertrand Russell",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-bertrand-russell",
+        "nodeTitle": "Bertrand Russell"
+      }
+    ]
+  },
+  "Q92741": {
+    "wikidataId": "Q92741",
+    "wikipediaTitle": "Alonzo_Church",
+    "canonicalTitle": "Alonzo Church",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-alonzo-church",
+        "nodeTitle": "Alonzo Church"
+      }
+    ]
+  },
+  "Q41390": {
+    "wikidataId": "Q41390",
+    "wikipediaTitle": "Kurt_Gödel",
+    "canonicalTitle": "Kurt Gödel",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-kurt-godel",
+        "nodeTitle": "Kurt Gödel"
+      }
+    ]
+  },
+  "Q84296": {
+    "wikidataId": "Q84296",
+    "wikipediaTitle": "Ludwig_Boltzmann",
+    "canonicalTitle": "Ludwig Boltzmann",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ludwig-boltzmann",
+        "nodeTitle": "Ludwig Boltzmann"
+      }
+    ]
+  },
+  "Q94028": {
+    "wikidataId": "Q94028",
+    "wikipediaTitle": "Oskar_Morgenstern",
+    "canonicalTitle": "Oskar Morgenstern",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-oskar-morgenstern",
+        "nodeTitle": "Oskar Morgenstern"
+      }
+    ]
+  },
+  "Q49108": {
+    "wikidataId": "Q49108",
+    "wikipediaTitle": "Massachusetts_Institute_of_Technology",
+    "canonicalTitle": "Massachusetts Institute of Technology",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-mit",
+        "nodeTitle": "Massachusetts Institute of Technology"
+      }
+    ]
+  },
+  "Q35794": {
+    "wikidataId": "Q35794",
+    "wikipediaTitle": "University_of_Cambridge",
+    "canonicalTitle": "Cambridge University",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-cambridge",
+        "nodeTitle": "Cambridge University"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-cambridge",
+        "nodeTitle": "University of Cambridge"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-cambridge-university",
+        "nodeTitle": "University of Cambridge"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-cambridge",
+        "nodeTitle": "University of Cambridge"
+      }
+    ]
+  },
+  "Q49116": {
+    "wikidataId": "Q49116",
+    "wikipediaTitle": "Dartmouth_College",
+    "canonicalTitle": "Dartmouth College",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-dartmouth",
+        "nodeTitle": "Dartmouth College"
+      }
+    ]
+  },
+  "Q1741": {
+    "wikidataId": "Q1741",
+    "wikipediaTitle": "Vienna",
+    "canonicalTitle": "Vienna",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-vienna",
+        "nodeTitle": "Vienna"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-vienna",
+        "nodeTitle": "Vienna"
+      }
+    ]
+  },
+  "Q13371": {
+    "wikidataId": "Q13371",
+    "wikipediaTitle": "Harvard_University",
+    "canonicalTitle": "Harvard University",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-harvard",
+        "nodeTitle": "Harvard University"
+      }
+    ]
+  },
+  "Q9353": {
+    "wikidataId": "Q9353",
+    "wikipediaTitle": "John_Locke",
+    "canonicalTitle": "John Locke",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-john-locke",
+        "nodeTitle": "John Locke"
+      }
+    ]
+  },
+  "Q935": {
+    "wikidataId": "Q935",
+    "wikipediaTitle": "Isaac_Newton",
+    "canonicalTitle": "Isaac Newton",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-isaac-newton",
+        "nodeTitle": "Isaac Newton"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-isaac-newton",
+        "nodeTitle": "Isaac Newton"
+      },
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-isaac-newton",
+        "nodeTitle": "Sir Isaac Newton"
+      }
+    ]
+  },
+  "Q9047": {
+    "wikidataId": "Q9047",
+    "wikipediaTitle": "Gottfried_Wilhelm_Leibniz",
+    "canonicalTitle": "Gottfried Wilhelm Leibniz",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-leibniz",
+        "nodeTitle": "Gottfried Wilhelm Leibniz"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-gottfried-leibniz",
+        "nodeTitle": "Gottfried Wilhelm Leibniz"
+      }
+    ]
+  },
+  "Q9068": {
+    "wikidataId": "Q9068",
+    "wikipediaTitle": "Voltaire",
+    "canonicalTitle": "Voltaire",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-voltaire",
+        "nodeTitle": "Voltaire"
+      }
+    ]
+  },
+  "Q448": {
+    "wikidataId": "Q448",
+    "wikipediaTitle": "Denis_Diderot",
+    "canonicalTitle": "Denis Diderot",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-diderot",
+        "nodeTitle": "Denis Diderot"
+      }
+    ]
+  },
+  "Q15975": {
+    "wikidataId": "Q15975",
+    "wikipediaTitle": "Montesquieu",
+    "canonicalTitle": "Montesquieu",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-montesquieu",
+        "nodeTitle": "Montesquieu"
+      }
+    ]
+  },
+  "Q6527": {
+    "wikidataId": "Q6527",
+    "wikipediaTitle": "Jean-Jacques_Rousseau",
+    "canonicalTitle": "Jean-Jacques Rousseau",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-rousseau",
+        "nodeTitle": "Jean-Jacques Rousseau"
+      }
+    ]
+  },
+  "Q7104": {
+    "wikidataId": "Q7104",
+    "wikipediaTitle": "Baron_d'Holbach",
+    "canonicalTitle": "Baron d'Holbach",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-dholbach",
+        "nodeTitle": "Baron d'Holbach"
+      }
+    ]
+  },
+  "Q7068": {
+    "wikidataId": "Q7068",
+    "wikipediaTitle": "Julien_Offray_de_La_Mettrie",
+    "canonicalTitle": "Julien Offray de La Mettrie",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-la-mettrie",
+        "nodeTitle": "Julien Offray de La Mettrie"
+      }
+    ]
+  },
+  "Q37160": {
+    "wikidataId": "Q37160",
+    "wikipediaTitle": "David_Hume",
+    "canonicalTitle": "David Hume",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-david-hume",
+        "nodeTitle": "David Hume"
+      }
+    ]
+  },
+  "Q9381": {
+    "wikidataId": "Q9381",
+    "wikipediaTitle": "Adam_Smith",
+    "canonicalTitle": "Adam Smith",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-adam-smith",
+        "nodeTitle": "Adam Smith"
+      }
+    ]
+  },
+  "Q9312": {
+    "wikidataId": "Q9312",
+    "wikipediaTitle": "Immanuel_Kant",
+    "canonicalTitle": "Immanuel Kant",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-immanuel-kant",
+        "nodeTitle": "Immanuel Kant"
+      }
+    ]
+  },
+  "Q76510": {
+    "wikidataId": "Q76510",
+    "wikipediaTitle": "Christian_Wolff_(philosopher)",
+    "canonicalTitle": "Christian Wolff",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-christian-wolff",
+        "nodeTitle": "Christian Wolff"
+      }
+    ]
+  },
+  "Q76997": {
+    "wikidataId": "Q76997",
+    "wikipediaTitle": "Moses_Mendelssohn",
+    "canonicalTitle": "Moses Mendelssohn",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-moses-mendelssohn",
+        "nodeTitle": "Moses Mendelssohn"
+      }
+    ]
+  },
+  "Q34628": {
+    "wikidataId": "Q34628",
+    "wikipediaTitle": "Gotthold_Ephraim_Lessing",
+    "canonicalTitle": "Gotthold Ephraim Lessing",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-gotthold-lessing",
+        "nodeTitle": "Gotthold Ephraim Lessing"
+      }
+    ]
+  },
+  "Q76517": {
+    "wikidataId": "Q76517",
+    "wikipediaTitle": "Alexander_Gottlieb_Baumgarten",
+    "canonicalTitle": "Alexander Gottlieb Baumgarten",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-baumgarten",
+        "nodeTitle": "Alexander Gottlieb Baumgarten"
+      }
+    ]
+  },
+  "Q5879": {
+    "wikidataId": "Q5879",
+    "wikipediaTitle": "Johann_Wolfgang_von_Goethe",
+    "canonicalTitle": "Johann Wolfgang von Goethe",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-goethe",
+        "nodeTitle": "Johann Wolfgang von Goethe"
+      }
+    ]
+  },
+  "Q82049": {
+    "wikidataId": "Q82049",
+    "wikipediaTitle": "George_Berkeley",
+    "canonicalTitle": "George Berkeley",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-george-berkeley",
+        "nodeTitle": "George Berkeley"
+      }
+    ]
+  },
+  "Q60887": {
+    "wikidataId": "Q60887",
+    "wikipediaTitle": "Jeremy_Bentham",
+    "canonicalTitle": "Jeremy Bentham",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-jeremy-bentham",
+        "nodeTitle": "Jeremy Bentham"
+      }
+    ]
+  },
+  "Q13575": {
+    "wikidataId": "Q13575",
+    "wikipediaTitle": "François_Quesnay",
+    "canonicalTitle": "François Quesnay",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-francois-quesnay",
+        "nodeTitle": "François Quesnay"
+      }
+    ]
+  },
+  "Q34969": {
+    "wikidataId": "Q34969",
+    "wikipediaTitle": "Benjamin_Franklin",
+    "canonicalTitle": "Benjamin Franklin",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-benjamin-franklin",
+        "nodeTitle": "Benjamin Franklin"
+      }
+    ]
+  },
+  "Q11812": {
+    "wikidataId": "Q11812",
+    "wikipediaTitle": "Thomas_Jefferson",
+    "canonicalTitle": "Thomas Jefferson",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-thomas-jefferson",
+        "nodeTitle": "Thomas Jefferson"
+      }
+    ]
+  },
+  "Q11813": {
+    "wikidataId": "Q11813",
+    "wikipediaTitle": "James_Madison",
+    "canonicalTitle": "James Madison",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-james-madison",
+        "nodeTitle": "James Madison"
+      }
+    ]
+  },
+  "Q11806": {
+    "wikidataId": "Q11806",
+    "wikipediaTitle": "John_Adams",
+    "canonicalTitle": "John Adams",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-john-adams",
+        "nodeTitle": "John Adams"
+      }
+    ]
+  },
+  "Q7604": {
+    "wikidataId": "Q7604",
+    "wikipediaTitle": "Leonhard_Euler",
+    "canonicalTitle": "Leonhard Euler",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-leonhard-euler",
+        "nodeTitle": "Leonhard Euler"
+      }
+    ]
+  },
+  "Q44481": {
+    "wikidataId": "Q44481",
+    "wikipediaTitle": "Pierre-Simon_Laplace",
+    "canonicalTitle": "Pierre-Simon Laplace",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-laplace",
+        "nodeTitle": "Pierre-Simon Laplace"
+      }
+    ]
+  },
+  "Q39607": {
+    "wikidataId": "Q39607",
+    "wikipediaTitle": "Antoine_Lavoisier",
+    "canonicalTitle": "Antoine Lavoisier",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-lavoisier",
+        "nodeTitle": "Antoine Lavoisier"
+      }
+    ]
+  },
+  "Q7286": {
+    "wikidataId": "Q7286",
+    "wikipediaTitle": "Émilie_du_Châtelet",
+    "canonicalTitle": "Émilie du Châtelet",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-emilie-du-chatelet",
+        "nodeTitle": "Émilie du Châtelet"
+      }
+    ]
+  },
+  "Q80222": {
+    "wikidataId": "Q80222",
+    "wikipediaTitle": "Joseph-Louis_Lagrange",
+    "canonicalTitle": "Joseph-Louis Lagrange",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-lagrange",
+        "nodeTitle": "Joseph-Louis Lagrange"
+      }
+    ]
+  },
+  "Q33550": {
+    "wikidataId": "Q33550",
+    "wikipediaTitle": "Frederick_the_Great",
+    "canonicalTitle": "Frederick II of Prussia",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-frederick-great",
+        "nodeTitle": "Frederick II of Prussia"
+      }
+    ]
+  },
+  "Q36450": {
+    "wikidataId": "Q36450",
+    "wikipediaTitle": "Catherine_the_Great",
+    "canonicalTitle": "Catherine II of Russia",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-catherine-great",
+        "nodeTitle": "Catherine II of Russia"
+      }
+    ]
+  },
+  "Q74263": {
+    "wikidataId": "Q74263",
+    "wikipediaTitle": "Opticks",
+    "canonicalTitle": "Opticks",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-opticks",
+        "nodeTitle": "Opticks"
+      }
+    ]
+  },
+  "Q447": {
+    "wikidataId": "Q447",
+    "wikipediaTitle": "Encyclopédie",
+    "canonicalTitle": "Encyclopédie",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-encyclopedie",
+        "nodeTitle": "Encyclopédie"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-encyclopedie-project",
+        "nodeTitle": "Encyclopédie Project"
+      }
+    ]
+  },
+  "Q23436": {
+    "wikidataId": "Q23436",
+    "wikipediaTitle": "Edinburgh",
+    "canonicalTitle": "Edinburgh",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-edinburgh",
+        "nodeTitle": "Edinburgh"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-edinburgh",
+        "nodeTitle": "Edinburgh"
+      },
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "loc-edinburgh",
+        "nodeTitle": "Edinburgh"
+      }
+    ]
+  },
+  "Q71": {
+    "wikidataId": "Q71",
+    "wikipediaTitle": "Geneva",
+    "canonicalTitle": "Geneva",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-geneva",
+        "nodeTitle": "Geneva"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-geneva",
+        "nodeTitle": "Geneva"
+      }
+    ]
+  },
+  "Q727": {
+    "wikidataId": "Q727",
+    "wikipediaTitle": "Amsterdam",
+    "canonicalTitle": "Amsterdam",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-amsterdam",
+        "nodeTitle": "Amsterdam"
+      },
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-amsterdam",
+        "nodeTitle": "Amsterdam"
+      }
+    ]
+  },
+  "Q4093": {
+    "wikidataId": "Q4093",
+    "wikipediaTitle": "Glasgow",
+    "canonicalTitle": "Glasgow",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-glasgow",
+        "nodeTitle": "Glasgow"
+      }
+    ]
+  },
+  "Q1345": {
+    "wikidataId": "Q1345",
+    "wikipediaTitle": "Philadelphia",
+    "canonicalTitle": "Philadelphia",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-philadelphia",
+        "nodeTitle": "Philadelphia"
+      }
+    ]
+  },
+  "Q656": {
+    "wikidataId": "Q656",
+    "wikipediaTitle": "Saint_Petersburg",
+    "canonicalTitle": "St. Petersburg",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-st-petersburg",
+        "nodeTitle": "St. Petersburg"
+      }
+    ]
+  },
+  "Q2946": {
+    "wikidataId": "Q2946",
+    "wikipediaTitle": "Palace_of_Versailles",
+    "canonicalTitle": "Versailles",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-versailles",
+        "nodeTitle": "Versailles"
+      }
+    ]
+  },
+  "Q83368": {
+    "wikidataId": "Q83368",
+    "wikipediaTitle": "Empiricism",
+    "canonicalTitle": "British Empiricism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-british-empiricism",
+        "nodeTitle": "British Empiricism"
+      }
+    ]
+  },
+  "Q30": {
+    "wikidataId": "Q30",
+    "wikipediaTitle": "United_States",
+    "canonicalTitle": "United States of America",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-united-states",
+        "nodeTitle": "United States of America"
+      }
+    ]
+  },
+  "Q6534": {
+    "wikidataId": "Q6534",
+    "wikipediaTitle": "French_Revolution",
+    "canonicalTitle": "French Revolution",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-french-revolution",
+        "nodeTitle": "French Revolution"
+      }
+    ]
+  },
+  "Q81994": {
+    "wikidataId": "Q81994",
+    "wikipediaTitle": "Pope_Leo_X",
+    "canonicalTitle": "Giovanni de' Medici (Pope Leo X)",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-giovanni-de-medici-pope-leo-x",
+        "nodeTitle": "Giovanni de' Medici (Pope Leo X)"
+      }
+    ]
+  },
+  "Q859": {
+    "wikidataId": "Q859",
+    "wikipediaTitle": "Plato",
+    "canonicalTitle": "Plato",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-plato",
+        "nodeTitle": "Plato"
+      }
+    ]
+  },
+  "Q44032": {
+    "wikidataId": "Q44032",
+    "wikipediaTitle": "Plotinus",
+    "canonicalTitle": "Plotinus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-plotinus",
+        "nodeTitle": "Plotinus"
+      }
+    ]
+  },
+  "Q42247": {
+    "wikidataId": "Q42247",
+    "wikipediaTitle": "Iamblichus",
+    "canonicalTitle": "Iamblichus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-iamblichus",
+        "nodeTitle": "Iamblichus"
+      }
+    ]
+  },
+  "Q43395": {
+    "wikidataId": "Q43395",
+    "wikipediaTitle": "Orpheus",
+    "canonicalTitle": "Orpheus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-orpheus",
+        "nodeTitle": "Orpheus"
+      }
+    ]
+  },
+  "Q4848": {
+    "wikidataId": "Q4848",
+    "wikipediaTitle": "Zoroaster",
+    "canonicalTitle": "Zoroaster",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-zoroaster",
+        "nodeTitle": "Zoroaster"
+      }
+    ]
+  },
+  "Q10261": {
+    "wikidataId": "Q10261",
+    "wikipediaTitle": "Pythagoras",
+    "canonicalTitle": "Pythagoras",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-pythagoras",
+        "nodeTitle": "Pythagoras"
+      }
+    ]
+  },
+  "Q36330": {
+    "wikidataId": "Q36330",
+    "wikipediaTitle": "Giordano_Bruno",
+    "canonicalTitle": "Giordano Bruno",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-giordano-bruno",
+        "nodeTitle": "Giordano Bruno"
+      }
+    ]
+  },
+  "Q45027": {
+    "wikidataId": "Q45027",
+    "wikipediaTitle": "Girolamo_Savonarola",
+    "canonicalTitle": "Girolamo Savonarola",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-girolamo-savonarola",
+        "nodeTitle": "Girolamo Savonarola"
+      }
+    ]
+  },
+  "Q83017": {
+    "wikidataId": "Q83017",
+    "wikipediaTitle": "Council_of_Florence",
+    "canonicalTitle": "Council of Florence",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "location-council-of-florence",
+        "nodeTitle": "Council of Florence"
+      }
+    ]
+  },
+  "Q9554": {
+    "wikidataId": "Q9554",
+    "wikipediaTitle": "Martin_Luther",
+    "canonicalTitle": "Martin Luther",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-martin-luther",
+        "nodeTitle": "Martin Luther"
+      }
+    ]
+  },
+  "Q37577": {
+    "wikidataId": "Q37577",
+    "wikipediaTitle": "John_Calvin",
+    "canonicalTitle": "John Calvin",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-calvin",
+        "nodeTitle": "John Calvin"
+      }
+    ]
+  },
+  "Q43499": {
+    "wikidataId": "Q43499",
+    "wikipediaTitle": "Erasmus",
+    "canonicalTitle": "Erasmus of Rotterdam",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-erasmus-of-rotterdam",
+        "nodeTitle": "Erasmus of Rotterdam"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-desiderius-erasmus",
+        "nodeTitle": "Desiderius Erasmus of Rotterdam"
+      }
+    ]
+  },
+  "Q76325": {
+    "wikidataId": "Q76325",
+    "wikipediaTitle": "Philip_Melanchthon",
+    "canonicalTitle": "Philip Melanchthon",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-philip-melanchthon",
+        "nodeTitle": "Philip Melanchthon"
+      }
+    ]
+  },
+  "Q77260": {
+    "wikidataId": "Q77260",
+    "wikipediaTitle": "Johannes_Bugenhagen",
+    "canonicalTitle": "Johannes Bugenhagen",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-johannes-bugenhagen",
+        "nodeTitle": "Johannes Bugenhagen"
+      }
+    ]
+  },
+  "Q38294": {
+    "wikidataId": "Q38294",
+    "wikipediaTitle": "Justus_Jonas",
+    "canonicalTitle": "Justus Jonas",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-justus-jonas",
+        "nodeTitle": "Justus Jonas"
+      }
+    ]
+  },
+  "Q60589": {
+    "wikidataId": "Q60589",
+    "wikipediaTitle": "Andreas_Karlstadt",
+    "canonicalTitle": "Andreas Karlstadt",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-andreas-karlstadt",
+        "nodeTitle": "Andreas Karlstadt"
+      }
+    ]
+  },
+  "Q77239": {
+    "wikidataId": "Q77239",
+    "wikipediaTitle": "Katharina_von_Bora",
+    "canonicalTitle": "Katharina von Bora",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-katharina-von-bora",
+        "nodeTitle": "Katharina von Bora"
+      }
+    ]
+  },
+  "Q85810": {
+    "wikidataId": "Q85810",
+    "wikipediaTitle": "Matthew_Zell",
+    "canonicalTitle": "Matthew Zell",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-matthew-zell",
+        "nodeTitle": "Matthew Zell"
+      }
+    ]
+  },
+  "Q61067": {
+    "wikidataId": "Q61067",
+    "wikipediaTitle": "Johann_Reuchlin",
+    "canonicalTitle": "Johannes Reuchlin",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-johannes-reuchlin",
+        "nodeTitle": "Johannes Reuchlin"
+      }
+    ]
+  },
+  "Q42544": {
+    "wikidataId": "Q42544",
+    "wikipediaTitle": "Thomas_More",
+    "canonicalTitle": "Thomas More",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-thomas-more",
+        "nodeTitle": "Thomas More"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-thomas-more",
+        "nodeTitle": "Thomas More"
+      }
+    ]
+  },
+  "Q62532": {
+    "wikidataId": "Q62532",
+    "wikipediaTitle": "Balthasar_Hubmaier",
+    "canonicalTitle": "Balthasar Hubmaier",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-balthasar-hubmaier",
+        "nodeTitle": "Balthasar Hubmaier"
+      }
+    ]
+  },
+  "Q77233": {
+    "wikidataId": "Q77233",
+    "wikipediaTitle": "Frederick_III,_Elector_of_Saxony",
+    "canonicalTitle": "Frederick the Wise",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-frederick-the-wise",
+        "nodeTitle": "Frederick the Wise"
+      }
+    ]
+  },
+  "Q61277": {
+    "wikidataId": "Q61277",
+    "wikipediaTitle": "John,_Elector_of_Saxony",
+    "canonicalTitle": "John the Steadfast",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-the-steadfast",
+        "nodeTitle": "John the Steadfast"
+      }
+    ]
+  },
+  "Q38370": {
+    "wikidataId": "Q38370",
+    "wikipediaTitle": "Henry_VIII",
+    "canonicalTitle": "Henry VIII",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-henry-viii",
+        "nodeTitle": "Henry VIII"
+      }
+    ]
+  },
+  "Q32500": {
+    "wikidataId": "Q32500",
+    "wikipediaTitle": "Charles_V,_Holy_Roman_Emperor",
+    "canonicalTitle": "Charles V",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-charles-v",
+        "nodeTitle": "Charles V"
+      }
+    ]
+  },
+  "Q60298": {
+    "wikidataId": "Q60298",
+    "wikipediaTitle": "Johann_Eck",
+    "canonicalTitle": "Johann Eck",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-johann-eck",
+        "nodeTitle": "Johann Eck"
+      }
+    ]
+  },
+  "Q6837": {
+    "wikidataId": "Q6837",
+    "wikipediaTitle": "Wittenberg",
+    "canonicalTitle": "Wittenberg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-wittenberg",
+        "nodeTitle": "Wittenberg"
+      }
+    ]
+  },
+  "Q3852": {
+    "wikidataId": "Q3852",
+    "wikipediaTitle": "Worms,_Germany",
+    "canonicalTitle": "Worms",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-worms",
+        "nodeTitle": "Worms"
+      }
+    ]
+  },
+  "Q2749": {
+    "wikidataId": "Q2749",
+    "wikipediaTitle": "Augsburg",
+    "canonicalTitle": "Augsburg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-augsburg",
+        "nodeTitle": "Augsburg"
+      },
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-augsburg",
+        "nodeTitle": "Augsburg"
+      }
+    ]
+  },
+  "Q3869": {
+    "wikidataId": "Q3869",
+    "wikipediaTitle": "Marburg",
+    "canonicalTitle": "Marburg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-marburg",
+        "nodeTitle": "Marburg"
+      },
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-marburg",
+        "nodeTitle": "Marburg"
+      }
+    ]
+  },
+  "Q2090": {
+    "wikidataId": "Q2090",
+    "wikipediaTitle": "Nuremberg",
+    "canonicalTitle": "Nuremberg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-nuremberg",
+        "nodeTitle": "Nuremberg"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-nuremberg",
+        "nodeTitle": "Nuremberg"
+      }
+    ]
+  },
+  "Q1729": {
+    "wikidataId": "Q1729",
+    "wikipediaTitle": "Erfurt",
+    "canonicalTitle": "Erfurt",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-erfurt",
+        "nodeTitle": "Erfurt"
+      }
+    ]
+  },
+  "Q14925": {
+    "wikidataId": "Q14925",
+    "wikipediaTitle": "Mühlhausen",
+    "canonicalTitle": "Mühlhausen",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-muhlhausen",
+        "nodeTitle": "Mühlhausen"
+      }
+    ]
+  },
+  "Q78": {
+    "wikidataId": "Q78",
+    "wikipediaTitle": "Basel",
+    "canonicalTitle": "Basel",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-basel",
+        "nodeTitle": "Basel"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-basel",
+        "nodeTitle": "Basel"
+      },
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-basel",
+        "nodeTitle": "Basel"
+      }
+    ]
+  },
+  "Q70": {
+    "wikidataId": "Q70",
+    "wikipediaTitle": "Bern",
+    "canonicalTitle": "Bern",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-bern",
+        "nodeTitle": "Bern"
+      }
+    ]
+  },
+  "Q807": {
+    "wikidataId": "Q807",
+    "wikipediaTitle": "Lausanne",
+    "canonicalTitle": "Lausanne",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-lausanne",
+        "nodeTitle": "Lausanne"
+      }
+    ]
+  },
+  "Q6602": {
+    "wikidataId": "Q6602",
+    "wikipediaTitle": "Strasbourg",
+    "canonicalTitle": "Strasbourg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-strasbourg",
+        "nodeTitle": "Strasbourg"
+      }
+    ]
+  },
+  "Q29303": {
+    "wikidataId": "Q29303",
+    "wikipediaTitle": "Canterbury",
+    "canonicalTitle": "Canterbury",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-canterbury",
+        "nodeTitle": "Canterbury"
+      }
+    ]
+  },
+  "Q34217": {
+    "wikidataId": "Q34217",
+    "wikipediaTitle": "Oxford",
+    "canonicalTitle": "Oxford",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-oxford",
+        "nodeTitle": "Oxford"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-oxford",
+        "nodeTitle": "Oxford"
+      }
+    ]
+  },
+  "Q34433": {
+    "wikidataId": "Q34433",
+    "wikipediaTitle": "University_of_Oxford",
+    "canonicalTitle": "University of Oxford",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-oxford-university",
+        "nodeTitle": "University of Oxford"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-oxford",
+        "nodeTitle": "University of Oxford"
+      }
+    ]
+  },
+  "Q350": {
+    "wikidataId": "Q350",
+    "wikipediaTitle": "Cambridge",
+    "canonicalTitle": "Cambridge",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-cambridge",
+        "nodeTitle": "Cambridge"
+      }
+    ]
+  },
+  "Q12892": {
+    "wikidataId": "Q12892",
+    "wikipediaTitle": "Antwerp",
+    "canonicalTitle": "Antwerp",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-antwerp",
+        "nodeTitle": "Antwerp"
+      }
+    ]
+  },
+  "Q3004": {
+    "wikidataId": "Q3004",
+    "wikipediaTitle": "Ingolstadt",
+    "canonicalTitle": "Ingolstadt",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-ingolstadt",
+        "nodeTitle": "Ingolstadt"
+      }
+    ]
+  },
+  "Q69111": {
+    "wikidataId": "Q69111",
+    "wikipediaTitle": "Schleitheim",
+    "canonicalTitle": "Schleitheim",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-schleitheim",
+        "nodeTitle": "Schleitheim"
+      }
+    ]
+  },
+  "Q75809": {
+    "wikidataId": "Q75809",
+    "wikipediaTitle": "Lutheranism",
+    "canonicalTitle": "Lutheran Territorial Churches",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-lutheran-churches",
+        "nodeTitle": "Lutheran Territorial Churches"
+      }
+    ]
+  },
+  "Q82708": {
+    "wikidataId": "Q82708",
+    "wikipediaTitle": "Church_of_England",
+    "canonicalTitle": "Church of England",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-church-of-england",
+        "nodeTitle": "Church of England"
+      }
+    ]
+  },
+  "Q12562": {
+    "wikidataId": "Q12562",
+    "wikipediaTitle": "Reformation",
+    "canonicalTitle": "Lutheran Reformation",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-lutheran-reformation",
+        "nodeTitle": "Lutheran Reformation"
+      }
+    ]
+  },
+  "Q29075": {
+    "wikidataId": "Q29075",
+    "wikipediaTitle": "Order_of_Saint_Augustine",
+    "canonicalTitle": "Augustinian Order",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-augustinian-order",
+        "nodeTitle": "Augustinian Order"
+      }
+    ]
+  },
+  "Q1401": {
+    "wikidataId": "Q1401",
+    "wikipediaTitle": "Petrarch",
+    "canonicalTitle": "Francesco Petrarca (Petrarch)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-francesco-petrarca",
+        "nodeTitle": "Francesco Petrarca (Petrarch)"
+      }
+    ]
+  },
+  "Q1402": {
+    "wikidataId": "Q1402",
+    "wikipediaTitle": "Giovanni_Boccaccio",
+    "canonicalTitle": "Giovanni Boccaccio",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giovanni-boccaccio",
+        "nodeTitle": "Giovanni Boccaccio"
+      }
+    ]
+  },
+  "Q93113": {
+    "wikidataId": "Q93113",
+    "wikipediaTitle": "Coluccio_Salutati",
+    "canonicalTitle": "Coluccio Salutati",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-coluccio-salutati",
+        "nodeTitle": "Coluccio Salutati"
+      }
+    ]
+  },
+  "Q1399": {
+    "wikidataId": "Q1399",
+    "wikipediaTitle": "Niccolò_Machiavelli",
+    "canonicalTitle": "Niccolò Machiavelli",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-niccolo-machiavelli",
+        "nodeTitle": "Niccolò Machiavelli"
+      }
+    ]
+  },
+  "Q44601": {
+    "wikidataId": "Q44601",
+    "wikipediaTitle": "Francesco_Guicciardini",
+    "canonicalTitle": "Francesco Guicciardini",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-francesco-guicciardini",
+        "nodeTitle": "Francesco Guicciardini"
+      }
+    ]
+  },
+  "Q60625": {
+    "wikidataId": "Q60625",
+    "wikipediaTitle": "Conrad_Celtes",
+    "canonicalTitle": "Conrad Celtis",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-conrad-celtis",
+        "nodeTitle": "Conrad Celtis"
+      }
+    ]
+  },
+  "Q62663": {
+    "wikidataId": "Q62663",
+    "wikipediaTitle": "Willibald_Pirckheimer",
+    "canonicalTitle": "Willibald Pirckheimer",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-willibald-pirckheimer",
+        "nodeTitle": "Willibald Pirckheimer"
+      }
+    ]
+  },
+  "Q71848": {
+    "wikidataId": "Q71848",
+    "wikipediaTitle": "Jakob_Wimpfeling",
+    "canonicalTitle": "Jakob Wimpfeling",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-jakob-wimpfeling",
+        "nodeTitle": "Jakob Wimpfeling"
+      }
+    ]
+  },
+  "Q41568": {
+    "wikidataId": "Q41568",
+    "wikipediaTitle": "Michel_de_Montaigne",
+    "canonicalTitle": "Michel de Montaigne",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-michel-de-montaigne",
+        "nodeTitle": "Michel de Montaigne"
+      }
+    ]
+  },
+  "Q66382": {
+    "wikidataId": "Q66382",
+    "wikipediaTitle": "Johannes_Sturm",
+    "canonicalTitle": "Johannes Sturm",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-johannes-sturm",
+        "nodeTitle": "Johannes Sturm"
+      }
+    ]
+  },
+  "Q26648": {
+    "wikidataId": "Q26648",
+    "wikipediaTitle": "John_Argyropoulos",
+    "canonicalTitle": "Johannes Argyropoulos",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-johannes-argyropoulos",
+        "nodeTitle": "Johannes Argyropoulos"
+      }
+    ]
+  },
+  "Q4622": {
+    "wikidataId": "Q4622",
+    "wikipediaTitle": "Francesco_Filelfo",
+    "canonicalTitle": "Francesco Filelfo",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-francesco-filelfo",
+        "nodeTitle": "Francesco Filelfo"
+      }
+    ]
+  },
+  "Q16438": {
+    "wikidataId": "Q16438",
+    "wikipediaTitle": "The_Decameron",
+    "canonicalTitle": "Decameron",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-decameron",
+        "nodeTitle": "Decameron"
+      }
+    ]
+  },
+  "Q2634": {
+    "wikidataId": "Q2634",
+    "wikipediaTitle": "Naples",
+    "canonicalTitle": "Naples",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-naples",
+        "nodeTitle": "Naples"
+      }
+    ]
+  },
+  "Q13362": {
+    "wikidataId": "Q13362",
+    "wikipediaTitle": "Ferrara",
+    "canonicalTitle": "Ferrara",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-ferrara",
+        "nodeTitle": "Ferrara"
+      }
+    ]
+  },
+  "Q617": {
+    "wikidataId": "Q617",
+    "wikipediaTitle": "Padua",
+    "canonicalTitle": "Padua",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-padua",
+        "nodeTitle": "Padua"
+      }
+    ]
+  },
+  "Q6247": {
+    "wikidataId": "Q6247",
+    "wikipediaTitle": "Mantua",
+    "canonicalTitle": "Mantua",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-mantua",
+        "nodeTitle": "Mantua"
+      }
+    ]
+  },
+  "Q2759": {
+    "wikidataId": "Q2759",
+    "wikipediaTitle": "Urbino",
+    "canonicalTitle": "Urbino",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-urbino",
+        "nodeTitle": "Urbino"
+      }
+    ]
+  },
+  "Q12994": {
+    "wikidataId": "Q12994",
+    "wikipediaTitle": "Bruges",
+    "canonicalTitle": "Bruges",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-bruges",
+        "nodeTitle": "Bruges"
+      }
+    ]
+  },
+  "Q34370": {
+    "wikidataId": "Q34370",
+    "wikipediaTitle": "Rotterdam",
+    "canonicalTitle": "Rotterdam",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-rotterdam",
+        "nodeTitle": "Rotterdam"
+      }
+    ]
+  },
+  "Q77017": {
+    "wikidataId": "Q77017",
+    "wikipediaTitle": "Jakob_Böhme",
+    "canonicalTitle": "Jacob Boehme",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-jacob-boehme",
+        "nodeTitle": "Jacob Boehme"
+      }
+    ]
+  },
+  "Q60854": {
+    "wikidataId": "Q60854",
+    "wikipediaTitle": "Johann_Valentin_Andreae",
+    "canonicalTitle": "Johann Valentin Andreae",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-jv-andreae",
+        "nodeTitle": "Johann Valentin Andreae"
+      }
+    ]
+  },
+  "Q99371": {
+    "wikidataId": "Q99371",
+    "wikipediaTitle": "Christopher_Besoldus",
+    "canonicalTitle": "Christoph Besold",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-christoph-besold",
+        "nodeTitle": "Christoph Besold"
+      }
+    ]
+  },
+  "Q61359": {
+    "wikidataId": "Q61359",
+    "wikipediaTitle": "Johann_Arndt",
+    "canonicalTitle": "Johann Arndt",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-johann-arndt",
+        "nodeTitle": "Johann Arndt"
+      }
+    ]
+  },
+  "Q77397": {
+    "wikidataId": "Q77397",
+    "wikipediaTitle": "Valentin_Weigel",
+    "canonicalTitle": "Valentin Weigel",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-valentin-weigel",
+        "nodeTitle": "Valentin Weigel"
+      }
+    ]
+  },
+  "Q63170": {
+    "wikidataId": "Q63170",
+    "wikipediaTitle": "Sebastian_Franck",
+    "canonicalTitle": "Sebastian Franck",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-sebastian-franck",
+        "nodeTitle": "Sebastian Franck"
+      }
+    ]
+  },
+  "Q64137": {
+    "wikidataId": "Q64137",
+    "wikipediaTitle": "Caspar_Schwenckfeld",
+    "canonicalTitle": "Caspar Schwenckfeld",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-caspar-schwenckfeld",
+        "nodeTitle": "Caspar Schwenckfeld"
+      }
+    ]
+  },
+  "Q75093": {
+    "wikidataId": "Q75093",
+    "wikipediaTitle": "Johann_Georg_Gichtel",
+    "canonicalTitle": "Johann Georg Gichtel",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-jg-gichtel",
+        "nodeTitle": "Johann Georg Gichtel"
+      }
+    ]
+  },
+  "Q91466": {
+    "wikidataId": "Q91466",
+    "wikipediaTitle": "Adam_von_Bodenstein",
+    "canonicalTitle": "Adam von Bodenstein",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-adam-bodenstein",
+        "nodeTitle": "Adam von Bodenstein"
+      }
+    ]
+  },
+  "Q73366": {
+    "wikidataId": "Q73366",
+    "wikipediaTitle": "Heinrich_Khunrath",
+    "canonicalTitle": "Heinrich Khunrath",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-heinrich-khunrath",
+        "nodeTitle": "Heinrich Khunrath"
+      }
+    ]
+  },
+  "Q31161": {
+    "wikidataId": "Q31161",
+    "wikipediaTitle": "Andreas_Libavius",
+    "canonicalTitle": "Andreas Libavius",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-andreas-libavius",
+        "nodeTitle": "Andreas Libavius"
+      }
+    ]
+  },
+  "Q75164": {
+    "wikidataId": "Q75164",
+    "wikipediaTitle": "Daniel_Sennert",
+    "canonicalTitle": "Daniel Sennert",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-daniel-sennert",
+        "nodeTitle": "Daniel Sennert"
+      }
+    ]
+  },
+  "Q36620": {
+    "wikidataId": "Q36620",
+    "wikipediaTitle": "Tycho_Brahe",
+    "canonicalTitle": "Tycho Brahe",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-tycho-brahe",
+        "nodeTitle": "Tycho Brahe"
+      }
+    ]
+  },
+  "Q8963": {
+    "wikidataId": "Q8963",
+    "wikipediaTitle": "Johannes_Kepler",
+    "canonicalTitle": "Johannes Kepler",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-johannes-kepler",
+        "nodeTitle": "Johannes Kepler"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-johannes-kepler",
+        "nodeTitle": "Johannes Kepler"
+      }
+    ]
+  },
+  "Q37388": {
+    "wikidataId": "Q37388",
+    "wikipediaTitle": "Francis_Bacon",
+    "canonicalTitle": "Francis Bacon",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-francis-bacon",
+        "nodeTitle": "Francis Bacon"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-francis-bacon",
+        "nodeTitle": "Francis Bacon"
+      }
+    ]
+  },
+  "Q57195": {
+    "wikidataId": "Q57195",
+    "wikipediaTitle": "Frederick_V_of_the_Palatinate",
+    "canonicalTitle": "Frederick V, Elector Palatine",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-frederick-v",
+        "nodeTitle": "Frederick V, Elector Palatine"
+      }
+    ]
+  },
+  "Q3806": {
+    "wikidataId": "Q3806",
+    "wikipediaTitle": "Tübingen",
+    "canonicalTitle": "Tübingen",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-tubingen",
+        "nodeTitle": "Tübingen"
+      }
+    ]
+  },
+  "Q1085": {
+    "wikidataId": "Q1085",
+    "wikipediaTitle": "Prague",
+    "canonicalTitle": "Prague",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-prague",
+        "nodeTitle": "Prague"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-prague",
+        "nodeTitle": "Prague"
+      }
+    ]
+  },
+  "Q2966": {
+    "wikidataId": "Q2966",
+    "wikipediaTitle": "Heidelberg",
+    "canonicalTitle": "Heidelberg",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-heidelberg",
+        "nodeTitle": "Heidelberg"
+      }
+    ]
+  },
+  "Q4077": {
+    "wikidataId": "Q4077",
+    "wikipediaTitle": "Görlitz",
+    "canonicalTitle": "Görlitz",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-gorlitz",
+        "nodeTitle": "Görlitz"
+      }
+    ]
+  },
+  "Q2865": {
+    "wikidataId": "Q2865",
+    "wikipediaTitle": "Kassel",
+    "canonicalTitle": "Kassel",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-kassel",
+        "nodeTitle": "Kassel"
+      }
+    ]
+  },
+  "Q36600": {
+    "wikidataId": "Q36600",
+    "wikipediaTitle": "The_Hague",
+    "canonicalTitle": "The Hague",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-the-hague",
+        "nodeTitle": "The Hague"
+      }
+    ]
+  },
+  "Q95479": {
+    "wikidataId": "Q95479",
+    "wikipediaTitle": "Daniel_Cramer",
+    "canonicalTitle": "Daniel Cramer",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-daniel-cramer",
+        "nodeTitle": "Daniel Cramer"
+      }
+    ]
+  },
+  "Q12735": {
+    "wikidataId": "Q12735",
+    "wikipediaTitle": "John_Amos_Comenius",
+    "canonicalTitle": "Jan Amos Comenius",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-jan-amos-comenius",
+        "nodeTitle": "Jan Amos Comenius"
+      }
+    ]
+  },
+  "Q71033": {
+    "wikidataId": "Q71033",
+    "wikipediaTitle": "Samuel_Hartlib",
+    "canonicalTitle": "Samuel Hartlib",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-samuel-hartlib",
+        "nodeTitle": "Samuel Hartlib"
+      }
+    ]
+  },
+  "Q619": {
+    "wikidataId": "Q619",
+    "wikipediaTitle": "Nicolaus_Copernicus",
+    "canonicalTitle": "Nicolaus Copernicus",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-nicolaus-copernicus",
+        "nodeTitle": "Nicolaus Copernicus"
+      }
+    ]
+  },
+  "Q36866": {
+    "wikidataId": "Q36866",
+    "wikipediaTitle": "Tycho_Brahe",
+    "canonicalTitle": "Tycho Brahe",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-tycho-brahe",
+        "nodeTitle": "Tycho Brahe"
+      }
+    ]
+  },
+  "Q307": {
+    "wikidataId": "Q307",
+    "wikipediaTitle": "Galileo_Galilei",
+    "canonicalTitle": "Galileo Galilei",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-galileo-galilei",
+        "nodeTitle": "Galileo Galilei"
+      }
+    ]
+  },
+  "Q43393": {
+    "wikidataId": "Q43393",
+    "wikipediaTitle": "Robert_Boyle",
+    "canonicalTitle": "Robert Boyle",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-robert-boyle",
+        "nodeTitle": "Robert Boyle"
+      }
+    ]
+  },
+  "Q47081": {
+    "wikidataId": "Q47081",
+    "wikipediaTitle": "Robert_Hooke",
+    "canonicalTitle": "Robert Hooke",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-robert-hooke",
+        "nodeTitle": "Robert Hooke"
+      }
+    ]
+  },
+  "Q41790": {
+    "wikidataId": "Q41790",
+    "wikipediaTitle": "Edmond_Halley",
+    "canonicalTitle": "Edmond Halley",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-edmond-halley",
+        "nodeTitle": "Edmond Halley"
+      }
+    ]
+  },
+  "Q39599": {
+    "wikidataId": "Q39599",
+    "wikipediaTitle": "Christiaan_Huygens",
+    "canonicalTitle": "Christiaan Huygens",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-christiaan-huygens",
+        "nodeTitle": "Christiaan Huygens"
+      }
+    ]
+  },
+  "Q62821": {
+    "wikidataId": "Q62821",
+    "wikipediaTitle": "Samuel_Hartlib",
+    "canonicalTitle": "Samuel Hartlib",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-samuel-hartlib",
+        "nodeTitle": "Samuel Hartlib"
+      }
+    ]
+  },
+  "Q72429": {
+    "wikidataId": "Q72429",
+    "wikipediaTitle": "Maria_Cunitz",
+    "canonicalTitle": "Maria Cunitz",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-maria-cunitz",
+        "nodeTitle": "Maria Cunitz"
+      }
+    ]
+  },
+  "Q5765": {
+    "wikidataId": "Q5765",
+    "wikipediaTitle": "Rudolf_II,_Holy_Roman_Emperor",
+    "canonicalTitle": "Rudolf II",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-rudolf-ii",
+        "nodeTitle": "Rudolf II"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-habsburg-court",
+        "nodeTitle": "Habsburg Court (Prague)"
+      }
+    ]
+  },
+  "Q37317": {
+    "wikidataId": "Q37317",
+    "wikipediaTitle": "House_of_Medici",
+    "canonicalTitle": "Medici Court",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-medici-court",
+        "nodeTitle": "Medici Court"
+      }
+    ]
+  },
+  "Q9191": {
+    "wikidataId": "Q9191",
+    "wikipediaTitle": "René_Descartes",
+    "canonicalTitle": "René Descartes",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-rene-descartes",
+        "nodeTitle": "René Descartes"
+      }
+    ]
+  },
+  "Q41279": {
+    "wikidataId": "Q41279",
+    "wikipediaTitle": "Christopher_Wren",
+    "canonicalTitle": "Christopher Wren",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-christopher-wren",
+        "nodeTitle": "Christopher Wren"
+      }
+    ]
+  },
+  "Q60017": {
+    "wikidataId": "Q60017",
+    "wikipediaTitle": "Henry_Oldenburg",
+    "canonicalTitle": "Henry Oldenburg",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-henry-oldenburg",
+        "nodeTitle": "Henry Oldenburg"
+      }
+    ]
+  },
+  "Q47159": {
+    "wikidataId": "Q47159",
+    "wikipediaTitle": "Evangelista_Torricelli",
+    "canonicalTitle": "Evangelista Torricelli",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-evangelista-torricelli",
+        "nodeTitle": "Evangelista Torricelli"
+      }
+    ]
+  },
+  "Q1290": {
+    "wikidataId": "Q1290",
+    "wikipediaTitle": "Blaise_Pascal",
+    "canonicalTitle": "Blaise Pascal",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-blaise-pascal",
+        "nodeTitle": "Blaise Pascal"
+      }
+    ]
+  },
+  "Q60025": {
+    "wikidataId": "Q60025",
+    "wikipediaTitle": "Otto_von_Guericke",
+    "canonicalTitle": "Otto von Guericke",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-otto-von-guericke",
+        "nodeTitle": "Otto von Guericke"
+      }
+    ]
+  },
+  "Q83371": {
+    "wikidataId": "Q83371",
+    "wikipediaTitle": "Ole_Rømer",
+    "canonicalTitle": "Ole Rømer",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-ole-romer",
+        "nodeTitle": "Ole Rømer"
+      }
+    ]
+  },
+  "Q76584": {
+    "wikidataId": "Q76584",
+    "wikipediaTitle": "Adolphe_Quetelet",
+    "canonicalTitle": "Adolphe Quetelet",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-adolphe-quetelet",
+        "nodeTitle": "Adolphe Quetelet"
+      }
+    ]
+  },
+  "Q6722": {
+    "wikidataId": "Q6722",
+    "wikipediaTitle": "Carl_Friedrich_Gauss",
+    "canonicalTitle": "Carl Friedrich Gauss",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-carl-friedrich-gauss",
+        "nodeTitle": "Carl Friedrich Gauss"
+      }
+    ]
+  },
+  "Q37979": {
+    "wikidataId": "Q37979",
+    "wikipediaTitle": "Marquis_de_Condorcet",
+    "canonicalTitle": "Marquis de Condorcet",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-marquis-de-condorcet",
+        "nodeTitle": "Marquis de Condorcet"
+      }
+    ]
+  },
+  "Q49767": {
+    "wikidataId": "Q49767",
+    "wikipediaTitle": "Siméon_Denis_Poisson",
+    "canonicalTitle": "Siméon Denis Poisson",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-simeon-denis-poisson",
+        "nodeTitle": "Siméon Denis Poisson"
+      }
+    ]
+  },
+  "Q38348": {
+    "wikidataId": "Q38348",
+    "wikipediaTitle": "Florence_Nightingale",
+    "canonicalTitle": "Florence Nightingale",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-florence-nightingale",
+        "nodeTitle": "Florence Nightingale"
+      }
+    ]
+  },
+  "Q1035": {
+    "wikidataId": "Q1035",
+    "wikipediaTitle": "Charles_Darwin",
+    "canonicalTitle": "Charles Darwin",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-charles-darwin",
+        "nodeTitle": "Charles Darwin"
+      }
+    ]
+  },
+  "Q44279": {
+    "wikidataId": "Q44279",
+    "wikipediaTitle": "Émile_Durkheim",
+    "canonicalTitle": "Émile Durkheim",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-emile-durkheim",
+        "nodeTitle": "Émile Durkheim"
+      }
+    ]
+  },
+  "Q76610": {
+    "wikidataId": "Q76610",
+    "wikipediaTitle": "Johann_Heinrich_Lambert",
+    "canonicalTitle": "Johann Heinrich Lambert",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-johann-heinrich-lambert",
+        "nodeTitle": "Johann Heinrich Lambert"
+      }
+    ]
+  },
+  "Q78247": {
+    "wikidataId": "Q78247",
+    "wikipediaTitle": "Friedrich_Bessel",
+    "canonicalTitle": "Friedrich Wilhelm Bessel",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-friedrich-bessel",
+        "nodeTitle": "Friedrich Wilhelm Bessel"
+      }
+    ]
+  },
+  "Q57330": {
+    "wikidataId": "Q57330",
+    "wikipediaTitle": "Johann_Franz_Encke",
+    "canonicalTitle": "Johann Franz Encke",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-johann-franz-encke",
+        "nodeTitle": "Johann Franz Encke"
+      }
+    ]
+  },
+  "Q61071": {
+    "wikidataId": "Q61071",
+    "wikipediaTitle": "Tobias_Mayer",
+    "canonicalTitle": "Tobias Mayer",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-tobias-mayer",
+        "nodeTitle": "Tobias Mayer"
+      }
+    ]
+  },
+  "Q64383": {
+    "wikidataId": "Q64383",
+    "wikipediaTitle": "Wilhelm_Lexis",
+    "canonicalTitle": "Wilhelm Lexis",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-wilhelm-lexis",
+        "nodeTitle": "Wilhelm Lexis"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q100000-Q199999.json
+++ b/public/cross-scene-index/by-wikidata/Q100000-Q199999.json
@@ -1,0 +1,1699 @@
+{
+  "Q180865": {
+    "wikidataId": "Q180865",
+    "wikipediaTitle": "University_of_Toronto",
+    "canonicalTitle": "University of Toronto",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-utoronto",
+        "nodeTitle": "University of Toronto"
+      }
+    ]
+  },
+  "Q168756": {
+    "wikidataId": "Q168756",
+    "wikipediaTitle": "University_of_California,_Berkeley",
+    "canonicalTitle": "UC Berkeley",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-ucberkeley",
+        "nodeTitle": "UC Berkeley"
+      }
+    ]
+  },
+  "Q190080": {
+    "wikidataId": "Q190080",
+    "wikipediaTitle": "Carnegie_Mellon_University",
+    "canonicalTitle": "Carnegie Mellon University",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-cmu",
+        "nodeTitle": "Carnegie Mellon University"
+      },
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-carnegie-mellon",
+        "nodeTitle": "Carnegie Mellon University"
+      }
+    ]
+  },
+  "Q108524": {
+    "wikidataId": "Q108524",
+    "wikipediaTitle": "Redmond,_Washington",
+    "canonicalTitle": "Redmond, Washington",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-redmond",
+        "nodeTitle": "Redmond, Washington"
+      }
+    ]
+  },
+  "Q187192": {
+    "wikidataId": "Q187192",
+    "wikipediaTitle": "Erik_Satie",
+    "canonicalTitle": "Erik Satie",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-erik-satie",
+        "nodeTitle": "Erik Satie"
+      }
+    ]
+  },
+  "Q180727": {
+    "wikidataId": "Q180727",
+    "wikipediaTitle": "John_Cage",
+    "canonicalTitle": "John Cage",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-john-cage",
+        "nodeTitle": "John Cage"
+      }
+    ]
+  },
+  "Q154556": {
+    "wikidataId": "Q154556",
+    "wikipediaTitle": "Karlheinz_Stockhausen",
+    "canonicalTitle": "Karlheinz Stockhausen",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-karlheinz-stockhausen",
+        "nodeTitle": "Karlheinz Stockhausen"
+      }
+    ]
+  },
+  "Q168015": {
+    "wikidataId": "Q168015",
+    "wikipediaTitle": "Klaus_Schulze",
+    "canonicalTitle": "Klaus Schulze",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-klaus-schulze",
+        "nodeTitle": "Klaus Schulze"
+      }
+    ]
+  },
+  "Q189729": {
+    "wikidataId": "Q189729",
+    "wikipediaTitle": "Philip_Glass",
+    "canonicalTitle": "Philip Glass",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-philip-glass",
+        "nodeTitle": "Philip Glass"
+      }
+    ]
+  },
+  "Q127100": {
+    "wikidataId": "Q127100",
+    "wikipediaTitle": "Ambient_1:_Music_for_Airports",
+    "canonicalTitle": "Ambient 1: Music for Airports",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-music-for-airports",
+        "nodeTitle": "Ambient 1: Music for Airports"
+      }
+    ]
+  },
+  "Q133116": {
+    "wikidataId": "Q133116",
+    "wikipediaTitle": "Hamilton,_Ontario",
+    "canonicalTitle": "Hamilton, Ontario",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-hamilton",
+        "nodeTitle": "Hamilton, Ontario"
+      }
+    ]
+  },
+  "Q153616": {
+    "wikidataId": "Q153616",
+    "wikipediaTitle": "Tangerine_Dream",
+    "canonicalTitle": "Tangerine Dream",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-tangerine-dream",
+        "nodeTitle": "Tangerine Dream"
+      }
+    ]
+  },
+  "Q181874": {
+    "wikidataId": "Q181874",
+    "wikipediaTitle": "Neu!",
+    "canonicalTitle": "Neu!",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-neu",
+        "nodeTitle": "Neu!"
+      }
+    ]
+  },
+  "Q189382": {
+    "wikidataId": "Q189382",
+    "wikipediaTitle": "King_Crimson",
+    "canonicalTitle": "King Crimson",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-king-crimson",
+        "nodeTitle": "King Crimson"
+      }
+    ]
+  },
+  "Q170132": {
+    "wikidataId": "Q170132",
+    "wikipediaTitle": "Can_(band)",
+    "canonicalTitle": "Can",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-can",
+        "nodeTitle": "Can"
+      }
+    ]
+  },
+  "Q193207": {
+    "wikidataId": "Q193207",
+    "wikipediaTitle": "Ambient_music",
+    "canonicalTitle": "Ambient Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-ambient-movement",
+        "nodeTitle": "Ambient Music"
+      }
+    ]
+  },
+  "Q131221": {
+    "wikidataId": "Q131221",
+    "wikipediaTitle": "Futurism",
+    "canonicalTitle": "Futurism",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-futurism",
+        "nodeTitle": "Futurism"
+      }
+    ]
+  },
+  "Q185977": {
+    "wikidataId": "Q185977",
+    "wikipediaTitle": "Giovanni_Pico_della_Mirandola",
+    "canonicalTitle": "Giovanni Pico della Mirandola",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-giovanni-pico-della-mirandola",
+        "nodeTitle": "Giovanni Pico della Mirandola"
+      }
+    ]
+  },
+  "Q154781": {
+    "wikidataId": "Q154781",
+    "wikipediaTitle": "Marsilio_Ficino",
+    "canonicalTitle": "Marsilio Ficino",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-marsilio-ficino",
+        "nodeTitle": "Marsilio Ficino"
+      }
+    ]
+  },
+  "Q151510": {
+    "wikidataId": "Q151510",
+    "wikipediaTitle": "University_of_Cologne",
+    "canonicalTitle": "University of Cologne",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "entity-university-of-cologne",
+        "nodeTitle": "University of Cologne"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-heidelberg",
+        "nodeTitle": "University of Heidelberg"
+      }
+    ]
+  },
+  "Q192632": {
+    "wikidataId": "Q192632",
+    "wikipediaTitle": "Dominican_Order",
+    "canonicalTitle": "Dominican Order (Cologne)",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "entity-dominican-order",
+        "nodeTitle": "Dominican Order (Cologne)"
+      }
+    ]
+  },
+  "Q177854": {
+    "wikidataId": "Q177854",
+    "wikipediaTitle": "Lorenzo_de'_Medici",
+    "canonicalTitle": "Lorenzo de' Medici",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-lorenzo-de-medici",
+        "nodeTitle": "Lorenzo de' Medici"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-lorenzo-de-medici",
+        "nodeTitle": "Lorenzo de' Medici"
+      }
+    ]
+  },
+  "Q188989": {
+    "wikidataId": "Q188989",
+    "wikipediaTitle": "Cosimo_de'_Medici",
+    "canonicalTitle": "Cosimo de' Medici",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-cosimo-de-medici",
+        "nodeTitle": "Cosimo de' Medici"
+      }
+    ]
+  },
+  "Q150726": {
+    "wikidataId": "Q150726",
+    "wikipediaTitle": "Maximilian_I,_Holy_Roman_Emperor",
+    "canonicalTitle": "Maximilian I, Holy Roman Emperor",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-maximilian-i",
+        "nodeTitle": "Maximilian I, Holy Roman Emperor"
+      }
+    ]
+  },
+  "Q170876": {
+    "wikidataId": "Q170876",
+    "wikipediaTitle": "Pope_Innocent_VIII",
+    "canonicalTitle": "Pope Innocent VIII",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-pope-innocent-viii",
+        "nodeTitle": "Pope Innocent VIII"
+      }
+    ]
+  },
+  "Q178577": {
+    "wikidataId": "Q178577",
+    "wikipediaTitle": "Norbert_Wiener",
+    "canonicalTitle": "Norbert Wiener",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-norbert-wiener",
+        "nodeTitle": "Norbert Wiener"
+      }
+    ]
+  },
+  "Q180099": {
+    "wikidataId": "Q180099",
+    "wikipediaTitle": "Margaret_Mead",
+    "canonicalTitle": "Margaret Mead",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-margaret-mead",
+        "nodeTitle": "Margaret Mead"
+      }
+    ]
+  },
+  "Q121729": {
+    "wikidataId": "Q121729",
+    "wikipediaTitle": "Arturo_Rosenblueth",
+    "canonicalTitle": "Arturo Rosenblueth",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-arturo-rosenblueth",
+        "nodeTitle": "Arturo Rosenblueth"
+      }
+    ]
+  },
+  "Q112176": {
+    "wikidataId": "Q112176",
+    "wikipediaTitle": "Ernst_von_Glasersfeld",
+    "canonicalTitle": "Ernst von Glasersfeld",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ernst-von-glasersfeld",
+        "nodeTitle": "Ernst von Glasersfeld"
+      }
+    ]
+  },
+  "Q181529": {
+    "wikidataId": "Q181529",
+    "wikipediaTitle": "Herbert_A._Simon",
+    "canonicalTitle": "Herbert Simon",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-herbert-simon",
+        "nodeTitle": "Herbert Simon"
+      }
+    ]
+  },
+  "Q183372": {
+    "wikidataId": "Q183372",
+    "wikipediaTitle": "Alfred_North_Whitehead",
+    "canonicalTitle": "Alfred North Whitehead",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-alfred-whitehead",
+        "nodeTitle": "Alfred North Whitehead"
+      }
+    ]
+  },
+  "Q153243": {
+    "wikidataId": "Q153243",
+    "wikipediaTitle": "Josiah_Willard_Gibbs",
+    "canonicalTitle": "Josiah Willard Gibbs",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-josiah-gibbs",
+        "nodeTitle": "Josiah Willard Gibbs"
+      }
+    ]
+  },
+  "Q187520": {
+    "wikidataId": "Q187520",
+    "wikipediaTitle": "Charles_Sanders_Peirce",
+    "canonicalTitle": "Charles Sanders Peirce",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-charles-peirce",
+        "nodeTitle": "Charles Sanders Peirce"
+      }
+    ]
+  },
+  "Q123190": {
+    "wikidataId": "Q123190",
+    "wikipediaTitle": "Jean_Piaget",
+    "canonicalTitle": "Jean Piaget",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-jean-piaget",
+        "nodeTitle": "Jean Piaget"
+      }
+    ]
+  },
+  "Q169399": {
+    "wikidataId": "Q169399",
+    "wikipediaTitle": "ENIAC",
+    "canonicalTitle": "ENIAC",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-eniac",
+        "nodeTitle": "ENIAC"
+      }
+    ]
+  },
+  "Q164591": {
+    "wikidataId": "Q164591",
+    "wikipediaTitle": "Biological_Computer_Laboratory",
+    "canonicalTitle": "Biological Computer Laboratory (BCL)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-bcl-illinois",
+        "nodeTitle": "Biological Computer Laboratory (BCL)"
+      },
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-bcl",
+        "nodeTitle": "Biological Computer Laboratory"
+      }
+    ]
+  },
+  "Q155921": {
+    "wikidataId": "Q155921",
+    "wikipediaTitle": "Bletchley_Park",
+    "canonicalTitle": "Bletchley Park",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-bletchley-park",
+        "nodeTitle": "Bletchley Park"
+      }
+    ]
+  },
+  "Q143363": {
+    "wikidataId": "Q143363",
+    "wikipediaTitle": "Macy_conferences",
+    "canonicalTitle": "Macy Conferences on Cybernetics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-macy-conferences",
+        "nodeTitle": "Macy Conferences on Cybernetics"
+      }
+    ]
+  },
+  "Q123637": {
+    "wikidataId": "Q123637",
+    "wikipediaTitle": "Cybernetics",
+    "canonicalTitle": "Cybernetics (Movement)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-cybernetics-movement",
+        "nodeTitle": "Cybernetics (Movement)"
+      }
+    ]
+  },
+  "Q131222": {
+    "wikidataId": "Q131222",
+    "wikipediaTitle": "Information_theory",
+    "canonicalTitle": "Information Theory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-information-theory",
+        "nodeTitle": "Information Theory"
+      }
+    ]
+  },
+  "Q177524": {
+    "wikidataId": "Q177524",
+    "wikipediaTitle": "ARPANET",
+    "canonicalTitle": "ARPANET",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-arpanet",
+        "nodeTitle": "ARPANET"
+      }
+    ]
+  },
+  "Q153232": {
+    "wikidataId": "Q153232",
+    "wikipediaTitle": "Jean_le_Rond_d'Alembert",
+    "canonicalTitle": "Jean le Rond d'Alembert",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-dalembert",
+        "nodeTitle": "Jean le Rond d'Alembert"
+      }
+    ]
+  },
+  "Q190302": {
+    "wikidataId": "Q190302",
+    "wikipediaTitle": "Claude_Adrien_Helvétius",
+    "canonicalTitle": "Claude-Adrien Helvétius",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-helvetius",
+        "nodeTitle": "Claude-Adrien Helvétius"
+      }
+    ]
+  },
+  "Q178653": {
+    "wikidataId": "Q178653",
+    "wikipediaTitle": "André_Morellet",
+    "canonicalTitle": "André Morellet",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-morellet",
+        "nodeTitle": "André Morellet"
+      }
+    ]
+  },
+  "Q183094": {
+    "wikidataId": "Q183094",
+    "wikipediaTitle": "Adam_Ferguson",
+    "canonicalTitle": "Adam Ferguson",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-adam-ferguson",
+        "nodeTitle": "Adam Ferguson"
+      }
+    ]
+  },
+  "Q155547": {
+    "wikidataId": "Q155547",
+    "wikipediaTitle": "Johann_Gottfried_Herder",
+    "canonicalTitle": "Johann Gottfried Herder",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-johann-herder",
+        "nodeTitle": "Johann Gottfried Herder"
+      }
+    ]
+  },
+  "Q165792": {
+    "wikidataId": "Q165792",
+    "wikipediaTitle": "Edmund_Burke",
+    "canonicalTitle": "Edmund Burke",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-edmund-burke",
+        "nodeTitle": "Edmund Burke"
+      }
+    ]
+  },
+  "Q159636": {
+    "wikidataId": "Q159636",
+    "wikipediaTitle": "Joseph_Priestley",
+    "canonicalTitle": "Joseph Priestley",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-joseph-priestley",
+        "nodeTitle": "Joseph Priestley"
+      }
+    ]
+  },
+  "Q126462": {
+    "wikidataId": "Q126462",
+    "wikipediaTitle": "Thomas_Paine",
+    "canonicalTitle": "Thomas Paine",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-thomas-paine",
+        "nodeTitle": "Thomas Paine"
+      }
+    ]
+  },
+  "Q135598": {
+    "wikidataId": "Q135598",
+    "wikipediaTitle": "Discourse_on_Inequality",
+    "canonicalTitle": "Discourse on the Origin of Inequality",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-discourse-inequality",
+        "nodeTitle": "Discourse on the Origin of Inequality"
+      }
+    ]
+  },
+  "Q190126": {
+    "wikidataId": "Q190126",
+    "wikipediaTitle": "The_Social_Contract",
+    "canonicalTitle": "The Social Contract",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-social-contract",
+        "nodeTitle": "The Social Contract"
+      }
+    ]
+  },
+  "Q127912": {
+    "wikidataId": "Q127912",
+    "wikipediaTitle": "United_States_Declaration_of_Independence",
+    "canonicalTitle": "Declaration of Independence",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-declaration-independence",
+        "nodeTitle": "Declaration of Independence"
+      }
+    ]
+  },
+  "Q160302": {
+    "wikidataId": "Q160302",
+    "wikipediaTitle": "University_of_Edinburgh",
+    "canonicalTitle": "University of Edinburgh",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-univ-edinburgh",
+        "nodeTitle": "University of Edinburgh"
+      }
+    ]
+  },
+  "Q192775": {
+    "wikidataId": "Q192775",
+    "wikipediaTitle": "University_of_Glasgow",
+    "canonicalTitle": "University of Glasgow",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-univ-glasgow",
+        "nodeTitle": "University of Glasgow"
+      }
+    ]
+  },
+  "Q161806": {
+    "wikidataId": "Q161806",
+    "wikipediaTitle": "Académie_Française",
+    "canonicalTitle": "Académie française",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-academie-francaise",
+        "nodeTitle": "Académie française"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-academie-francaise",
+        "nodeTitle": "Académie française (Institution)"
+      }
+    ]
+  },
+  "Q188771": {
+    "wikidataId": "Q188771",
+    "wikipediaTitle": "French_Academy_of_Sciences",
+    "canonicalTitle": "Académie des Sciences",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-academie-sciences",
+        "nodeTitle": "Académie des Sciences"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-academie-sciences",
+        "nodeTitle": "Académie des Sciences (Institution)"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-academie-des-sciences",
+        "nodeTitle": "Académie des Sciences"
+      }
+    ]
+  },
+  "Q123885": {
+    "wikidataId": "Q123885",
+    "wikipediaTitle": "Royal_Society",
+    "canonicalTitle": "Royal Society of London",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-royal-society",
+        "nodeTitle": "Royal Society of London"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-royal-society",
+        "nodeTitle": "Royal Society of London (Institution)"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-royal-society",
+        "nodeTitle": "Royal Society of London"
+      },
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "entity-royal-society",
+        "nodeTitle": "Royal Society"
+      }
+    ]
+  },
+  "Q151330": {
+    "wikidataId": "Q151330",
+    "wikipediaTitle": "Sanssouci",
+    "canonicalTitle": "Sans-Souci Palace",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-sans-souci",
+        "nodeTitle": "Sans-Souci Palace"
+      }
+    ]
+  },
+  "Q182147": {
+    "wikidataId": "Q182147",
+    "wikipediaTitle": "Winter_Palace",
+    "canonicalTitle": "Winter Palace",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-winter-palace",
+        "nodeTitle": "Winter Palace"
+      }
+    ]
+  },
+  "Q183244": {
+    "wikidataId": "Q183244",
+    "wikipediaTitle": "Physiocracy",
+    "canonicalTitle": "Physiocracy",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-physiocracy",
+        "nodeTitle": "Physiocracy"
+      }
+    ]
+  },
+  "Q160590": {
+    "wikidataId": "Q160590",
+    "wikipediaTitle": "Utilitarianism",
+    "canonicalTitle": "Utilitarianism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-utilitarianism",
+        "nodeTitle": "Utilitarianism"
+      }
+    ]
+  },
+  "Q186539": {
+    "wikidataId": "Q186539",
+    "wikipediaTitle": "Founding_Fathers_of_the_United_States",
+    "canonicalTitle": "American Founders",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-american-founders",
+        "nodeTitle": "American Founders"
+      }
+    ]
+  },
+  "Q160239": {
+    "wikidataId": "Q160239",
+    "wikipediaTitle": "Marsilio_Ficino",
+    "canonicalTitle": "Marsilio Ficino",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-marsilio-ficino",
+        "nodeTitle": "Marsilio Ficino"
+      }
+    ]
+  },
+  "Q189798": {
+    "wikidataId": "Q189798",
+    "wikipediaTitle": "Giovanni_Pico_della_Mirandola",
+    "canonicalTitle": "Giovanni Pico della Mirandola",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-giovanni-pico-della-mirandola",
+        "nodeTitle": "Giovanni Pico della Mirandola"
+      }
+    ]
+  },
+  "Q167696": {
+    "wikidataId": "Q167696",
+    "wikipediaTitle": "Cosimo_de'_Medici",
+    "canonicalTitle": "Cosimo de' Medici",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-cosimo-de-medici",
+        "nodeTitle": "Cosimo de' Medici"
+      }
+    ]
+  },
+  "Q166689": {
+    "wikidataId": "Q166689",
+    "wikipediaTitle": "Poliziano",
+    "canonicalTitle": "Angelo Poliziano",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-angelo-poliziano",
+        "nodeTitle": "Angelo Poliziano"
+      }
+    ]
+  },
+  "Q188847": {
+    "wikidataId": "Q188847",
+    "wikipediaTitle": "Proclus",
+    "canonicalTitle": "Proclus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-proclus",
+        "nodeTitle": "Proclus"
+      }
+    ]
+  },
+  "Q179742": {
+    "wikidataId": "Q179742",
+    "wikipediaTitle": "Pseudo-Dionysius_the_Areopagite",
+    "canonicalTitle": "Pseudo-Dionysius the Areopagite",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-pseudo-dionysius",
+        "nodeTitle": "Pseudo-Dionysius the Areopagite"
+      }
+    ]
+  },
+  "Q154537": {
+    "wikidataId": "Q154537",
+    "wikipediaTitle": "Johann_Reuchlin",
+    "canonicalTitle": "Johannes Reuchlin",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-johannes-reuchlin",
+        "nodeTitle": "Johannes Reuchlin"
+      }
+    ]
+  },
+  "Q123034": {
+    "wikidataId": "Q123034",
+    "wikipediaTitle": "Huldrych_Zwingli",
+    "canonicalTitle": "Huldrych Zwingli",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-huldrych-zwingli",
+        "nodeTitle": "Huldrych Zwingli"
+      }
+    ]
+  },
+  "Q199894": {
+    "wikidataId": "Q199894",
+    "wikipediaTitle": "Thomas_Cranmer",
+    "canonicalTitle": "Thomas Cranmer",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-thomas-cranmer",
+        "nodeTitle": "Thomas Cranmer"
+      }
+    ]
+  },
+  "Q191748": {
+    "wikidataId": "Q191748",
+    "wikipediaTitle": "Lucas_Cranach_the_Elder",
+    "canonicalTitle": "Lucas Cranach the Elder",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-lucas-cranach",
+        "nodeTitle": "Lucas Cranach the Elder"
+      }
+    ]
+  },
+  "Q153981": {
+    "wikidataId": "Q153981",
+    "wikipediaTitle": "Thomas_Müntzer",
+    "canonicalTitle": "Thomas Müntzer",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-thomas-muntzer",
+        "nodeTitle": "Thomas Müntzer"
+      }
+    ]
+  },
+  "Q123839": {
+    "wikidataId": "Q123839",
+    "wikipediaTitle": "Heinrich_Bullinger",
+    "canonicalTitle": "Heinrich Bullinger",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-heinrich-bullinger",
+        "nodeTitle": "Heinrich Bullinger"
+      }
+    ]
+  },
+  "Q123450": {
+    "wikidataId": "Q123450",
+    "wikipediaTitle": "Johannes_Oecolampadius",
+    "canonicalTitle": "Johannes Oecolampadius",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-johannes-oecolampadius",
+        "nodeTitle": "Johannes Oecolampadius"
+      }
+    ]
+  },
+  "Q120138": {
+    "wikidataId": "Q120138",
+    "wikipediaTitle": "Rudolf_Gwalther",
+    "canonicalTitle": "Rudolf Gwalther",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-rudolf-gwalther",
+        "nodeTitle": "Rudolf Gwalther"
+      }
+    ]
+  },
+  "Q123337": {
+    "wikidataId": "Q123337",
+    "wikipediaTitle": "Pierre_Viret",
+    "canonicalTitle": "Pierre Viret",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-pierre-viret",
+        "nodeTitle": "Pierre Viret"
+      }
+    ]
+  },
+  "Q118998": {
+    "wikidataId": "Q118998",
+    "wikipediaTitle": "Katharina_Zell",
+    "canonicalTitle": "Katharina Schütz Zell",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-katharina-schutz-zell",
+        "nodeTitle": "Katharina Schütz Zell"
+      }
+    ]
+  },
+  "Q115638": {
+    "wikidataId": "Q115638",
+    "wikipediaTitle": "Conrad_Grebel",
+    "canonicalTitle": "Conrad Grebel",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-conrad-grebel",
+        "nodeTitle": "Conrad Grebel"
+      }
+    ]
+  },
+  "Q124188": {
+    "wikidataId": "Q124188",
+    "wikipediaTitle": "Felix_Manz",
+    "canonicalTitle": "Felix Manz",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-felix-manz",
+        "nodeTitle": "Felix Manz"
+      }
+    ]
+  },
+  "Q124175": {
+    "wikidataId": "Q124175",
+    "wikipediaTitle": "George_Blaurock",
+    "canonicalTitle": "George Blaurock",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-george-blaurock",
+        "nodeTitle": "George Blaurock"
+      }
+    ]
+  },
+  "Q142309": {
+    "wikidataId": "Q142309",
+    "wikipediaTitle": "Michael_Sattler",
+    "canonicalTitle": "Michael Sattler",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-michael-sattler",
+        "nodeTitle": "Michael Sattler"
+      }
+    ]
+  },
+  "Q190058": {
+    "wikidataId": "Q190058",
+    "wikipediaTitle": "Marguerite_de_Navarre",
+    "canonicalTitle": "Marguerite of Navarre",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-marguerite-of-navarre",
+        "nodeTitle": "Marguerite of Navarre"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-marguerite-of-navarre",
+        "nodeTitle": "Marguerite of Navarre"
+      }
+    ]
+  },
+  "Q108926": {
+    "wikidataId": "Q108926",
+    "wikipediaTitle": "Clément_Marot",
+    "canonicalTitle": "Clément Marot",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-clement-marot",
+        "nodeTitle": "Clément Marot"
+      }
+    ]
+  },
+  "Q169319": {
+    "wikidataId": "Q169319",
+    "wikipediaTitle": "Philip_I,_Landgrave_of_Hesse",
+    "canonicalTitle": "Philip of Hesse",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-philip-of-hesse",
+        "nodeTitle": "Philip of Hesse"
+      }
+    ]
+  },
+  "Q189937": {
+    "wikidataId": "Q189937",
+    "wikipediaTitle": "John_Knox",
+    "canonicalTitle": "John Knox",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-knox",
+        "nodeTitle": "John Knox"
+      }
+    ]
+  },
+  "Q157506": {
+    "wikidataId": "Q157506",
+    "wikipediaTitle": "Ninety-five_Theses",
+    "canonicalTitle": "Ninety-Five Theses",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-ninety-five-theses",
+        "nodeTitle": "Ninety-Five Theses"
+      }
+    ]
+  },
+  "Q154483": {
+    "wikidataId": "Q154483",
+    "wikipediaTitle": "Augsburg_Confession",
+    "canonicalTitle": "Augsburg Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-augsburg-confession",
+        "nodeTitle": "Augsburg Confession"
+      }
+    ]
+  },
+  "Q151545": {
+    "wikidataId": "Q151545",
+    "wikipediaTitle": "Wartburg",
+    "canonicalTitle": "Wartburg Castle",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-wartburg",
+        "nodeTitle": "Wartburg Castle"
+      }
+    ]
+  },
+  "Q110223": {
+    "wikidataId": "Q110223",
+    "wikipediaTitle": "Mennonites",
+    "canonicalTitle": "Mennonite Movement",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-mennonites",
+        "nodeTitle": "Mennonite Movement"
+      }
+    ]
+  },
+  "Q155024": {
+    "wikidataId": "Q155024",
+    "wikipediaTitle": "Schmalkaldic_League",
+    "canonicalTitle": "Schmalkaldic League",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-schmalkaldic-league",
+        "nodeTitle": "Schmalkaldic League"
+      }
+    ]
+  },
+  "Q131479": {
+    "wikidataId": "Q131479",
+    "wikipediaTitle": "Dominican_Order",
+    "canonicalTitle": "Dominican Order",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-dominican-order",
+        "nodeTitle": "Dominican Order"
+      }
+    ]
+  },
+  "Q154577": {
+    "wikidataId": "Q154577",
+    "wikipediaTitle": "Peace_of_Augsburg",
+    "canonicalTitle": "Peace of Augsburg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-peace-of-augsburg",
+        "nodeTitle": "Peace of Augsburg"
+      }
+    ]
+  },
+  "Q116611": {
+    "wikidataId": "Q116611",
+    "wikipediaTitle": "Johann_Froben",
+    "canonicalTitle": "Froben Press",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-froben-press",
+        "nodeTitle": "Froben Press"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-johann-froben",
+        "nodeTitle": "Johann Froben"
+      }
+    ]
+  },
+  "Q192374": {
+    "wikidataId": "Q192374",
+    "wikipediaTitle": "Marsilio_Ficino",
+    "canonicalTitle": "Marsilio Ficino",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-marsilio-ficino",
+        "nodeTitle": "Marsilio Ficino"
+      }
+    ]
+  },
+  "Q182128": {
+    "wikidataId": "Q182128",
+    "wikipediaTitle": "Giovanni_Pico_della_Mirandola",
+    "canonicalTitle": "Giovanni Pico della Mirandola",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giovanni-pico",
+        "nodeTitle": "Giovanni Pico della Mirandola"
+      }
+    ]
+  },
+  "Q182046": {
+    "wikidataId": "Q182046",
+    "wikipediaTitle": "Leon_Battista_Alberti",
+    "canonicalTitle": "Leon Battista Alberti",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-leon-battista-alberti",
+        "nodeTitle": "Leon Battista Alberti"
+      }
+    ]
+  },
+  "Q101437": {
+    "wikidataId": "Q101437",
+    "wikipediaTitle": "Pope_Pius_II",
+    "canonicalTitle": "Enea Silvio Piccolomini (Pope Pius II)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-enea-silvio-piccolomini",
+        "nodeTitle": "Enea Silvio Piccolomini (Pope Pius II)"
+      }
+    ]
+  },
+  "Q131719": {
+    "wikidataId": "Q131719",
+    "wikipediaTitle": "The_Prince",
+    "canonicalTitle": "Il Principe (The Prince)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-il-principe",
+        "nodeTitle": "Il Principe (The Prince)"
+      }
+    ]
+  },
+  "Q193510": {
+    "wikidataId": "Q193510",
+    "wikipediaTitle": "University_of_Padua",
+    "canonicalTitle": "University of Padua",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-padua",
+        "nodeTitle": "University of Padua"
+      }
+    ]
+  },
+  "Q131262": {
+    "wikidataId": "Q131262",
+    "wikipediaTitle": "University_of_Bologna",
+    "canonicalTitle": "University of Bologna",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-bologna",
+        "nodeTitle": "University of Bologna"
+      }
+    ]
+  },
+  "Q165980": {
+    "wikidataId": "Q165980",
+    "wikipediaTitle": "University_of_Vienna",
+    "canonicalTitle": "University of Vienna",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-vienna",
+        "nodeTitle": "University of Vienna"
+      }
+    ]
+  },
+  "Q159583": {
+    "wikidataId": "Q159583",
+    "wikipediaTitle": "Holy_See",
+    "canonicalTitle": "Papal Court (Vatican)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-vatican",
+        "nodeTitle": "Papal Court (Vatican)"
+      }
+    ]
+  },
+  "Q143886": {
+    "wikidataId": "Q143886",
+    "wikipediaTitle": "Accademia_Pontaniana",
+    "canonicalTitle": "Accademia Pontaniana",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-accademia-pontaniana",
+        "nodeTitle": "Accademia Pontaniana"
+      }
+    ]
+  },
+  "Q173065": {
+    "wikidataId": "Q173065",
+    "wikipediaTitle": "Kingdom_of_Naples",
+    "canonicalTitle": "Aragonese Patronage (Naples)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-aragonese-patronage",
+        "nodeTitle": "Aragonese Patronage (Naples)"
+      }
+    ]
+  },
+  "Q109400": {
+    "wikidataId": "Q109400",
+    "wikipediaTitle": "Benedictus_Figulus",
+    "canonicalTitle": "Benedictus Figulus",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-benedictus-figulus",
+        "nodeTitle": "Benedictus Figulus"
+      }
+    ]
+  },
+  "Q150586": {
+    "wikidataId": "Q150586",
+    "wikipediaTitle": "Rudolf_II,_Holy_Roman_Emperor",
+    "canonicalTitle": "Rudolf II",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-rudolf-ii",
+        "nodeTitle": "Rudolf II"
+      }
+    ]
+  },
+  "Q127080": {
+    "wikidataId": "Q127080",
+    "wikipediaTitle": "Edward_Kelley",
+    "canonicalTitle": "Edward Kelley",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-edward-kelley",
+        "nodeTitle": "Edward Kelley"
+      }
+    ]
+  },
+  "Q158252": {
+    "wikidataId": "Q158252",
+    "wikipediaTitle": "Elizabeth_Stuart,_Queen_of_Bohemia",
+    "canonicalTitle": "Elizabeth Stuart",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-elizabeth-stuart",
+        "nodeTitle": "Elizabeth Stuart"
+      }
+    ]
+  },
+  "Q194267": {
+    "wikidataId": "Q194267",
+    "wikipediaTitle": "Rosicrucianism",
+    "canonicalTitle": "Rosicrucian Brotherhood",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-rosicrucian-brotherhood",
+        "nodeTitle": "Rosicrucian Brotherhood"
+      }
+    ]
+  },
+  "Q192933": {
+    "wikidataId": "Q192933",
+    "wikipediaTitle": "Hermeticism",
+    "canonicalTitle": "Hermeticism (Early Modern)",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-hermeticism",
+        "nodeTitle": "Hermeticism (Early Modern)"
+      }
+    ]
+  },
+  "Q153978": {
+    "wikidataId": "Q153978",
+    "wikipediaTitle": "University_of_Tübingen",
+    "canonicalTitle": "University of Tübingen",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-university-tubingen",
+        "nodeTitle": "University of Tübingen"
+      }
+    ]
+  },
+  "Q104712": {
+    "wikidataId": "Q104712",
+    "wikipediaTitle": "Elbląg",
+    "canonicalTitle": "Elbing",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-elbing",
+        "nodeTitle": "Elbing"
+      }
+    ]
+  },
+  "Q134556": {
+    "wikidataId": "Q134556",
+    "wikipediaTitle": "Pope_Urban_VIII",
+    "canonicalTitle": "Pope Urban VIII",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-urban-viii",
+        "nodeTitle": "Pope Urban VIII"
+      }
+    ]
+  },
+  "Q101072": {
+    "wikidataId": "Q101072",
+    "wikipediaTitle": "Marin_Mersenne",
+    "canonicalTitle": "Marin Mersenne",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-marin-mersenne",
+        "nodeTitle": "Marin Mersenne"
+      }
+    ]
+  },
+  "Q192330": {
+    "wikidataId": "Q192330",
+    "wikipediaTitle": "William_Gilbert_(physician)",
+    "canonicalTitle": "William Gilbert",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-william-gilbert",
+        "nodeTitle": "William Gilbert"
+      }
+    ]
+  },
+  "Q142862": {
+    "wikidataId": "Q142862",
+    "wikipediaTitle": "Andreas_Vesalius",
+    "canonicalTitle": "Andreas Vesalius",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-andreas-vesalius",
+        "nodeTitle": "Andreas Vesalius"
+      }
+    ]
+  },
+  "Q185092": {
+    "wikidataId": "Q185092",
+    "wikipediaTitle": "Marcello_Malpighi",
+    "canonicalTitle": "Marcello Malpighi",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-marcello-malpighi",
+        "nodeTitle": "Marcello Malpighi"
+      }
+    ]
+  },
+  "Q186596": {
+    "wikidataId": "Q186596",
+    "wikipediaTitle": "Pierre-Simon_Laplace",
+    "canonicalTitle": "Pierre-Simon Laplace",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-pierre-simon-laplace",
+        "nodeTitle": "Pierre-Simon Laplace"
+      }
+    ]
+  },
+  "Q131566": {
+    "wikidataId": "Q131566",
+    "wikipediaTitle": "Francis_Galton",
+    "canonicalTitle": "Francis Galton",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-francis-galton",
+        "nodeTitle": "Francis Galton"
+      }
+    ]
+  },
+  "Q180850": {
+    "wikidataId": "Q180850",
+    "wikipediaTitle": "Karl_Pearson",
+    "canonicalTitle": "Karl Pearson",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-karl-pearson",
+        "nodeTitle": "Karl Pearson"
+      }
+    ]
+  },
+  "Q191799": {
+    "wikidataId": "Q191799",
+    "wikipediaTitle": "Adrien-Marie_Legendre",
+    "canonicalTitle": "Adrien-Marie Legendre",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-adrien-marie-legendre",
+        "nodeTitle": "Adrien-Marie Legendre"
+      }
+    ]
+  },
+  "Q122420": {
+    "wikidataId": "Q122420",
+    "wikipediaTitle": "Jacob_Bernoulli",
+    "canonicalTitle": "Jacob Bernoulli",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-jacob-bernoulli",
+        "nodeTitle": "Jacob Bernoulli"
+      }
+    ]
+  },
+  "Q140282": {
+    "wikidataId": "Q140282",
+    "wikipediaTitle": "Andrey_Markov",
+    "canonicalTitle": "Andrey Markov",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-andrey-markov",
+        "nodeTitle": "Andrey Markov"
+      }
+    ]
+  },
+  "Q193196": {
+    "wikidataId": "Q193196",
+    "wikipediaTitle": "University_College_London",
+    "canonicalTitle": "University College London",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "location-university-college-london",
+        "nodeTitle": "University College London"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q1000000-Q1099999.json
+++ b/public/cross-scene-index/by-wikidata/Q1000000-Q1099999.json
@@ -1,0 +1,158 @@
+{
+  "Q1065671": {
+    "wikidataId": "Q1065671",
+    "wikipediaTitle": "Neu!_'75",
+    "canonicalTitle": "Neu! 75",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-neu-75",
+        "nodeTitle": "Neu! 75"
+      }
+    ]
+  },
+  "Q1054058": {
+    "wikidataId": "Q1054058",
+    "wikipediaTitle": "Frippertronics",
+    "canonicalTitle": "Frippertronics System",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-frippertronics",
+        "nodeTitle": "Frippertronics System"
+      }
+    ]
+  },
+  "Q1048881": {
+    "wikidataId": "Q1048881",
+    "wikipediaTitle": "Homeostat",
+    "canonicalTitle": "The Homeostat",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-homeostat-ashby",
+        "nodeTitle": "The Homeostat"
+      }
+    ]
+  },
+  "Q1050365": {
+    "wikidataId": "Q1050365",
+    "wikipediaTitle": "NLS_(computer_system)",
+    "canonicalTitle": "NLS/Augment System & Mouse",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-nls-engelbart",
+        "nodeTitle": "NLS/Augment System & Mouse"
+      }
+    ]
+  },
+  "Q1063818": {
+    "wikidataId": "Q1063818",
+    "wikipediaTitle": "Office_of_Naval_Research",
+    "canonicalTitle": "Office of Naval Research",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-onr",
+        "nodeTitle": "Office of Naval Research"
+      }
+    ]
+  },
+  "Q1050479": {
+    "wikidataId": "Q1050479",
+    "wikipediaTitle": "Persian_Letters",
+    "canonicalTitle": "Persian Letters",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-persian-letters",
+        "nodeTitle": "Persian Letters"
+      }
+    ]
+  },
+  "Q1056332": {
+    "wikidataId": "Q1056332",
+    "wikipediaTitle": "Critique_of_Judgment",
+    "canonicalTitle": "Critique of Judgment",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-critique-judgment",
+        "nodeTitle": "Critique of Judgment"
+      }
+    ]
+  },
+  "Q1063038": {
+    "wikidataId": "Q1063038",
+    "wikipediaTitle": "Scottish_Enlightenment",
+    "canonicalTitle": "Scottish Enlightenment",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-scottish-enlightenment",
+        "nodeTitle": "Scottish Enlightenment"
+      }
+    ]
+  },
+  "Q1077624": {
+    "wikidataId": "Q1077624",
+    "wikipediaTitle": "De_re_aedificatoria",
+    "canonicalTitle": "De re aedificatoria",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-re-aedificatoria",
+        "nodeTitle": "De re aedificatoria"
+      }
+    ]
+  },
+  "Q1084061": {
+    "wikidataId": "Q1084061",
+    "wikipediaTitle": "Christian_Kabbalah",
+    "canonicalTitle": "Christian Kabbalah",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-christian-kabbalah",
+        "nodeTitle": "Christian Kabbalah"
+      }
+    ]
+  },
+  "Q1017439": {
+    "wikidataId": "Q1017439",
+    "wikipediaTitle": "Dialogue_Concerning_the_Two_Chief_World_Systems",
+    "canonicalTitle": "Dialogue Concerning the Two Chief World Systems",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-dialogo",
+        "nodeTitle": "Dialogue Concerning the Two Chief World Systems"
+      }
+    ]
+  },
+  "Q1046250": {
+    "wikidataId": "Q1046250",
+    "wikipediaTitle": "Roman_Inquisition",
+    "canonicalTitle": "Roman Inquisition",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-roman-inquisition",
+        "nodeTitle": "Roman Inquisition"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q104800000-Q104899999.json
+++ b/public/cross-scene-index/by-wikidata/Q104800000-Q104899999.json
@@ -1,0 +1,15 @@
+{
+  "Q104831864": {
+    "wikidataId": "Q104831864",
+    "wikipediaTitle": "DALL-E",
+    "canonicalTitle": "DALL-E",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-dalle",
+        "nodeTitle": "DALL-E"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q106000000-Q106099999.json
+++ b/public/cross-scene-index/by-wikidata/Q106000000-Q106099999.json
@@ -1,0 +1,15 @@
+{
+  "Q106006054": {
+    "wikidataId": "Q106006054",
+    "wikipediaTitle": "Anthropic",
+    "canonicalTitle": "Anthropic",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-anthropic",
+        "nodeTitle": "Anthropic"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q106400000-Q106499999.json
+++ b/public/cross-scene-index/by-wikidata/Q106400000-Q106499999.json
@@ -1,0 +1,28 @@
+{
+  "Q106409817": {
+    "wikidataId": "Q106409817",
+    "wikipediaTitle": "Margaret_Mitchell_(scientist)",
+    "canonicalTitle": "Margaret Mitchell",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-margaret-mitchell",
+        "nodeTitle": "Margaret Mitchell"
+      }
+    ]
+  },
+  "Q106481889": {
+    "wikidataId": "Q106481889",
+    "wikipediaTitle": "Stanford_Institute_for_Human-Centered_AI",
+    "canonicalTitle": "Stanford HAI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-stanford-hai",
+        "nodeTitle": "Stanford HAI"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q107300000-Q107399999.json
+++ b/public/cross-scene-index/by-wikidata/Q107300000-Q107399999.json
@@ -1,0 +1,15 @@
+{
+  "Q107388794": {
+    "wikidataId": "Q107388794",
+    "wikipediaTitle": "Green_(Hiroshi_Yoshimura_album)",
+    "canonicalTitle": "Green",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-yoshimura-green",
+        "nodeTitle": "Green"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q107500000-Q107599999.json
+++ b/public/cross-scene-index/by-wikidata/Q107500000-Q107599999.json
@@ -1,0 +1,15 @@
+{
+  "Q107588589": {
+    "wikidataId": "Q107588589",
+    "wikipediaTitle": "OpenAI_Codex",
+    "canonicalTitle": "Codex / GitHub Copilot",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-codex",
+        "nodeTitle": "Codex / GitHub Copilot"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q108700000-Q108799999.json
+++ b/public/cross-scene-index/by-wikidata/Q108700000-Q108799999.json
@@ -1,0 +1,93 @@
+{
+  "Q108741568": {
+    "wikidataId": "Q108741568",
+    "wikipediaTitle": "Dario_Amodei",
+    "canonicalTitle": "Dario Amodei",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-dario-amodei",
+        "nodeTitle": "Dario Amodei"
+      }
+    ]
+  },
+  "Q108743009": {
+    "wikidataId": "Q108743009",
+    "wikipediaTitle": "Daniela_Amodei",
+    "canonicalTitle": "Daniela Amodei",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-daniela-amodei",
+        "nodeTitle": "Daniela Amodei"
+      }
+    ]
+  },
+  "Q108742236": {
+    "wikidataId": "Q108742236",
+    "wikipediaTitle": "Jared_Kaplan_(physicist)",
+    "canonicalTitle": "Jared Kaplan",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jared-kaplan",
+        "nodeTitle": "Jared Kaplan"
+      }
+    ]
+  },
+  "Q108742779": {
+    "wikidataId": "Q108742779",
+    "wikipediaTitle": "Jack_Clark_(AI_researcher)",
+    "canonicalTitle": "Jack Clark",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jack-clark",
+        "nodeTitle": "Jack Clark"
+      }
+    ]
+  },
+  "Q108741880": {
+    "wikidataId": "Q108741880",
+    "wikipediaTitle": "Tom_Brown_(AI_researcher)",
+    "canonicalTitle": "Tom Brown",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-tom-brown",
+        "nodeTitle": "Tom Brown"
+      }
+    ]
+  },
+  "Q108742500": {
+    "wikidataId": "Q108742500",
+    "wikipediaTitle": "Christopher_Olah",
+    "canonicalTitle": "Chris Olah",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-chris-olah",
+        "nodeTitle": "Chris Olah"
+      }
+    ]
+  },
+  "Q108765213": {
+    "wikidataId": "Q108765213",
+    "wikipediaTitle": "Attention_Is_All_You_Need",
+    "canonicalTitle": "Attention Is All You Need",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-transformer-paper",
+        "nodeTitle": "Attention Is All You Need"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q1100000-Q1199999.json
+++ b/public/cross-scene-index/by-wikidata/Q1100000-Q1199999.json
@@ -1,0 +1,216 @@
+{
+  "Q1176914": {
+    "wikidataId": "Q1176914",
+    "wikipediaTitle": "David_Tudor",
+    "canonicalTitle": "David Tudor",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-david-tudor",
+        "nodeTitle": "David Tudor"
+      }
+    ]
+  },
+  "Q1129735": {
+    "wikidataId": "Q1129735",
+    "wikipediaTitle": "Gesang_der_Jünglinge",
+    "canonicalTitle": "Gesang der Jünglinge",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-stockhausen-gesang",
+        "nodeTitle": "Gesang der Jünglinge"
+      }
+    ]
+  },
+  "Q1180147": {
+    "wikidataId": "Q1180147",
+    "wikipediaTitle": "De_Arte_Cabalistica",
+    "canonicalTitle": "De Arte Cabalistica",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-arte-cabalistica",
+        "nodeTitle": "De Arte Cabalistica"
+      }
+    ]
+  },
+  "Q1180145": {
+    "wikidataId": "Q1180145",
+    "wikipediaTitle": "De_verbo_mirifico",
+    "canonicalTitle": "De Verbo Mirifico",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-verbo-mirifico",
+        "nodeTitle": "De Verbo Mirifico"
+      }
+    ]
+  },
+  "Q1182689": {
+    "wikidataId": "Q1182689",
+    "wikipediaTitle": "De_incertitudine_et_vanitate_scientiarum_et_artium",
+    "canonicalTitle": "De incertitudine et vanitate scientiarum",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-vanitate-scientiarum",
+        "nodeTitle": "De incertitudine et vanitate scientiarum"
+      }
+    ]
+  },
+  "Q1181428": {
+    "wikidataId": "Q1181428",
+    "wikipediaTitle": "De_vita_libri_tres",
+    "canonicalTitle": "De vita libri tres",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-vita-libri-tres",
+        "nodeTitle": "De vita libri tres"
+      }
+    ]
+  },
+  "Q1147211": {
+    "wikidataId": "Q1147211",
+    "wikipediaTitle": "Project_Cybersyn",
+    "canonicalTitle": "OPSROOM (Cybersyn)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-opsroom-chile",
+        "nodeTitle": "OPSROOM (Cybersyn)"
+      },
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-cybersyn",
+        "nodeTitle": "Cybersyn (Project Synco)"
+      }
+    ]
+  },
+  "Q1113461": {
+    "wikidataId": "Q1113461",
+    "wikipediaTitle": "William_Robertson_(historian)",
+    "canonicalTitle": "William Robertson",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-william-robertson",
+        "nodeTitle": "William Robertson"
+      }
+    ]
+  },
+  "Q1171104": {
+    "wikidataId": "Q1171104",
+    "wikipediaTitle": "The_Fable_of_the_Bees",
+    "canonicalTitle": "The Fable of the Bees",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-fable-bees",
+        "nodeTitle": "The Fable of the Bees"
+      }
+    ]
+  },
+  "Q1111930": {
+    "wikidataId": "Q1111930",
+    "wikipediaTitle": "The_System_of_Nature",
+    "canonicalTitle": "The System of Nature",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-system-nature",
+        "nodeTitle": "The System of Nature"
+      }
+    ]
+  },
+  "Q1116026": {
+    "wikidataId": "Q1116026",
+    "wikipediaTitle": "Scottish_common_sense_realism",
+    "canonicalTitle": "Common Sense Philosophy",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-common-sense-philosophy",
+        "nodeTitle": "Common Sense Philosophy"
+      }
+    ]
+  },
+  "Q1180745": {
+    "wikidataId": "Q1180745",
+    "wikipediaTitle": "On_the_Bondage_of_the_Will",
+    "canonicalTitle": "The Bondage of the Will",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-bondage-of-will",
+        "nodeTitle": "The Bondage of the Will"
+      }
+    ]
+  },
+  "Q1138103": {
+    "wikidataId": "Q1138103",
+    "wikipediaTitle": "Coverdale_Bible",
+    "canonicalTitle": "Coverdale Bible",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-coverdale-bible",
+        "nodeTitle": "Coverdale Bible"
+      }
+    ]
+  },
+  "Q1125192": {
+    "wikidataId": "Q1125192",
+    "wikipediaTitle": "Scots_Confession",
+    "canonicalTitle": "Scots Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-scots-confession",
+        "nodeTitle": "Scots Confession"
+      }
+    ]
+  },
+  "Q1121746": {
+    "wikidataId": "Q1121746",
+    "wikipediaTitle": "Complutensian_Polyglot_Bible",
+    "canonicalTitle": "Complutensian Polyglot Bible",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-complutensian-polyglot",
+        "nodeTitle": "Complutensian Polyglot Bible"
+      }
+    ]
+  },
+  "Q1126858": {
+    "wikidataId": "Q1126858",
+    "wikipediaTitle": "Conrad_Khunrath",
+    "canonicalTitle": "Conrad Khunrath",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-conrad-khunrath",
+        "nodeTitle": "Conrad Khunrath"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q110100000-Q110199999.json
+++ b/public/cross-scene-index/by-wikidata/Q110100000-Q110199999.json
@@ -1,0 +1,15 @@
+{
+  "Q110131254": {
+    "wikidataId": "Q110131254",
+    "wikipediaTitle": "Distributed_Artificial_Intelligence_Research_Institute",
+    "canonicalTitle": "DAIR Institute",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-dair",
+        "nodeTitle": "DAIR Institute"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q110500000-Q110599999.json
+++ b/public/cross-scene-index/by-wikidata/Q110500000-Q110599999.json
@@ -1,0 +1,28 @@
+{
+  "Q110560178": {
+    "wikidataId": "Q110560178",
+    "wikipediaTitle": "Mira_Murati",
+    "canonicalTitle": "Mira Murati",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-mira-murati",
+        "nodeTitle": "Mira Murati"
+      }
+    ]
+  },
+  "Q110561437": {
+    "wikidataId": "Q110561437",
+    "wikipediaTitle": "Neural_scaling_law",
+    "canonicalTitle": "Scaling Laws for Neural Language Models",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-scaling-laws",
+        "nodeTitle": "Scaling Laws for Neural Language Models"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q110800000-Q110899999.json
+++ b/public/cross-scene-index/by-wikidata/Q110800000-Q110899999.json
@@ -1,0 +1,28 @@
+{
+  "Q110894704": {
+    "wikidataId": "Q110894704",
+    "wikipediaTitle": "Inflection_AI",
+    "canonicalTitle": "Inflection AI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-inflection",
+        "nodeTitle": "Inflection AI"
+      }
+    ]
+  },
+  "Q110891631": {
+    "wikidataId": "Q110891631",
+    "wikipediaTitle": "Character.ai",
+    "canonicalTitle": "Character.AI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-character-ai",
+        "nodeTitle": "Character.AI"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q111400000-Q111499999.json
+++ b/public/cross-scene-index/by-wikidata/Q111400000-Q111499999.json
@@ -1,0 +1,15 @@
+{
+  "Q111449379": {
+    "wikidataId": "Q111449379",
+    "wikipediaTitle": "Microsoft_Copilot",
+    "canonicalTitle": "Microsoft AI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-microsoft-ai",
+        "nodeTitle": "Microsoft AI"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q111900000-Q111999999.json
+++ b/public/cross-scene-index/by-wikidata/Q111900000-Q111999999.json
@@ -1,0 +1,15 @@
+{
+  "Q111955226": {
+    "wikidataId": "Q111955226",
+    "wikipediaTitle": "Book_of_Common_Prayer_(1552)",
+    "canonicalTitle": "Book of Common Prayer (1552)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-bcp-1552",
+        "nodeTitle": "Book of Common Prayer (1552)"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q113400000-Q113499999.json
+++ b/public/cross-scene-index/by-wikidata/Q113400000-Q113499999.json
@@ -1,0 +1,34 @@
+{
+  "Q113414756": {
+    "wikidataId": "Q113414756",
+    "wikipediaTitle": "Emad_Mostaque",
+    "canonicalTitle": "Emad Mostaque",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-emad-mostaque",
+        "nodeTitle": "Emad Mostaque"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-stability",
+        "nodeTitle": "Stability AI"
+      }
+    ]
+  },
+  "Q113414728": {
+    "wikidataId": "Q113414728",
+    "wikipediaTitle": "Stable_Diffusion",
+    "canonicalTitle": "Stable Diffusion",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-stable-diffusion",
+        "nodeTitle": "Stable Diffusion"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q113500000-Q113599999.json
+++ b/public/cross-scene-index/by-wikidata/Q113500000-Q113599999.json
@@ -1,0 +1,41 @@
+{
+  "Q113500048": {
+    "wikidataId": "Q113500048",
+    "wikipediaTitle": "Robin_Rombach",
+    "canonicalTitle": "Robin Rombach",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-robin-rombach",
+        "nodeTitle": "Robin Rombach"
+      }
+    ]
+  },
+  "Q113503106": {
+    "wikidataId": "Q113503106",
+    "wikipediaTitle": "Proximal_policy_optimization",
+    "canonicalTitle": "Proximal Policy Optimization Algorithms",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-ppo-paper",
+        "nodeTitle": "Proximal Policy Optimization Algorithms"
+      }
+    ]
+  },
+  "Q113503095": {
+    "wikidataId": "Q113503095",
+    "wikipediaTitle": "Trust_region_policy_optimization",
+    "canonicalTitle": "Trust Region Policy Optimization",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-trpo-paper",
+        "nodeTitle": "Trust Region Policy Optimization"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q11400000-Q11499999.json
+++ b/public/cross-scene-index/by-wikidata/Q11400000-Q11499999.json
@@ -1,0 +1,15 @@
+{
+  "Q11413264": {
+    "wikidataId": "Q11413264",
+    "wikipediaTitle": "Hiroshi_Yoshimura",
+    "canonicalTitle": "Hiroshi Yoshimura",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-hiroshi-yoshimura",
+        "nodeTitle": "Hiroshi Yoshimura"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q115000000-Q115099999.json
+++ b/public/cross-scene-index/by-wikidata/Q115000000-Q115099999.json
@@ -1,0 +1,15 @@
+{
+  "Q115035180": {
+    "wikidataId": "Q115035180",
+    "wikipediaTitle": "ChatGPT",
+    "canonicalTitle": "ChatGPT",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-chatgpt",
+        "nodeTitle": "ChatGPT"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q115500000-Q115599999.json
+++ b/public/cross-scene-index/by-wikidata/Q115500000-Q115599999.json
@@ -1,0 +1,15 @@
+{
+  "Q115591629": {
+    "wikidataId": "Q115591629",
+    "wikipediaTitle": "Jimmy_Ba",
+    "canonicalTitle": "Jimmy Ba",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jimmy-ba",
+        "nodeTitle": "Jimmy Ba"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q115600000-Q115699999.json
+++ b/public/cross-scene-index/by-wikidata/Q115600000-Q115699999.json
@@ -1,0 +1,28 @@
+{
+  "Q115667430": {
+    "wikidataId": "Q115667430",
+    "wikipediaTitle": "John_Jumper",
+    "canonicalTitle": "John Jumper",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-john-jumper",
+        "nodeTitle": "John Jumper"
+      }
+    ]
+  },
+  "Q115646799": {
+    "wikidataId": "Q115646799",
+    "wikipediaTitle": "GPT-1",
+    "canonicalTitle": "GPT-1",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt1",
+        "nodeTitle": "GPT-1"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q116700000-Q116799999.json
+++ b/public/cross-scene-index/by-wikidata/Q116700000-Q116799999.json
@@ -1,0 +1,15 @@
+{
+  "Q116709893": {
+    "wikidataId": "Q116709893",
+    "wikipediaTitle": "GPT-4",
+    "canonicalTitle": "GPT-4",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt4",
+        "nodeTitle": "GPT-4"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q116900000-Q116999999.json
+++ b/public/cross-scene-index/by-wikidata/Q116900000-Q116999999.json
@@ -1,0 +1,39 @@
+{
+  "Q116965708": {
+    "wikidataId": "Q116965708",
+    "wikipediaTitle": "Claude_(language_model)",
+    "canonicalTitle": "Claude",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-claude",
+        "nodeTitle": "Claude"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-claude3",
+        "nodeTitle": "Claude 3"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-claude35-sonnet",
+        "nodeTitle": "Claude 3.5 Sonnet"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-claude4",
+        "nodeTitle": "Claude 4"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-claude45",
+        "nodeTitle": "Claude 4.5"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q11700000-Q11799999.json
+++ b/public/cross-scene-index/by-wikidata/Q11700000-Q11799999.json
@@ -1,0 +1,15 @@
+{
+  "Q11772588": {
+    "wikidataId": "Q11772588",
+    "wikipediaTitle": "John_Frith",
+    "canonicalTitle": "John Frith",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-frith",
+        "nodeTitle": "John Frith"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q117100000-Q117199999.json
+++ b/public/cross-scene-index/by-wikidata/Q117100000-Q117199999.json
@@ -1,0 +1,15 @@
+{
+  "Q117181040": {
+    "wikidataId": "Q117181040",
+    "wikipediaTitle": "Cohere",
+    "canonicalTitle": "Cohere",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-cohere",
+        "nodeTitle": "Cohere"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q117200000-Q117299999.json
+++ b/public/cross-scene-index/by-wikidata/Q117200000-Q117299999.json
@@ -1,0 +1,64 @@
+{
+  "Q117270377": {
+    "wikidataId": "Q117270377",
+    "wikipediaTitle": "Clem_Delangue",
+    "canonicalTitle": "Clément Delangue",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-clement-delangue",
+        "nodeTitle": "Clément Delangue"
+      }
+    ]
+  },
+  "Q117276906": {
+    "wikidataId": "Q117276906",
+    "wikipediaTitle": "Llama_(language_model)",
+    "canonicalTitle": "LLaMA",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama",
+        "nodeTitle": "LLaMA"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama2",
+        "nodeTitle": "LLaMA 2"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama3",
+        "nodeTitle": "LLaMA 3"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama31",
+        "nodeTitle": "LLaMA 3.1"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama32",
+        "nodeTitle": "LLaMA 3.2"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama33",
+        "nodeTitle": "LLaMA 3.3"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama4",
+        "nodeTitle": "LLaMA 4"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q118200000-Q118299999.json
+++ b/public/cross-scene-index/by-wikidata/Q118200000-Q118299999.json
@@ -1,0 +1,28 @@
+{
+  "Q118283055": {
+    "wikidataId": "Q118283055",
+    "wikipediaTitle": "Guillaume_Lample",
+    "canonicalTitle": "Guillaume Lample",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-guillaume-lample",
+        "nodeTitle": "Guillaume Lample"
+      }
+    ]
+  },
+  "Q118282911": {
+    "wikidataId": "Q118282911",
+    "wikipediaTitle": "Arthur_Mensch",
+    "canonicalTitle": "Arthur Mensch",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-arthur-mensch",
+        "nodeTitle": "Arthur Mensch"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q118300000-Q118399999.json
+++ b/public/cross-scene-index/by-wikidata/Q118300000-Q118399999.json
@@ -1,0 +1,46 @@
+{
+  "Q118389636": {
+    "wikidataId": "Q118389636",
+    "wikipediaTitle": "Gemini_(chatbot)",
+    "canonicalTitle": "Gemini",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gemini",
+        "nodeTitle": "Gemini"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gemini15",
+        "nodeTitle": "Gemini 1.5 Pro"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gemini20",
+        "nodeTitle": "Gemini 2.0"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gemini25",
+        "nodeTitle": "Gemini 2.5"
+      }
+    ]
+  },
+  "Q118358654": {
+    "wikidataId": "Q118358654",
+    "wikipediaTitle": "Google_DeepMind",
+    "canonicalTitle": "Google DeepMind",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-google-deepmind",
+        "nodeTitle": "Google DeepMind"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q118400000-Q118499999.json
+++ b/public/cross-scene-index/by-wikidata/Q118400000-Q118499999.json
@@ -1,0 +1,21 @@
+{
+  "Q118473029": {
+    "wikidataId": "Q118473029",
+    "wikipediaTitle": "Mistral_AI#Models",
+    "canonicalTitle": "Mistral 7B",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-mistral-7b",
+        "nodeTitle": "Mistral 7B"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-mistral",
+        "nodeTitle": "Mistral AI"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q118800000-Q118899999.json
+++ b/public/cross-scene-index/by-wikidata/Q118800000-Q118899999.json
@@ -1,0 +1,15 @@
+{
+  "Q118898952": {
+    "wikidataId": "Q118898952",
+    "wikipediaTitle": "Grant_Avenue_Studio",
+    "canonicalTitle": "Grant Avenue Studio",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-grant-avenue",
+        "nodeTitle": "Grant Avenue Studio"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q1200000-Q1299999.json
+++ b/public/cross-scene-index/by-wikidata/Q1200000-Q1299999.json
@@ -1,0 +1,119 @@
+{
+  "Q1238976": {
+    "wikidataId": "Q1238976",
+    "wikipediaTitle": "Don_Buchla",
+    "canonicalTitle": "Don Buchla",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-don-buchla",
+        "nodeTitle": "Don Buchla"
+      }
+    ]
+  },
+  "Q1273664": {
+    "wikidataId": "Q1273664",
+    "wikipediaTitle": "E2-E4",
+    "canonicalTitle": "E2-E4",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-gottsching-e2e4",
+        "nodeTitle": "E2-E4"
+      }
+    ]
+  },
+  "Q1211539": {
+    "wikidataId": "Q1211539",
+    "wikipediaTitle": "Monadology",
+    "canonicalTitle": "Monadology",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-monadology",
+        "nodeTitle": "Monadology"
+      }
+    ]
+  },
+  "Q1210631": {
+    "wikidataId": "Q1210631",
+    "wikipediaTitle": "Platonic_Academy_(Florence)",
+    "canonicalTitle": "Platonic Academy of Florence",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "entity-platonic-academy",
+        "nodeTitle": "Platonic Academy of Florence"
+      }
+    ]
+  },
+  "Q1237075": {
+    "wikidataId": "Q1237075",
+    "wikipediaTitle": "Robert_Barnes_(martyr)",
+    "canonicalTitle": "Robert Barnes",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-robert-barnes",
+        "nodeTitle": "Robert Barnes"
+      }
+    ]
+  },
+  "Q1236187": {
+    "wikidataId": "Q1236187",
+    "wikipediaTitle": "Gasparino_Barzizza",
+    "canonicalTitle": "Gasparino Barzizza",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-gasparino-barzizza",
+        "nodeTitle": "Gasparino Barzizza"
+      }
+    ]
+  },
+  "Q1229872": {
+    "wikidataId": "Q1229872",
+    "wikipediaTitle": "Matteo_Palmieri",
+    "canonicalTitle": "Matteo Palmieri",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-matteo-palmieri",
+        "nodeTitle": "Matteo Palmieri"
+      }
+    ]
+  },
+  "Q1234681": {
+    "wikidataId": "Q1234681",
+    "wikipediaTitle": "Giannozzo_Manetti",
+    "canonicalTitle": "Giannozzo Manetti",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giannozzo-manetti",
+        "nodeTitle": "Giannozzo Manetti"
+      }
+    ]
+  },
+  "Q1243904": {
+    "wikidataId": "Q1243904",
+    "wikipediaTitle": "University_of_Alcalá",
+    "canonicalTitle": "University of Alcalá de Henares",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-alcala",
+        "nodeTitle": "University of Alcalá de Henares"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q120200000-Q120299999.json
+++ b/public/cross-scene-index/by-wikidata/Q120200000-Q120299999.json
@@ -1,0 +1,28 @@
+{
+  "Q120206584": {
+    "wikidataId": "Q120206584",
+    "wikipediaTitle": "CLIP_(language_model)",
+    "canonicalTitle": "CLIP",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-clip",
+        "nodeTitle": "CLIP"
+      }
+    ]
+  },
+  "Q120201695": {
+    "wikidataId": "Q120201695",
+    "wikipediaTitle": "Constitutional_AI",
+    "canonicalTitle": "Constitutional AI Paper",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-constitutional-ai",
+        "nodeTitle": "Constitutional AI Paper"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q120300000-Q120399999.json
+++ b/public/cross-scene-index/by-wikidata/Q120300000-Q120399999.json
@@ -1,0 +1,15 @@
+{
+  "Q120303340": {
+    "wikidataId": "Q120303340",
+    "wikipediaTitle": "XAI_(company)",
+    "canonicalTitle": "xAI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-xai",
+        "nodeTitle": "xAI"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q120600000-Q120699999.json
+++ b/public/cross-scene-index/by-wikidata/Q120600000-Q120699999.json
@@ -1,0 +1,15 @@
+{
+  "Q120696689": {
+    "wikidataId": "Q120696689",
+    "wikipediaTitle": "Code_Llama",
+    "canonicalTitle": "Code Llama",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-code-llama",
+        "nodeTitle": "Code Llama"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q121600000-Q121699999.json
+++ b/public/cross-scene-index/by-wikidata/Q121600000-Q121699999.json
@@ -1,0 +1,15 @@
+{
+  "Q121668234": {
+    "wikidataId": "Q121668234",
+    "wikipediaTitle": "Sakana_AI",
+    "canonicalTitle": "Sakana AI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-sakana",
+        "nodeTitle": "Sakana AI"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q122600000-Q122699999.json
+++ b/public/cross-scene-index/by-wikidata/Q122600000-Q122699999.json
@@ -1,0 +1,27 @@
+{
+  "Q122645637": {
+    "wikidataId": "Q122645637",
+    "wikipediaTitle": "Grok_(chatbot)",
+    "canonicalTitle": "Grok",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-grok",
+        "nodeTitle": "Grok"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-grok2",
+        "nodeTitle": "Grok 2"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-grok3",
+        "nodeTitle": "Grok 3"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q122900000-Q122999999.json
+++ b/public/cross-scene-index/by-wikidata/Q122900000-Q122999999.json
@@ -1,0 +1,15 @@
+{
+  "Q122968991": {
+    "wikidataId": "Q122968991",
+    "wikipediaTitle": "Mixtral",
+    "canonicalTitle": "Mixtral 8x22B",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-mixtral-8x22b",
+        "nodeTitle": "Mixtral 8x22B"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q125400000-Q125499999.json
+++ b/public/cross-scene-index/by-wikidata/Q125400000-Q125499999.json
@@ -1,0 +1,15 @@
+{
+  "Q125461951": {
+    "wikidataId": "Q125461951",
+    "wikipediaTitle": "Giovanni_Nesi",
+    "canonicalTitle": "Giovanni Nesi",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giovanni-nesi",
+        "nodeTitle": "Giovanni Nesi"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q126000000-Q126099999.json
+++ b/public/cross-scene-index/by-wikidata/Q126000000-Q126099999.json
@@ -1,0 +1,34 @@
+{
+  "Q126055790": {
+    "wikidataId": "Q126055790",
+    "wikipediaTitle": "Safe_Superintelligence_Inc.",
+    "canonicalTitle": "Safe Superintelligence Inc.",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-ssi",
+        "nodeTitle": "Safe Superintelligence Inc."
+      }
+    ]
+  },
+  "Q126055869": {
+    "wikidataId": "Q126055869",
+    "wikipediaTitle": "GPT-4o",
+    "canonicalTitle": "GPT-4o",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt4o",
+        "nodeTitle": "GPT-4o"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt4o-mini",
+        "nodeTitle": "GPT-4o mini"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q126300000-Q126399999.json
+++ b/public/cross-scene-index/by-wikidata/Q126300000-Q126399999.json
@@ -1,0 +1,15 @@
+{
+  "Q126330684": {
+    "wikidataId": "Q126330684",
+    "wikipediaTitle": "David_Ha_(computer_scientist)",
+    "canonicalTitle": "David Ha",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-david-ha",
+        "nodeTitle": "David Ha"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q1300000-Q1399999.json
+++ b/public/cross-scene-index/by-wikidata/Q1300000-Q1399999.json
@@ -1,0 +1,216 @@
+{
+  "Q1371324": {
+    "wikidataId": "Q1371324",
+    "wikipediaTitle": "Yann_LeCun",
+    "canonicalTitle": "Yann LeCun",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-yann-lecun",
+        "nodeTitle": "Yann LeCun"
+      }
+    ]
+  },
+  "Q1334617": {
+    "wikidataId": "Q1334617",
+    "wikipediaTitle": "Raymond_Scott",
+    "canonicalTitle": "Raymond Scott",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-raymond-scott",
+        "nodeTitle": "Raymond Scott"
+      }
+    ]
+  },
+  "Q1333326": {
+    "wikidataId": "Q1333326",
+    "wikipediaTitle": "Maurice_Martenot",
+    "canonicalTitle": "Maurice Martenot",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-maurice-martenot",
+        "nodeTitle": "Maurice Martenot"
+      }
+    ]
+  },
+  "Q1351281": {
+    "wikidataId": "Q1351281",
+    "wikipediaTitle": "Roger_Eno",
+    "canonicalTitle": "Roger Eno",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-roger-eno",
+        "nodeTitle": "Roger Eno"
+      }
+    ]
+  },
+  "Q1326103": {
+    "wikidataId": "Q1326103",
+    "wikipediaTitle": "Electronic_Music_Studios",
+    "canonicalTitle": "EMS (Electronic Music Studios)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-ems",
+        "nodeTitle": "EMS (Electronic Music Studios)"
+      }
+    ]
+  },
+  "Q1384845": {
+    "wikidataId": "Q1384845",
+    "wikipediaTitle": "Francesco_Giorgio_Veneto",
+    "canonicalTitle": "Francesco Giorgi",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-francesco-giorgi",
+        "nodeTitle": "Francesco Giorgi"
+      }
+    ]
+  },
+  "Q1340677": {
+    "wikidataId": "Q1340677",
+    "wikipediaTitle": "John_R._Pierce",
+    "canonicalTitle": "John R. Pierce",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-john-pierce",
+        "nodeTitle": "John R. Pierce"
+      }
+    ]
+  },
+  "Q1359845": {
+    "wikidataId": "Q1359845",
+    "wikipediaTitle": "William_Grey_Walter",
+    "canonicalTitle": "W. Grey Walter",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-grey-walter",
+        "nodeTitle": "W. Grey Walter"
+      }
+    ]
+  },
+  "Q1354917": {
+    "wikidataId": "Q1354917",
+    "wikipediaTitle": "MIT_Computer_Science_and_Artificial_Intelligence_Laboratory",
+    "canonicalTitle": "MIT Artificial Intelligence Laboratory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-mit-ai-lab",
+        "nodeTitle": "MIT Artificial Intelligence Laboratory"
+      },
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-project-mac",
+        "nodeTitle": "Project MAC"
+      }
+    ]
+  },
+  "Q1341370": {
+    "wikidataId": "Q1341370",
+    "wikipediaTitle": "Henry_Home,_Lord_Kames",
+    "canonicalTitle": "Henry Home, Lord Kames",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-lord-kames",
+        "nodeTitle": "Henry Home, Lord Kames"
+      }
+    ]
+  },
+  "Q1306656": {
+    "wikidataId": "Q1306656",
+    "wikipediaTitle": "An_Enquiry_Concerning_Human_Understanding",
+    "canonicalTitle": "An Enquiry Concerning Human Understanding",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-enquiry-human-understanding",
+        "nodeTitle": "An Enquiry Concerning Human Understanding"
+      }
+    ]
+  },
+  "Q1345599": {
+    "wikidataId": "Q1345599",
+    "wikipediaTitle": "Leo_Jud",
+    "canonicalTitle": "Leo Jud",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-leo-jud",
+        "nodeTitle": "Leo Jud"
+      }
+    ]
+  },
+  "Q1368362": {
+    "wikidataId": "Q1368362",
+    "wikipediaTitle": "Wolfgang_Capito",
+    "canonicalTitle": "Wolfgang Capito",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-wolfgang-capito",
+        "nodeTitle": "Wolfgang Capito"
+      }
+    ]
+  },
+  "Q1367426": {
+    "wikidataId": "Q1367426",
+    "wikipediaTitle": "George_Wishart",
+    "canonicalTitle": "George Wishart",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-george-wishart",
+        "nodeTitle": "George Wishart"
+      }
+    ]
+  },
+  "Q1381018": {
+    "wikidataId": "Q1381018",
+    "wikipediaTitle": "William_Stukeley",
+    "canonicalTitle": "William Stukeley",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-william-stukeley",
+        "nodeTitle": "William Stukeley"
+      }
+    ]
+  },
+  "Q1302219": {
+    "wikidataId": "Q1302219",
+    "wikipediaTitle": "Egon_Pearson",
+    "canonicalTitle": "Egon Pearson",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-egon-pearson",
+        "nodeTitle": "Egon Pearson"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q130400000-Q130499999.json
+++ b/public/cross-scene-index/by-wikidata/Q130400000-Q130499999.json
@@ -1,0 +1,15 @@
+{
+  "Q130449908": {
+    "wikidataId": "Q130449908",
+    "wikipediaTitle": "Jan_Leike",
+    "canonicalTitle": "Jan Leike",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jan-leike",
+        "nodeTitle": "Jan Leike"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q131000000-Q131099999.json
+++ b/public/cross-scene-index/by-wikidata/Q131000000-Q131099999.json
@@ -1,0 +1,15 @@
+{
+  "Q131065549": {
+    "wikidataId": "Q131065549",
+    "wikipediaTitle": "OpenAI_o1",
+    "canonicalTitle": "o1",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-o1",
+        "nodeTitle": "o1"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q133000000-Q133099999.json
+++ b/public/cross-scene-index/by-wikidata/Q133000000-Q133099999.json
@@ -1,0 +1,15 @@
+{
+  "Q133034217": {
+    "wikidataId": "Q133034217",
+    "wikipediaTitle": "OpenAI_o3",
+    "canonicalTitle": "o3",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-o3",
+        "nodeTitle": "o3"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q133100000-Q133199999.json
+++ b/public/cross-scene-index/by-wikidata/Q133100000-Q133199999.json
@@ -1,0 +1,21 @@
+{
+  "Q133138199": {
+    "wikidataId": "Q133138199",
+    "wikipediaTitle": "Amazon_Nova",
+    "canonicalTitle": "Amazon Nova",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-nova",
+        "nodeTitle": "Amazon Nova"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-nova-premier",
+        "nodeTitle": "Nova Premier"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q13500000-Q13599999.json
+++ b/public/cross-scene-index/by-wikidata/Q13500000-Q13599999.json
@@ -1,0 +1,28 @@
+{
+  "Q13583325": {
+    "wikidataId": "Q13583325",
+    "wikipediaTitle": "Laraaji",
+    "canonicalTitle": "Laraaji",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-laraaji",
+        "nodeTitle": "Laraaji"
+      }
+    ]
+  },
+  "Q13570719": {
+    "wikidataId": "Q13570719",
+    "wikipediaTitle": "Horace_Barlow",
+    "canonicalTitle": "Horace Barlow",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-horace-barlow",
+        "nodeTitle": "Horace Barlow"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q136200000-Q136299999.json
+++ b/public/cross-scene-index/by-wikidata/Q136200000-Q136299999.json
@@ -1,0 +1,15 @@
+{
+  "Q136274201": {
+    "wikidataId": "Q136274201",
+    "wikipediaTitle": "Aufklärung",
+    "canonicalTitle": "German Aufklärung",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-aufklarung",
+        "nodeTitle": "German Aufklärung"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q136900000-Q136999999.json
+++ b/public/cross-scene-index/by-wikidata/Q136900000-Q136999999.json
@@ -1,0 +1,15 @@
+{
+  "Q136953442": {
+    "wikidataId": "Q136953442",
+    "wikipediaTitle": "The_Living_Brain",
+    "canonicalTitle": "The Living Brain",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-living-brain-walter",
+        "nodeTitle": "The Living Brain"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q1400000-Q1499999.json
+++ b/public/cross-scene-index/by-wikidata/Q1400000-Q1499999.json
@@ -1,0 +1,119 @@
+{
+  "Q1450908": {
+    "wikidataId": "Q1450908",
+    "wikipediaTitle": "François_Bayle",
+    "canonicalTitle": "François Bayle",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-francois-bayle",
+        "nodeTitle": "François Bayle"
+      }
+    ]
+  },
+  "Q1426689": {
+    "wikidataId": "Q1426689",
+    "wikipediaTitle": "Flavius_Mithridates",
+    "canonicalTitle": "Flavius Mithridates",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-flavius-mithridates",
+        "nodeTitle": "Flavius Mithridates"
+      }
+    ]
+  },
+  "Q1431186": {
+    "wikidataId": "Q1431186",
+    "wikipediaTitle": "Russell_L._Ackoff",
+    "canonicalTitle": "Russell Ackoff",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-russell-ackoff",
+        "nodeTitle": "Russell Ackoff"
+      }
+    ]
+  },
+  "Q1494101": {
+    "wikidataId": "Q1494101",
+    "wikipediaTitle": "Ranulph_Glanville",
+    "canonicalTitle": "Ranulph Glanville",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ranulph-glanville",
+        "nodeTitle": "Ranulph Glanville"
+      }
+    ]
+  },
+  "Q1413683": {
+    "wikidataId": "Q1413683",
+    "wikipediaTitle": "Whirlwind_I",
+    "canonicalTitle": "Whirlwind / SAGE",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-whirlwind",
+        "nodeTitle": "Whirlwind / SAGE"
+      }
+    ]
+  },
+  "Q1438448": {
+    "wikidataId": "Q1438448",
+    "wikipediaTitle": "The_Theory_of_Moral_Sentiments",
+    "canonicalTitle": "The Theory of Moral Sentiments",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-theory-moral-sentiments",
+        "nodeTitle": "The Theory of Moral Sentiments"
+      }
+    ]
+  },
+  "Q1440694": {
+    "wikidataId": "Q1440694",
+    "wikipediaTitle": "Francesco_Cattani_da_Diacceto",
+    "canonicalTitle": "Francesco Cattani da Diacceto",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-francesco-cattani-da-diacceto",
+        "nodeTitle": "Francesco Cattani da Diacceto"
+      }
+    ]
+  },
+  "Q1425428": {
+    "wikidataId": "Q1425428",
+    "wikipediaTitle": "Newcastle_upon_Tyne",
+    "canonicalTitle": "Newcastle upon Tyne",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "loc-newcastle-upon-tyne",
+        "nodeTitle": "Newcastle upon Tyne"
+      }
+    ]
+  },
+  "Q1423882": {
+    "wikidataId": "Q1423882",
+    "wikipediaTitle": "Royal_Statistical_Society",
+    "canonicalTitle": "Royal Statistical Society",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "entity-royal-statistical-society",
+        "nodeTitle": "Royal Statistical Society"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q14900000-Q14999999.json
+++ b/public/cross-scene-index/by-wikidata/Q14900000-Q14999999.json
@@ -1,0 +1,15 @@
+{
+  "Q14941935": {
+    "wikidataId": "Q14941935",
+    "wikipediaTitle": "Hermetica",
+    "canonicalTitle": "Corpus Hermeticum Translation",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-corpus-hermeticum",
+        "nodeTitle": "Corpus Hermeticum Translation"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q1500000-Q1599999.json
+++ b/public/cross-scene-index/by-wikidata/Q1500000-Q1599999.json
@@ -1,0 +1,177 @@
+{
+  "Q1500990": {
+    "wikidataId": "Q1500990",
+    "wikipediaTitle": "In_C",
+    "canonicalTitle": "In C",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-riley-in-c",
+        "nodeTitle": "In C"
+      }
+    ]
+  },
+  "Q1566338": {
+    "wikidataId": "Q1566338",
+    "wikipediaTitle": "Neu!_(album)",
+    "canonicalTitle": "Neu!",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-neu-1",
+        "nodeTitle": "Neu!"
+      }
+    ]
+  },
+  "Q1518623": {
+    "wikidataId": "Q1518623",
+    "wikipediaTitle": "Ohr_(record_label)",
+    "canonicalTitle": "Ohr Records",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-ohr",
+        "nodeTitle": "Ohr Records"
+      }
+    ]
+  },
+  "Q1544281": {
+    "wikidataId": "Q1544281",
+    "wikipediaTitle": "Management_cybernetics",
+    "canonicalTitle": "Management Cybernetics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-management-cybernetics",
+        "nodeTitle": "Management Cybernetics"
+      }
+    ]
+  },
+  "Q1543820": {
+    "wikidataId": "Q1543820",
+    "wikipediaTitle": "900_Theses",
+    "canonicalTitle": "900 Theses (Conclusiones)",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-900-theses",
+        "nodeTitle": "900 Theses (Conclusiones)"
+      }
+    ]
+  },
+  "Q1571095": {
+    "wikidataId": "Q1571095",
+    "wikipediaTitle": "Luther_Bible",
+    "canonicalTitle": "Luther's German Bible",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-luther-bible",
+        "nodeTitle": "Luther's German Bible"
+      }
+    ]
+  },
+  "Q1526516": {
+    "wikidataId": "Q1526516",
+    "wikipediaTitle": "Novum_Instrumentum_omne",
+    "canonicalTitle": "Erasmus's Greek New Testament",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-novum-instrumentum",
+        "nodeTitle": "Erasmus's Greek New Testament"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-novum-instrumentum",
+        "nodeTitle": "Novum Instrumentum (Greek New Testament)"
+      }
+    ]
+  },
+  "Q1544227": {
+    "wikidataId": "Q1544227",
+    "wikipediaTitle": "Great_Bible",
+    "canonicalTitle": "Great Bible",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-great-bible",
+        "nodeTitle": "Great Bible"
+      }
+    ]
+  },
+  "Q1502139": {
+    "wikidataId": "Q1502139",
+    "wikipediaTitle": "Geneva_Bible",
+    "canonicalTitle": "Geneva Bible",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-geneva-bible",
+        "nodeTitle": "Geneva Bible"
+      }
+    ]
+  },
+  "Q1525570": {
+    "wikidataId": "Q1525570",
+    "wikipediaTitle": "Giorgio_Valla",
+    "canonicalTitle": "Giorgio Valla",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giorgio-valla",
+        "nodeTitle": "Giorgio Valla"
+      }
+    ]
+  },
+  "Q1517519": {
+    "wikidataId": "Q1517519",
+    "wikipediaTitle": "The_Book_of_the_Courtier",
+    "canonicalTitle": "Il libro del cortegiano (The Book of the Courtier)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-book-courtier",
+        "nodeTitle": "Il libro del cortegiano (The Book of the Courtier)"
+      }
+    ]
+  },
+  "Q1508044": {
+    "wikidataId": "Q1508044",
+    "wikipediaTitle": "George_Payne_(Freemason)",
+    "canonicalTitle": "George Payne",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-george-payne",
+        "nodeTitle": "George Payne"
+      }
+    ]
+  },
+  "Q1573240": {
+    "wikidataId": "Q1573240",
+    "wikipediaTitle": "W._F._R._Weldon",
+    "canonicalTitle": "W.F.R. Weldon",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-walter-frank-raphael-weldon",
+        "nodeTitle": "W.F.R. Weldon"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q15400000-Q15499999.json
+++ b/public/cross-scene-index/by-wikidata/Q15400000-Q15499999.json
@@ -1,0 +1,15 @@
+{
+  "Q15430706": {
+    "wikidataId": "Q15430706",
+    "wikipediaTitle": "Lawrence_K._Frank",
+    "canonicalTitle": "Lawrence Frank",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-lawrence-frank",
+        "nodeTitle": "Lawrence Frank"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q15700000-Q15799999.json
+++ b/public/cross-scene-index/by-wikidata/Q15700000-Q15799999.json
@@ -1,0 +1,15 @@
+{
+  "Q15733006": {
+    "wikidataId": "Q15733006",
+    "wikipediaTitle": "Google_DeepMind",
+    "canonicalTitle": "DeepMind",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-deepmind",
+        "nodeTitle": "DeepMind"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q15900000-Q15999999.json
+++ b/public/cross-scene-index/by-wikidata/Q15900000-Q15999999.json
@@ -1,0 +1,15 @@
+{
+  "Q15989807": {
+    "wikidataId": "Q15989807",
+    "wikipediaTitle": "Theoria_motus_corporum_coelestium_in_sectionibus_conicis_solem_ambientium",
+    "canonicalTitle": "Theoria motus corporum coelestium",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-theoria-motus",
+        "nodeTitle": "Theoria motus corporum coelestium"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q1600000-Q1699999.json
+++ b/public/cross-scene-index/by-wikidata/Q1600000-Q1699999.json
@@ -1,0 +1,93 @@
+{
+  "Q1608180": {
+    "wikidataId": "Q1608180",
+    "wikipediaTitle": "Herb_Deutsch",
+    "canonicalTitle": "Herb Deutsch",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-herb-deutsch",
+        "nodeTitle": "Herb Deutsch"
+      }
+    ]
+  },
+  "Q1611073": {
+    "wikidataId": "Q1611073",
+    "wikipediaTitle": "E.G._Records",
+    "canonicalTitle": "EG Records",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-eg-records",
+        "nodeTitle": "EG Records"
+      }
+    ]
+  },
+  "Q1650528": {
+    "wikidataId": "Q1650528",
+    "wikipediaTitle": "Moog_Music",
+    "canonicalTitle": "Moog Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-moog-music",
+        "nodeTitle": "Moog Music"
+      }
+    ]
+  },
+  "Q1672919": {
+    "wikidataId": "Q1672919",
+    "wikipediaTitle": "Philosophes",
+    "canonicalTitle": "French Philosophes",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-philosophes",
+        "nodeTitle": "French Philosophes"
+      }
+    ]
+  },
+  "Q1626866": {
+    "wikidataId": "Q1626866",
+    "wikipediaTitle": "Orphic_Hymns",
+    "canonicalTitle": "Orphic Hymns",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-orphic-hymns",
+        "nodeTitle": "Orphic Hymns"
+      }
+    ]
+  },
+  "Q1645505": {
+    "wikidataId": "Q1645505",
+    "wikipediaTitle": "English_Reformation",
+    "canonicalTitle": "English Reformation",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-english-reformation",
+        "nodeTitle": "English Reformation"
+      }
+    ]
+  },
+  "Q1696381": {
+    "wikidataId": "Q1696381",
+    "wikipediaTitle": "Johann_Theodor_de_Bry",
+    "canonicalTitle": "Johann Theodor de Bry Publishing House",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-de-bry-publishing",
+        "nodeTitle": "Johann Theodor de Bry Publishing House"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q16500000-Q16599999.json
+++ b/public/cross-scene-index/by-wikidata/Q16500000-Q16599999.json
@@ -1,0 +1,15 @@
+{
+  "Q16520311": {
+    "wikidataId": "Q16520311",
+    "wikipediaTitle": "AlexNet",
+    "canonicalTitle": "ImageNet Classification with Deep Convolutional Neural Networks",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-alexnet-paper",
+        "nodeTitle": "ImageNet Classification with Deep Convolutional Neural Networks"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q16900000-Q16999999.json
+++ b/public/cross-scene-index/by-wikidata/Q16900000-Q16999999.json
@@ -1,0 +1,41 @@
+{
+  "Q16928269": {
+    "wikidataId": "Q16928269",
+    "wikipediaTitle": "Evening_Star_(album)",
+    "canonicalTitle": "Evening Star",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-fripp-eno-evening-star",
+        "nodeTitle": "Evening Star"
+      }
+    ]
+  },
+  "Q16953441": {
+    "wikidataId": "Q16953441",
+    "wikipediaTitle": "Cybernetics:_Or_Control_and_Communication_in_the_Animal_and_the_Machine",
+    "canonicalTitle": "Cybernetics: Or Control and Communication in the Animal and the Machine",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-cybernetics-wiener",
+        "nodeTitle": "Cybernetics: Or Control and Communication in the Animal and the Machine"
+      }
+    ]
+  },
+  "Q16950662": {
+    "wikidataId": "Q16950662",
+    "wikipediaTitle": "Venerable_Company_of_Pastors",
+    "canonicalTitle": "Company of Pastors",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-company-of-pastors",
+        "nodeTitle": "Company of Pastors"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q1700000-Q1799999.json
+++ b/public/cross-scene-index/by-wikidata/Q1700000-Q1799999.json
@@ -1,0 +1,106 @@
+{
+  "Q1778799": {
+    "wikidataId": "Q1778799",
+    "wikipediaTitle": "BBC_Radiophonic_Workshop",
+    "canonicalTitle": "BBC Radiophonic Workshop",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-bbc-radiophonic",
+        "nodeTitle": "BBC Radiophonic Workshop"
+      }
+    ]
+  },
+  "Q1747160": {
+    "wikidataId": "Q1747160",
+    "wikipediaTitle": "Tableau_économique",
+    "canonicalTitle": "Tableau économique",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-tableau-economique",
+        "nodeTitle": "Tableau économique"
+      }
+    ]
+  },
+  "Q1735077": {
+    "wikidataId": "Q1735077",
+    "wikipediaTitle": "Kaspar_Megander",
+    "canonicalTitle": "Kaspar Megander",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-kaspar-megander",
+        "nodeTitle": "Kaspar Megander"
+      }
+    ]
+  },
+  "Q1756294": {
+    "wikidataId": "Q1756294",
+    "wikipediaTitle": "Thomas_Bilney",
+    "canonicalTitle": "Thomas Bilney",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-thomas-bilney",
+        "nodeTitle": "Thomas Bilney"
+      }
+    ]
+  },
+  "Q1786655": {
+    "wikidataId": "Q1786655",
+    "wikipediaTitle": "Radical_Reformation",
+    "canonicalTitle": "Radical Reformation",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-radical-reformation",
+        "nodeTitle": "Radical Reformation"
+      }
+    ]
+  },
+  "Q1700457": {
+    "wikidataId": "Q1700457",
+    "wikipediaTitle": "John_Heydon_(astrologer)",
+    "canonicalTitle": "John Heydon",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-john-heydon",
+        "nodeTitle": "John Heydon"
+      }
+    ]
+  },
+  "Q1757843": {
+    "wikidataId": "Q1757843",
+    "wikipediaTitle": "The_Doctrine_of_Chances",
+    "canonicalTitle": "The Doctrine of Chances",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-doctrine-of-chances",
+        "nodeTitle": "The Doctrine of Chances"
+      }
+    ]
+  },
+  "Q1796310": {
+    "wikidataId": "Q1796310",
+    "wikipediaTitle": "Königsberg_Observatory",
+    "canonicalTitle": "Königsberg Observatory",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "location-konigsberg-observatory",
+        "nodeTitle": "Königsberg Observatory"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q17000000-Q17099999.json
+++ b/public/cross-scene-index/by-wikidata/Q17000000-Q17099999.json
@@ -1,0 +1,15 @@
+{
+  "Q17033033": {
+    "wikidataId": "Q17033033",
+    "wikipediaTitle": "Académie_de_Bordeaux",
+    "canonicalTitle": "Académie de Bordeaux",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-academie-bordeaux",
+        "nodeTitle": "Académie de Bordeaux"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q1800000-Q1899999.json
+++ b/public/cross-scene-index/by-wikidata/Q1800000-Q1899999.json
@@ -1,0 +1,41 @@
+{
+  "Q1815536": {
+    "wikidataId": "Q1815536",
+    "wikipediaTitle": "(No_Pussyfooting)",
+    "canonicalTitle": "(No Pussyfooting)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-fripp-eno-no-pussyfooting",
+        "nodeTitle": "(No Pussyfooting)"
+      }
+    ]
+  },
+  "Q1899088": {
+    "wikidataId": "Q1899088",
+    "wikipediaTitle": "Masoret_HaMasoret",
+    "canonicalTitle": "Masoret ha-Masoret",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-masoret-ha-masoret",
+        "nodeTitle": "Masoret ha-Masoret"
+      }
+    ]
+  },
+  "Q1873081": {
+    "wikidataId": "Q1873081",
+    "wikipediaTitle": "Lucas_Jennis",
+    "canonicalTitle": "Lucas Jennis Publishing House",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-lucas-jennis",
+        "nodeTitle": "Lucas Jennis Publishing House"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q18600000-Q18699999.json
+++ b/public/cross-scene-index/by-wikidata/Q18600000-Q18699999.json
@@ -1,0 +1,15 @@
+{
+  "Q18685271": {
+    "wikidataId": "Q18685271",
+    "wikipediaTitle": "Word2vec",
+    "canonicalTitle": "Word2Vec",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-word2vec",
+        "nodeTitle": "Word2Vec"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q1900000-Q1999999.json
+++ b/public/cross-scene-index/by-wikidata/Q1900000-Q1999999.json
@@ -1,0 +1,93 @@
+{
+  "Q1927926": {
+    "wikidataId": "Q1927926",
+    "wikipediaTitle": "Michael_I._Jordan",
+    "canonicalTitle": "Michael I. Jordan",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-michael-jordan",
+        "nodeTitle": "Michael I. Jordan"
+      }
+    ]
+  },
+  "Q1933643": {
+    "wikidataId": "Q1933643",
+    "wikipediaTitle": "Timewind",
+    "canonicalTitle": "Timewind",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-schulze-timewind",
+        "nodeTitle": "Timewind"
+      }
+    ]
+  },
+  "Q1972942": {
+    "wikidataId": "Q1972942",
+    "wikipediaTitle": "New_York_School_(art)",
+    "canonicalTitle": "New York School",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-new-york-school",
+        "nodeTitle": "New York School"
+      }
+    ]
+  },
+  "Q1933629": {
+    "wikidataId": "Q1933629",
+    "wikipediaTitle": "Selected_Ambient_Works_Volume_II",
+    "canonicalTitle": "Selected Ambient Works Volume II",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-aphex-saw-ii",
+        "nodeTitle": "Selected Ambient Works Volume II"
+      }
+    ]
+  },
+  "Q1970551": {
+    "wikidataId": "Q1970551",
+    "wikipediaTitle": "Steps_to_an_Ecology_of_Mind",
+    "canonicalTitle": "Steps to an Ecology of Mind",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-steps-ecology-mind-bateson",
+        "nodeTitle": "Steps to an Ecology of Mind"
+      }
+    ]
+  },
+  "Q1967606": {
+    "wikidataId": "Q1967606",
+    "wikipediaTitle": "National_Physical_Laboratory_(United_Kingdom)",
+    "canonicalTitle": "National Physical Laboratory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-npl",
+        "nodeTitle": "National Physical Laboratory"
+      }
+    ]
+  },
+  "Q1983019": {
+    "wikidataId": "Q1983019",
+    "wikipediaTitle": "The_Age_of_Reason",
+    "canonicalTitle": "The Age of Reason",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-age-reason",
+        "nodeTitle": "The Age of Reason"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q19000000-Q19099999.json
+++ b/public/cross-scene-index/by-wikidata/Q19000000-Q19099999.json
@@ -1,0 +1,28 @@
+{
+  "Q19041209": {
+    "wikidataId": "Q19041209",
+    "wikipediaTitle": "An_Introduction_to_the_Principles_of_Morals_and_Legislation",
+    "canonicalTitle": "Introduction to the Principles of Morals and Legislation",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-principles-morals-legislation",
+        "nodeTitle": "Introduction to the Principles of Morals and Legislation"
+      }
+    ]
+  },
+  "Q19020085": {
+    "wikidataId": "Q19020085",
+    "wikipediaTitle": "Colloquies",
+    "canonicalTitle": "Colloquia familiaria",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-colloquia",
+        "nodeTitle": "Colloquia familiaria"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q19100000-Q19199999.json
+++ b/public/cross-scene-index/by-wikidata/Q19100000-Q19199999.json
@@ -1,0 +1,28 @@
+{
+  "Q19108828": {
+    "wikidataId": "Q19108828",
+    "wikipediaTitle": "Experiments_and_Observations_on_Electricity",
+    "canonicalTitle": "Experiments and Observations on Electricity",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-experiments-electricity",
+        "nodeTitle": "Experiments and Observations on Electricity"
+      }
+    ]
+  },
+  "Q19169639": {
+    "wikidataId": "Q19169639",
+    "wikipediaTitle": "A_Philosophical_Essay_on_Probabilities",
+    "canonicalTitle": "Essai philosophique sur les probabilités",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-essai-philosophique-sur-les-probabilites",
+        "nodeTitle": "Essai philosophique sur les probabilités"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q19600000-Q19699999.json
+++ b/public/cross-scene-index/by-wikidata/Q19600000-Q19699999.json
@@ -1,0 +1,15 @@
+{
+  "Q19600170": {
+    "wikidataId": "Q19600170",
+    "wikipediaTitle": "Meta_AI",
+    "canonicalTitle": "Meta AI / FAIR",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-meta-ai",
+        "nodeTitle": "Meta AI / FAIR"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q19800000-Q19899999.json
+++ b/public/cross-scene-index/by-wikidata/Q19800000-Q19899999.json
@@ -1,0 +1,28 @@
+{
+  "Q19845246": {
+    "wikidataId": "Q19845246",
+    "wikipediaTitle": "Demis_Hassabis",
+    "canonicalTitle": "Demis Hassabis",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-demis-hassabis",
+        "nodeTitle": "Demis Hassabis"
+      }
+    ]
+  },
+  "Q19829553": {
+    "wikidataId": "Q19829553",
+    "wikipediaTitle": "AlphaGo",
+    "canonicalTitle": "AlphaGo",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-alphago",
+        "nodeTitle": "AlphaGo"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q200000-Q299999.json
+++ b/public/cross-scene-index/by-wikidata/Q200000-Q299999.json
@@ -1,0 +1,858 @@
+{
+  "Q271187": {
+    "wikidataId": "Q271187",
+    "wikipediaTitle": "Clara_Rockmore",
+    "canonicalTitle": "Clara Rockmore",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-clara-rockmore",
+        "nodeTitle": "Clara Rockmore"
+      }
+    ]
+  },
+  "Q200883": {
+    "wikidataId": "Q200883",
+    "wikipediaTitle": "Robert_Moog",
+    "canonicalTitle": "Robert Moog",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-robert-moog",
+        "nodeTitle": "Robert Moog"
+      }
+    ]
+  },
+  "Q203185": {
+    "wikidataId": "Q203185",
+    "wikipediaTitle": "Robert_Fripp",
+    "canonicalTitle": "Robert Fripp",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-robert-fripp",
+        "nodeTitle": "Robert Fripp"
+      }
+    ]
+  },
+  "Q262791": {
+    "wikidataId": "Q262791",
+    "wikipediaTitle": "Steve_Reich",
+    "canonicalTitle": "Steve Reich",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-steve-reich",
+        "nodeTitle": "Steve Reich"
+      }
+    ]
+  },
+  "Q240785": {
+    "wikidataId": "Q240785",
+    "wikipediaTitle": "Irrlicht",
+    "canonicalTitle": "Irrlicht",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-schulze-irrlicht",
+        "nodeTitle": "Irrlicht"
+      }
+    ]
+  },
+  "Q207691": {
+    "wikidataId": "Q207691",
+    "wikipediaTitle": "Theremin",
+    "canonicalTitle": "Theremin",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-theremin",
+        "nodeTitle": "Theremin"
+      }
+    ]
+  },
+  "Q213205": {
+    "wikidataId": "Q213205",
+    "wikipediaTitle": "San_Francisco_Bay_Area",
+    "canonicalTitle": "San Francisco Bay Area",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-san-francisco",
+        "nodeTitle": "San Francisco Bay Area"
+      }
+    ]
+  },
+  "Q218160": {
+    "wikidataId": "Q218160",
+    "wikipediaTitle": "Zodiak_Free_Arts_Lab",
+    "canonicalTitle": "Zodiak Free Arts Lab",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-zodiak",
+        "nodeTitle": "Zodiak Free Arts Lab"
+      }
+    ]
+  },
+  "Q203059": {
+    "wikidataId": "Q203059",
+    "wikipediaTitle": "Virgin_Records",
+    "canonicalTitle": "Virgin Records",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-virgin-german",
+        "nodeTitle": "Virgin Records"
+      }
+    ]
+  },
+  "Q212688": {
+    "wikidataId": "Q212688",
+    "wikipediaTitle": "Dub_music",
+    "canonicalTitle": "Dub",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-dub",
+        "nodeTitle": "Dub"
+      }
+    ]
+  },
+  "Q223161": {
+    "wikidataId": "Q223161",
+    "wikipediaTitle": "Aphex_Twin",
+    "canonicalTitle": "Richard D. James (Aphex Twin)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-richard-d-james",
+        "nodeTitle": "Richard D. James (Aphex Twin)"
+      }
+    ]
+  },
+  "Q202660": {
+    "wikidataId": "Q202660",
+    "wikipediaTitle": "Collège_de_France",
+    "canonicalTitle": "Collège de France",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "entity-college-de-france",
+        "nodeTitle": "Collège de France"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-college-de-france",
+        "nodeTitle": "Collège de France"
+      }
+    ]
+  },
+  "Q224372": {
+    "wikidataId": "Q224372",
+    "wikipediaTitle": "I._J._Good",
+    "canonicalTitle": "I.J. Good",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-i-j-good",
+        "nodeTitle": "I.J. Good"
+      }
+    ]
+  },
+  "Q271226": {
+    "wikidataId": "Q271226",
+    "wikipediaTitle": "Donella_Meadows",
+    "canonicalTitle": "Donella Meadows",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-donella-meadows",
+        "nodeTitle": "Donella Meadows"
+      }
+    ]
+  },
+  "Q204815": {
+    "wikidataId": "Q204815",
+    "wikipediaTitle": "Marvin_Minsky",
+    "canonicalTitle": "Marvin Minsky",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-marvin-minsky",
+        "nodeTitle": "Marvin Minsky"
+      }
+    ]
+  },
+  "Q299595": {
+    "wikidataId": "Q299595",
+    "wikipediaTitle": "Vannevar_Bush",
+    "canonicalTitle": "Vannevar Bush",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-vannevar-bush",
+        "nodeTitle": "Vannevar Bush"
+      }
+    ]
+  },
+  "Q277111": {
+    "wikidataId": "Q277111",
+    "wikipediaTitle": "The_Limits_to_Growth",
+    "canonicalTitle": "The Limits to Growth",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-limits-growth-meadows",
+        "nodeTitle": "The Limits to Growth"
+      }
+    ]
+  },
+  "Q217365": {
+    "wikidataId": "Q217365",
+    "wikipediaTitle": "Bell_Labs",
+    "canonicalTitle": "Bell Labs",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-bell-labs",
+        "nodeTitle": "Bell Labs"
+      },
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-bell-labs-research",
+        "nodeTitle": "Bell Labs Research"
+      }
+    ]
+  },
+  "Q230899": {
+    "wikidataId": "Q230899",
+    "wikipediaTitle": "University_of_Manchester",
+    "canonicalTitle": "University of Manchester",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-manchester",
+        "nodeTitle": "University of Manchester"
+      }
+    ]
+  },
+  "Q232141": {
+    "wikidataId": "Q232141",
+    "wikipediaTitle": "University_of_Chile",
+    "canonicalTitle": "University of Chile",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-chile",
+        "nodeTitle": "University of Chile"
+      }
+    ]
+  },
+  "Q201492": {
+    "wikidataId": "Q201492",
+    "wikipediaTitle": "McGill_University",
+    "canonicalTitle": "McGill University",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-mcgill",
+        "nodeTitle": "McGill University"
+      }
+    ]
+  },
+  "Q230492": {
+    "wikidataId": "Q230492",
+    "wikipediaTitle": "University_of_Michigan",
+    "canonicalTitle": "University of Michigan",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-michigan",
+        "nodeTitle": "University of Michigan"
+      }
+    ]
+  },
+  "Q269699": {
+    "wikidataId": "Q269699",
+    "wikipediaTitle": "Systems_theory",
+    "canonicalTitle": "General Systems Theory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-general-systems-theory",
+        "nodeTitle": "General Systems Theory"
+      }
+    ]
+  },
+  "Q203790": {
+    "wikidataId": "Q203790",
+    "wikipediaTitle": "Connectionism",
+    "canonicalTitle": "Connectionism / Neural Networks",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-connectionism",
+        "nodeTitle": "Connectionism / Neural Networks"
+      }
+    ]
+  },
+  "Q272119": {
+    "wikidataId": "Q272119",
+    "wikipediaTitle": "Étienne_Bonnot_de_Condillac",
+    "canonicalTitle": "Étienne Bonnot de Condillac",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-condillac",
+        "nodeTitle": "Étienne Bonnot de Condillac"
+      }
+    ]
+  },
+  "Q201477": {
+    "wikidataId": "Q201477",
+    "wikipediaTitle": "Marquis_de_Condorcet",
+    "canonicalTitle": "Nicolas de Condorcet",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-condorcet",
+        "nodeTitle": "Nicolas de Condorcet"
+      }
+    ]
+  },
+  "Q218254": {
+    "wikidataId": "Q218254",
+    "wikipediaTitle": "Dugald_Stewart",
+    "canonicalTitle": "Dugald Stewart",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-dugald-stewart",
+        "nodeTitle": "Dugald Stewart"
+      }
+    ]
+  },
+  "Q223723": {
+    "wikidataId": "Q223723",
+    "wikipediaTitle": "Cesare_Beccaria",
+    "canonicalTitle": "Cesare Beccaria",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-cesare-beccaria",
+        "nodeTitle": "Cesare Beccaria"
+      }
+    ]
+  },
+  "Q221303": {
+    "wikidataId": "Q221303",
+    "wikipediaTitle": "Anne_Robert_Jacques_Turgot",
+    "canonicalTitle": "Anne-Robert-Jacques Turgot",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-turgot",
+        "nodeTitle": "Anne-Robert-Jacques Turgot"
+      }
+    ]
+  },
+  "Q229264": {
+    "wikidataId": "Q229264",
+    "wikipediaTitle": "Georges-Louis_Leclerc,_Comte_de_Buffon",
+    "canonicalTitle": "Georges-Louis Leclerc, Comte de Buffon",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-buffon",
+        "nodeTitle": "Georges-Louis Leclerc, Comte de Buffon"
+      }
+    ]
+  },
+  "Q269865": {
+    "wikidataId": "Q269865",
+    "wikipediaTitle": "Marie_Thérèse_Rodet_Geoffrin",
+    "canonicalTitle": "Marie-Thérèse Rodet Geoffrin",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-madame-geoffrin",
+        "nodeTitle": "Marie-Thérèse Rodet Geoffrin"
+      }
+    ]
+  },
+  "Q297785": {
+    "wikidataId": "Q297785",
+    "wikipediaTitle": "Marie_Anne_de_Vichy-Chamrond,_marquise_du_Deffand",
+    "canonicalTitle": "Marie de Vichy-Chamrond, Marquise du Deffand",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-madame-du-deffand",
+        "nodeTitle": "Marie de Vichy-Chamrond, Marquise du Deffand"
+      }
+    ]
+  },
+  "Q205921": {
+    "wikidataId": "Q205921",
+    "wikipediaTitle": "Philosophiæ_Naturalis_Principia_Mathematica",
+    "canonicalTitle": "Philosophiæ Naturalis Principia Mathematica",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-principia-mathematica",
+        "nodeTitle": "Philosophiæ Naturalis Principia Mathematica"
+      }
+    ]
+  },
+  "Q231949": {
+    "wikidataId": "Q231949",
+    "wikipediaTitle": "Two_Treatises_of_Government",
+    "canonicalTitle": "Two Treatises of Government",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-two-treatises",
+        "nodeTitle": "Two Treatises of Government"
+      }
+    ]
+  },
+  "Q215894": {
+    "wikidataId": "Q215894",
+    "wikipediaTitle": "Candide",
+    "canonicalTitle": "Candide",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-candide",
+        "nodeTitle": "Candide"
+      }
+    ]
+  },
+  "Q233562": {
+    "wikidataId": "Q233562",
+    "wikipediaTitle": "The_Wealth_of_Nations",
+    "canonicalTitle": "An Inquiry into the Nature and Causes of the Wealth of Nations",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-wealth-nations",
+        "nodeTitle": "An Inquiry into the Nature and Causes of the Wealth of Nations"
+      }
+    ]
+  },
+  "Q286611": {
+    "wikidataId": "Q286611",
+    "wikipediaTitle": "Nathan_the_Wise",
+    "canonicalTitle": "Nathan the Wise",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-nathan-wise",
+        "nodeTitle": "Nathan the Wise"
+      }
+    ]
+  },
+  "Q220002": {
+    "wikidataId": "Q220002",
+    "wikipediaTitle": "Critique_of_Pure_Reason",
+    "canonicalTitle": "Critique of Pure Reason",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-critique-pure-reason",
+        "nodeTitle": "Critique of Pure Reason"
+      }
+    ]
+  },
+  "Q209842": {
+    "wikidataId": "Q209842",
+    "wikipediaTitle": "University_of_Paris",
+    "canonicalTitle": "Sorbonne / University of Paris",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-sorbonne",
+        "nodeTitle": "Sorbonne / University of Paris"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-sorbonne",
+        "nodeTitle": "University of Paris (Sorbonne)"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-paris",
+        "nodeTitle": "University of Paris"
+      }
+    ]
+  },
+  "Q233733": {
+    "wikidataId": "Q233733",
+    "wikipediaTitle": "Ferney-Voltaire",
+    "canonicalTitle": "Ferney",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-ferney",
+        "nodeTitle": "Ferney"
+      }
+    ]
+  },
+  "Q219934": {
+    "wikidataId": "Q219934",
+    "wikipediaTitle": "Enlightened_absolutism",
+    "canonicalTitle": "Enlightened Despotism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-enlightened-despotism",
+        "nodeTitle": "Enlightened Despotism"
+      }
+    ]
+  },
+  "Q219639": {
+    "wikidataId": "Q219639",
+    "wikipediaTitle": "William_Tyndale",
+    "canonicalTitle": "William Tyndale",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-william-tyndale",
+        "nodeTitle": "William Tyndale"
+      }
+    ]
+  },
+  "Q294435": {
+    "wikidataId": "Q294435",
+    "wikipediaTitle": "Thomas_Cromwell",
+    "canonicalTitle": "Thomas Cromwell",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-thomas-cromwell",
+        "nodeTitle": "Thomas Cromwell"
+      }
+    ]
+  },
+  "Q282497": {
+    "wikidataId": "Q282497",
+    "wikipediaTitle": "On_the_Babylonian_Captivity_of_the_Church",
+    "canonicalTitle": "On the Babylonian Captivity of the Church",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-babylonian-captivity",
+        "nodeTitle": "On the Babylonian Captivity of the Church"
+      }
+    ]
+  },
+  "Q265613": {
+    "wikidataId": "Q265613",
+    "wikipediaTitle": "Schleitheim_Confession",
+    "canonicalTitle": "Schleitheim Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-schleitheim-confession",
+        "nodeTitle": "Schleitheim Confession"
+      }
+    ]
+  },
+  "Q207620": {
+    "wikidataId": "Q207620",
+    "wikipediaTitle": "Meaux",
+    "canonicalTitle": "Meaux",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-meaux",
+        "nodeTitle": "Meaux"
+      }
+    ]
+  },
+  "Q207736": {
+    "wikidataId": "Q207736",
+    "wikipediaTitle": "St_Andrews",
+    "canonicalTitle": "St. Andrews",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-st-andrews",
+        "nodeTitle": "St. Andrews"
+      }
+    ]
+  },
+  "Q216273": {
+    "wikidataId": "Q216273",
+    "wikipediaTitle": "University_of_St_Andrews",
+    "canonicalTitle": "University of St. Andrews",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-st-andrews-university",
+        "nodeTitle": "University of St. Andrews"
+      }
+    ]
+  },
+  "Q214115": {
+    "wikidataId": "Q214115",
+    "wikipediaTitle": "Lorenzo_Valla",
+    "canonicalTitle": "Lorenzo Valla",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-lorenzo-valla",
+        "nodeTitle": "Lorenzo Valla"
+      }
+    ]
+  },
+  "Q213220": {
+    "wikidataId": "Q213220",
+    "wikipediaTitle": "Aldus_Manutius",
+    "canonicalTitle": "Aldo Manuzio (Aldus Manutius)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-aldo-manuzio",
+        "nodeTitle": "Aldo Manuzio (Aldus Manutius)"
+      }
+    ]
+  },
+  "Q260921": {
+    "wikidataId": "Q260921",
+    "wikipediaTitle": "Robert_Estienne",
+    "canonicalTitle": "Robert Estienne (Stephanus)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-robert-estienne",
+        "nodeTitle": "Robert Estienne (Stephanus)"
+      }
+    ]
+  },
+  "Q290227": {
+    "wikidataId": "Q290227",
+    "wikipediaTitle": "Étienne_de_La_Boétie",
+    "canonicalTitle": "Étienne de La Boétie",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-etienne-de-la-boetie",
+        "nodeTitle": "Étienne de La Boétie"
+      }
+    ]
+  },
+  "Q299446": {
+    "wikidataId": "Q299446",
+    "wikipediaTitle": "Bessarion",
+    "canonicalTitle": "Cardinal Bessarion",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-cardinal-bessarion",
+        "nodeTitle": "Cardinal Bessarion"
+      }
+    ]
+  },
+  "Q296272": {
+    "wikidataId": "Q296272",
+    "wikipediaTitle": "Pietro_Aretino",
+    "canonicalTitle": "Pietro Aretino",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-pietro-aretino",
+        "nodeTitle": "Pietro Aretino"
+      }
+    ]
+  },
+  "Q211133": {
+    "wikidataId": "Q211133",
+    "wikipediaTitle": "Baldassare_Castiglione",
+    "canonicalTitle": "Baldassare Castiglione",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-baldassare-castiglione",
+        "nodeTitle": "Baldassare Castiglione"
+      }
+    ]
+  },
+  "Q201484": {
+    "wikidataId": "Q201484",
+    "wikipediaTitle": "John_Dee",
+    "canonicalTitle": "John Dee",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-john-dee",
+        "nodeTitle": "John Dee"
+      }
+    ]
+  },
+  "Q298908": {
+    "wikidataId": "Q298908",
+    "wikipediaTitle": "Robert_Bellarmine",
+    "canonicalTitle": "Robert Bellarmine",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-robert-bellarmine",
+        "nodeTitle": "Robert Bellarmine"
+      }
+    ]
+  },
+  "Q234858": {
+    "wikidataId": "Q234858",
+    "wikipediaTitle": "Margaret_Cavendish,_Duchess_of_Newcastle-upon-Tyne",
+    "canonicalTitle": "Margaret Cavendish",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-margaret-cavendish",
+        "nodeTitle": "Margaret Cavendish"
+      }
+    ]
+  },
+  "Q211423": {
+    "wikidataId": "Q211423",
+    "wikipediaTitle": "De_revolutionibus_orbium_coelestium",
+    "canonicalTitle": "De revolutionibus orbium coelestium",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-de-revolutionibus",
+        "nodeTitle": "De revolutionibus orbium coelestium"
+      }
+    ]
+  },
+  "Q205934": {
+    "wikidataId": "Q205934",
+    "wikipediaTitle": "Philosophiæ_Naturalis_Principia_Mathematica",
+    "canonicalTitle": "Philosophiæ Naturalis Principia Mathematica",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-principia",
+        "nodeTitle": "Philosophiæ Naturalis Principia Mathematica"
+      }
+    ]
+  },
+  "Q215733": {
+    "wikidataId": "Q215733",
+    "wikipediaTitle": "Warrington",
+    "canonicalTitle": "Warrington",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "loc-warrington",
+        "nodeTitle": "Warrington"
+      }
+    ]
+  },
+  "Q216723": {
+    "wikidataId": "Q216723",
+    "wikipediaTitle": "Ronald_Fisher",
+    "canonicalTitle": "Ronald A. Fisher",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-ronald-fisher",
+        "nodeTitle": "Ronald A. Fisher"
+      }
+    ]
+  },
+  "Q273626": {
+    "wikidataId": "Q273626",
+    "wikipediaTitle": "École_Polytechnique",
+    "canonicalTitle": "École Polytechnique",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "location-ecole-polytechnique",
+        "nodeTitle": "École Polytechnique"
+      }
+    ]
+  },
+  "Q206012": {
+    "wikidataId": "Q206012",
+    "wikipediaTitle": "Pafnuty_Chebyshev",
+    "canonicalTitle": "Pafnuty Chebyshev",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-pafnuty-chebyshev",
+        "nodeTitle": "Pafnuty Chebyshev"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q2000000-Q2099999.json
+++ b/public/cross-scene-index/by-wikidata/Q2000000-Q2099999.json
@@ -1,0 +1,93 @@
+{
+  "Q2016462": {
+    "wikidataId": "Q2016462",
+    "wikipediaTitle": "Conference_on_Neural_Information_Processing_Systems",
+    "canonicalTitle": "NeurIPS",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-neurips",
+        "nodeTitle": "NeurIPS"
+      }
+    ]
+  },
+  "Q2058212": {
+    "wikidataId": "Q2058212",
+    "wikipediaTitle": "Discreet_Music",
+    "canonicalTitle": "Discreet Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-discreet-music",
+        "nodeTitle": "Discreet Music"
+      }
+    ]
+  },
+  "Q2021193": {
+    "wikidataId": "Q2021193",
+    "wikipediaTitle": "Oration_on_the_Dignity_of_Man",
+    "canonicalTitle": "Oration on the Dignity of Man",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-oration-dignity-man",
+        "nodeTitle": "Oration on the Dignity of Man"
+      }
+    ]
+  },
+  "Q2046693": {
+    "wikidataId": "Q2046693",
+    "wikipediaTitle": "Platonic_Academy_(Florence)",
+    "canonicalTitle": "Platonic Academy of Florence",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "entity-platonic-academy-florence",
+        "nodeTitle": "Platonic Academy of Florence"
+      }
+    ]
+  },
+  "Q2085760": {
+    "wikidataId": "Q2085760",
+    "wikipediaTitle": "Oration_on_the_Dignity_of_Man",
+    "canonicalTitle": "Oratio de hominis dignitate",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-oration-dignity-man",
+        "nodeTitle": "Oratio de hominis dignitate"
+      }
+    ]
+  },
+  "Q2063476": {
+    "wikidataId": "Q2063476",
+    "wikipediaTitle": "The_Sceptical_Chymist",
+    "canonicalTitle": "The Sceptical Chymist",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-sceptical-chymist",
+        "nodeTitle": "The Sceptical Chymist"
+      }
+    ]
+  },
+  "Q2088170": {
+    "wikidataId": "Q2088170",
+    "wikipediaTitle": "Suicide_(Durkheim_book)",
+    "canonicalTitle": "Le Suicide",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-le-suicide",
+        "nodeTitle": "Le Suicide"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q2100000-Q2199999.json
+++ b/public/cross-scene-index/by-wikidata/Q2100000-Q2199999.json
@@ -1,0 +1,54 @@
+{
+  "Q2101507": {
+    "wikidataId": "Q2101507",
+    "wikipediaTitle": "Polygraphia_(book)",
+    "canonicalTitle": "Polygraphia",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-polygraphia",
+        "nodeTitle": "Polygraphia"
+      }
+    ]
+  },
+  "Q2166858": {
+    "wikidataId": "Q2166858",
+    "wikipediaTitle": "Théodicée",
+    "canonicalTitle": "Theodicy",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-theodicy",
+        "nodeTitle": "Theodicy"
+      }
+    ]
+  },
+  "Q2163561": {
+    "wikidataId": "Q2163561",
+    "wikipediaTitle": "Traité_Élémentaire_de_Chimie",
+    "canonicalTitle": "Elements of Chemistry",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-elements-chemistry",
+        "nodeTitle": "Elements of Chemistry"
+      }
+    ]
+  },
+  "Q2157227": {
+    "wikidataId": "Q2157227",
+    "wikipediaTitle": "Rothamsted_Research",
+    "canonicalTitle": "Rothamsted Experimental Station",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "location-rothamsted-experimental-station",
+        "nodeTitle": "Rothamsted Experimental Station"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q21000000-Q21099999.json
+++ b/public/cross-scene-index/by-wikidata/Q21000000-Q21099999.json
@@ -1,0 +1,15 @@
+{
+  "Q21072607": {
+    "wikidataId": "Q21072607",
+    "wikipediaTitle": "Google_Brain",
+    "canonicalTitle": "Google Brain",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-google-brain",
+        "nodeTitle": "Google Brain"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q21100000-Q21199999.json
+++ b/public/cross-scene-index/by-wikidata/Q21100000-Q21199999.json
@@ -1,0 +1,15 @@
+{
+  "Q21167448": {
+    "wikidataId": "Q21167448",
+    "wikipediaTitle": "Christian_Szegedy",
+    "canonicalTitle": "Christian Szegedy",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-christian-szegedy",
+        "nodeTitle": "Christian Szegedy"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q21400000-Q21499999.json
+++ b/public/cross-scene-index/by-wikidata/Q21400000-Q21499999.json
@@ -1,0 +1,15 @@
+{
+  "Q21447974": {
+    "wikidataId": "Q21447974",
+    "wikipediaTitle": "TensorFlow",
+    "canonicalTitle": "TensorFlow",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-tensorflow",
+        "nodeTitle": "TensorFlow"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q21500000-Q21599999.json
+++ b/public/cross-scene-index/by-wikidata/Q21500000-Q21599999.json
@@ -1,0 +1,15 @@
+{
+  "Q21545259": {
+    "wikidataId": "Q21545259",
+    "wikipediaTitle": "Olga_Russakovsky",
+    "canonicalTitle": "Olga Russakovsky",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-olga-russakovsky",
+        "nodeTitle": "Olga Russakovsky"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q21600000-Q21699999.json
+++ b/public/cross-scene-index/by-wikidata/Q21600000-Q21699999.json
@@ -1,0 +1,15 @@
+{
+  "Q21658269": {
+    "wikidataId": "Q21658269",
+    "wikipediaTitle": "Tomáš_Mikolov",
+    "canonicalTitle": "Tomas Mikolov",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-tomas-mikolov",
+        "nodeTitle": "Tomas Mikolov"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q21700000-Q21799999.json
+++ b/public/cross-scene-index/by-wikidata/Q21700000-Q21799999.json
@@ -1,0 +1,15 @@
+{
+  "Q21708200": {
+    "wikidataId": "Q21708200",
+    "wikipediaTitle": "OpenAI",
+    "canonicalTitle": "OpenAI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-openai",
+        "nodeTitle": "OpenAI"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q2200000-Q2299999.json
+++ b/public/cross-scene-index/by-wikidata/Q2200000-Q2299999.json
@@ -1,0 +1,41 @@
+{
+  "Q2296309": {
+    "wikidataId": "Q2296309",
+    "wikipediaTitle": "Electronic_Meditation",
+    "canonicalTitle": "Electronic Meditation",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-td-electronic-meditation",
+        "nodeTitle": "Electronic Meditation"
+      }
+    ]
+  },
+  "Q2287584": {
+    "wikidataId": "Q2287584",
+    "wikipediaTitle": "Reflections_on_the_Revolution_in_France",
+    "canonicalTitle": "Reflections on the Revolution in France",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-reflections-revolution",
+        "nodeTitle": "Reflections on the Revolution in France"
+      }
+    ]
+  },
+  "Q2240551": {
+    "wikidataId": "Q2240551",
+    "wikipediaTitle": "Château_de_Cirey",
+    "canonicalTitle": "Cirey",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-cirey",
+        "nodeTitle": "Cirey"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q22000000-Q22099999.json
+++ b/public/cross-scene-index/by-wikidata/Q22000000-Q22099999.json
@@ -1,0 +1,15 @@
+{
+  "Q22078899": {
+    "wikidataId": "Q22078899",
+    "wikipediaTitle": "Alex_Krizhevsky",
+    "canonicalTitle": "Alex Krizhevsky",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-alex-krizhevsky",
+        "nodeTitle": "Alex Krizhevsky"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q22300000-Q22399999.json
+++ b/public/cross-scene-index/by-wikidata/Q22300000-Q22399999.json
@@ -1,0 +1,28 @@
+{
+  "Q22341183": {
+    "wikidataId": "Q22341183",
+    "wikipediaTitle": "Midori_Takada",
+    "canonicalTitle": "Midori Takada",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-midori-takada",
+        "nodeTitle": "Midori Takada"
+      }
+    ]
+  },
+  "Q22337370": {
+    "wikidataId": "Q22337370",
+    "wikipediaTitle": "A_Logical_Calculus_of_the_Ideas_Immanent_in_Nervous_Activity",
+    "canonicalTitle": "A Logical Calculus of the Ideas Immanent in Nervous Activity",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-logical-calculus-mcculloch-pitts",
+        "nodeTitle": "A Logical Calculus of the Ideas Immanent in Nervous Activity"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q22900000-Q22999999.json
+++ b/public/cross-scene-index/by-wikidata/Q22900000-Q22999999.json
@@ -1,0 +1,15 @@
+{
+  "Q22908016": {
+    "wikidataId": "Q22908016",
+    "wikipediaTitle": "Quoc_Viet_Le",
+    "canonicalTitle": "Quoc V. Le",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-quoc-le",
+        "nodeTitle": "Quoc V. Le"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q2300000-Q2399999.json
+++ b/public/cross-scene-index/by-wikidata/Q2300000-Q2399999.json
@@ -1,0 +1,47 @@
+{
+  "Q2358704": {
+    "wikidataId": "Q2358704",
+    "wikipediaTitle": "Studio_for_Electronic_Music_(WDR)",
+    "canonicalTitle": "WDR Studio for Electronic Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-wdr-studio",
+        "nodeTitle": "WDR Studio for Electronic Music"
+      }
+    ]
+  },
+  "Q2327432": {
+    "wikidataId": "Q2327432",
+    "wikipediaTitle": "Christian_humanism",
+    "canonicalTitle": "Christian Humanism",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-christian-humanism",
+        "nodeTitle": "Christian Humanism"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-northern-humanism",
+        "nodeTitle": "Northern (Christian) Humanism"
+      }
+    ]
+  },
+  "Q2306608": {
+    "wikidataId": "Q2306608",
+    "wikipediaTitle": "Philosophical_Transactions_of_the_Royal_Society",
+    "canonicalTitle": "Philosophical Transactions of the Royal Society",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-philosophical-transactions",
+        "nodeTitle": "Philosophical Transactions of the Royal Society"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q23800000-Q23899999.json
+++ b/public/cross-scene-index/by-wikidata/Q23800000-Q23899999.json
@@ -1,0 +1,28 @@
+{
+  "Q23831774": {
+    "wikidataId": "Q23831774",
+    "wikipediaTitle": "David_Silver_(computer_scientist)",
+    "canonicalTitle": "David Silver",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-david-silver",
+        "nodeTitle": "David Silver"
+      }
+    ]
+  },
+  "Q23831959": {
+    "wikidataId": "Q23831959",
+    "wikipediaTitle": "Aja_Huang",
+    "canonicalTitle": "Aja Huang",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-aja-huang",
+        "nodeTitle": "Aja Huang"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q2400000-Q2499999.json
+++ b/public/cross-scene-index/by-wikidata/Q2400000-Q2499999.json
@@ -1,0 +1,92 @@
+{
+  "Q2453355": {
+    "wikidataId": "Q2453355",
+    "wikipediaTitle": "Dartmouth_workshop",
+    "canonicalTitle": "A Proposal for the Dartmouth Summer Research Project on Artificial Intelligence",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-dartmouth-proposal",
+        "nodeTitle": "A Proposal for the Dartmouth Summer Research Project on Artificial Intelligence"
+      },
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-dartmouth-conference",
+        "nodeTitle": "Dartmouth Conference"
+      }
+    ]
+  },
+  "Q2414313": {
+    "wikidataId": "Q2414313",
+    "wikipediaTitle": "The_Society_of_Mind",
+    "canonicalTitle": "The Society of Mind",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-society-mind-minsky",
+        "nodeTitle": "The Society of Mind"
+      }
+    ]
+  },
+  "Q2451675": {
+    "wikidataId": "Q2451675",
+    "wikipediaTitle": "A_Treatise_of_Human_Nature",
+    "canonicalTitle": "A Treatise of Human Nature",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-treatise-human-nature",
+        "nodeTitle": "A Treatise of Human Nature"
+      }
+    ]
+  },
+  "Q2492149": {
+    "wikidataId": "Q2492149",
+    "wikipediaTitle": "To_the_Christian_Nobility_of_the_German_Nation",
+    "canonicalTitle": "Address to the Christian Nobility of the German Nation",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-address-christian-nobility",
+        "nodeTitle": "Address to the Christian Nobility of the German Nation"
+      }
+    ]
+  },
+  "Q2462802": {
+    "wikidataId": "Q2462802",
+    "wikipediaTitle": "Tyndale_Bible",
+    "canonicalTitle": "Tyndale's New Testament",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-tyndale-nt",
+        "nodeTitle": "Tyndale's New Testament"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-tyndale-pentateuch",
+        "nodeTitle": "Tyndale's Pentateuch"
+      }
+    ]
+  },
+  "Q2456034": {
+    "wikidataId": "Q2456034",
+    "wikipediaTitle": "Chymical_Wedding_of_Christian_Rosenkreutz",
+    "canonicalTitle": "Chymical Wedding of Christian Rosenkreutz",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-chymical-wedding",
+        "nodeTitle": "Chymical Wedding of Christian Rosenkreutz"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q24700000-Q24799999.json
+++ b/public/cross-scene-index/by-wikidata/Q24700000-Q24799999.json
@@ -1,0 +1,15 @@
+{
+  "Q24709116": {
+    "wikidataId": "Q24709116",
+    "wikipediaTitle": "Greg_Corrado",
+    "canonicalTitle": "Greg Corrado",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-greg-corrado",
+        "nodeTitle": "Greg Corrado"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q2500000-Q2599999.json
+++ b/public/cross-scene-index/by-wikidata/Q2500000-Q2599999.json
@@ -1,0 +1,28 @@
+{
+  "Q2574388": {
+    "wikidataId": "Q2574388",
+    "wikipediaTitle": "Jeanne_Loriod",
+    "canonicalTitle": "Jeanne Loriod",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-jeanne-loriod",
+        "nodeTitle": "Jeanne Loriod"
+      }
+    ]
+  },
+  "Q2551373": {
+    "wikidataId": "Q2551373",
+    "wikipediaTitle": "Letters_on_the_English",
+    "canonicalTitle": "Letters on the English",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-letters-english",
+        "nodeTitle": "Letters on the English"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q25300000-Q25399999.json
+++ b/public/cross-scene-index/by-wikidata/Q25300000-Q25399999.json
@@ -1,0 +1,28 @@
+{
+  "Q25347847": {
+    "wikidataId": "Q25347847",
+    "wikipediaTitle": "Generative_adversarial_network",
+    "canonicalTitle": "Generative Adversarial Networks",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gan-paper",
+        "nodeTitle": "Generative Adversarial Networks"
+      }
+    ]
+  },
+  "Q25348086": {
+    "wikidataId": "Q25348086",
+    "wikipediaTitle": "Variational_autoencoder",
+    "canonicalTitle": "Auto-Encoding Variational Bayes",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-vae-paper",
+        "nodeTitle": "Auto-Encoding Variational Bayes"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q25400000-Q25499999.json
+++ b/public/cross-scene-index/by-wikidata/Q25400000-Q25499999.json
@@ -1,0 +1,15 @@
+{
+  "Q25460599": {
+    "wikidataId": "Q25460599",
+    "wikipediaTitle": "Richard_Socher",
+    "canonicalTitle": "Richard Socher",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-richard-socher",
+        "nodeTitle": "Richard Socher"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q25900000-Q25999999.json
+++ b/public/cross-scene-index/by-wikidata/Q25900000-Q25999999.json
@@ -1,0 +1,15 @@
+{
+  "Q25927621": {
+    "wikidataId": "Q25927621",
+    "wikipediaTitle": "Statistical_Methods_for_Research_Workers",
+    "canonicalTitle": "Statistical Methods for Research Workers",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-statistical-methods-for-research-workers",
+        "nodeTitle": "Statistical Methods for Research Workers"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q2600000-Q2699999.json
+++ b/public/cross-scene-index/by-wikidata/Q2600000-Q2699999.json
@@ -1,0 +1,54 @@
+{
+  "Q2655756": {
+    "wikidataId": "Q2655756",
+    "wikipediaTitle": "Hans-Joachim_Roedelius",
+    "canonicalTitle": "Hans-Joachim Roedelius",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-hans-joachim-roedelius",
+        "nodeTitle": "Hans-Joachim Roedelius"
+      }
+    ]
+  },
+  "Q2674076": {
+    "wikidataId": "Q2674076",
+    "wikipediaTitle": "900_Theses",
+    "canonicalTitle": "Conclusiones philosophicae, cabalisticae et theologicae",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-900-theses",
+        "nodeTitle": "Conclusiones philosophicae, cabalisticae et theologicae"
+      }
+    ]
+  },
+  "Q2651957": {
+    "wikidataId": "Q2651957",
+    "wikipediaTitle": "Oliver_Selfridge",
+    "canonicalTitle": "Oliver Selfridge",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-oliver-selfridge",
+        "nodeTitle": "Oliver Selfridge"
+      }
+    ]
+  },
+  "Q2657053": {
+    "wikidataId": "Q2657053",
+    "wikipediaTitle": "Novum_Organum",
+    "canonicalTitle": "Novum Organum",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-novum-organum",
+        "nodeTitle": "Novum Organum"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q26800000-Q26899999.json
+++ b/public/cross-scene-index/by-wikidata/Q26800000-Q26899999.json
@@ -1,0 +1,15 @@
+{
+  "Q26884227": {
+    "wikidataId": "Q26884227",
+    "wikipediaTitle": "Andrej_Karpathy",
+    "canonicalTitle": "Andrej Karpathy",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-andrej-karpathy",
+        "nodeTitle": "Andrej Karpathy"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q26900000-Q26999999.json
+++ b/public/cross-scene-index/by-wikidata/Q26900000-Q26999999.json
@@ -1,0 +1,15 @@
+{
+  "Q26903314": {
+    "wikidataId": "Q26903314",
+    "wikipediaTitle": "Dropout_(neural_networks)",
+    "canonicalTitle": "Dropout: A Simple Way to Prevent Neural Networks from Overfitting",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-dropout-paper",
+        "nodeTitle": "Dropout: A Simple Way to Prevent Neural Networks from Overfitting"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q2700000-Q2799999.json
+++ b/public/cross-scene-index/by-wikidata/Q2700000-Q2799999.json
@@ -1,0 +1,41 @@
+{
+  "Q2746944": {
+    "wikidataId": "Q2746944",
+    "wikipediaTitle": "The_Art_of_Noises",
+    "canonicalTitle": "The Art of Noises (L'arte dei Rumori)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-russolo-art-of-noises",
+        "nodeTitle": "The Art of Noises (L'arte dei Rumori)"
+      }
+    ]
+  },
+  "Q2714697": {
+    "wikidataId": "Q2714697",
+    "wikipediaTitle": "Music_for_18_Musicians",
+    "canonicalTitle": "Music for 18 Musicians",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-reich-music-for-18",
+        "nodeTitle": "Music for 18 Musicians"
+      }
+    ]
+  },
+  "Q2755269": {
+    "wikidataId": "Q2755269",
+    "wikipediaTitle": "On_Crimes_and_Punishments",
+    "canonicalTitle": "On Crimes and Punishments",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-crimes-punishments",
+        "nodeTitle": "On Crimes and Punishments"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q27300000-Q27399999.json
+++ b/public/cross-scene-index/by-wikidata/Q27300000-Q27399999.json
@@ -1,0 +1,28 @@
+{
+  "Q27311979": {
+    "wikidataId": "Q27311979",
+    "wikipediaTitle": "Ian_Goodfellow",
+    "canonicalTitle": "Ian Goodfellow",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-ian-goodfellow",
+        "nodeTitle": "Ian Goodfellow"
+      }
+    ]
+  },
+  "Q27312191": {
+    "wikidataId": "Q27312191",
+    "wikipediaTitle": "Aaron_Courville",
+    "canonicalTitle": "Aaron Courville",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-aaron-courville",
+        "nodeTitle": "Aaron Courville"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q2800000-Q2899999.json
+++ b/public/cross-scene-index/by-wikidata/Q2800000-Q2899999.json
@@ -1,0 +1,67 @@
+{
+  "Q2819874": {
+    "wikidataId": "Q2819874",
+    "wikipediaTitle": "A_Rainbow_in_Curved_Air",
+    "canonicalTitle": "A Rainbow in Curved Air",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-riley-rainbow",
+        "nodeTitle": "A Rainbow in Curved Air"
+      }
+    ]
+  },
+  "Q2842051": {
+    "wikidataId": "Q2842051",
+    "wikipediaTitle": "Ambient_2:_The_Plateaux_of_Mirror",
+    "canonicalTitle": "Ambient 2: The Plateaux of Mirror",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-budd-plateaux",
+        "nodeTitle": "Ambient 2: The Plateaux of Mirror"
+      }
+    ]
+  },
+  "Q2842048": {
+    "wikidataId": "Q2842048",
+    "wikipediaTitle": "Ambient_3:_Day_of_Radiance",
+    "canonicalTitle": "Ambient 3: Day of Radiance",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-laraaji-day-of-radiance",
+        "nodeTitle": "Ambient 3: Day of Radiance"
+      }
+    ]
+  },
+  "Q2823426": {
+    "wikidataId": "Q2823426",
+    "wikipediaTitle": "Acousmonium",
+    "canonicalTitle": "Acousmonium",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-acousmonium",
+        "nodeTitle": "Acousmonium"
+      }
+    ]
+  },
+  "Q2847710": {
+    "wikidataId": "Q2847710",
+    "wikipediaTitle": "André-Michel_Guerry",
+    "canonicalTitle": "André-Michel Guerry",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-andre-michel-guerry",
+        "nodeTitle": "André-Michel Guerry"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q28100000-Q28199999.json
+++ b/public/cross-scene-index/by-wikidata/Q28100000-Q28199999.json
@@ -1,0 +1,15 @@
+{
+  "Q28153721": {
+    "wikidataId": "Q28153721",
+    "wikipediaTitle": "Deep_Learning_(book)",
+    "canonicalTitle": "Deep Learning Textbook",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-deep-learning-book",
+        "nodeTitle": "Deep Learning Textbook"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q28700000-Q28799999.json
+++ b/public/cross-scene-index/by-wikidata/Q28700000-Q28799999.json
@@ -1,0 +1,28 @@
+{
+  "Q28738478": {
+    "wikidataId": "Q28738478",
+    "wikipediaTitle": "Ilya_Sutskever",
+    "canonicalTitle": "Ilya Sutskever",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-ilya-sutskever",
+        "nodeTitle": "Ilya Sutskever"
+      }
+    ]
+  },
+  "Q28733656": {
+    "wikidataId": "Q28733656",
+    "wikipediaTitle": "Greg_Brockman",
+    "canonicalTitle": "Greg Brockman",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-greg-brockman",
+        "nodeTitle": "Greg Brockman"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q2900000-Q2999999.json
+++ b/public/cross-scene-index/by-wikidata/Q2900000-Q2999999.json
@@ -1,0 +1,15 @@
+{
+  "Q2980401": {
+    "wikidataId": "Q2980401",
+    "wikipediaTitle": "Cluster_&_Eno",
+    "canonicalTitle": "Cluster & Eno",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-cluster-eno",
+        "nodeTitle": "Cluster & Eno"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q29000000-Q29099999.json
+++ b/public/cross-scene-index/by-wikidata/Q29000000-Q29099999.json
@@ -1,0 +1,28 @@
+{
+  "Q29039302": {
+    "wikidataId": "Q29039302",
+    "wikipediaTitle": "Doina_Precup",
+    "canonicalTitle": "Doina Precup",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-doina-precup",
+        "nodeTitle": "Doina Precup"
+      }
+    ]
+  },
+  "Q29056997": {
+    "wikidataId": "Q29056997",
+    "wikipediaTitle": "Mila_(research_institute)",
+    "canonicalTitle": "MILA",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-mila",
+        "nodeTitle": "MILA"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q300000-Q399999.json
+++ b/public/cross-scene-index/by-wikidata/Q300000-Q399999.json
@@ -1,0 +1,891 @@
+{
+  "Q317521": {
+    "wikidataId": "Q317521",
+    "wikipediaTitle": "Elon_Musk",
+    "canonicalTitle": "Elon Musk",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-elon-musk",
+        "nodeTitle": "Elon Musk"
+      }
+    ]
+  },
+  "Q392189": {
+    "wikidataId": "Q392189",
+    "wikipediaTitle": "Université_de_Montréal",
+    "canonicalTitle": "Université de Montréal",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-umontreal",
+        "nodeTitle": "Université de Montréal"
+      }
+    ]
+  },
+  "Q316427": {
+    "wikidataId": "Q316427",
+    "wikipediaTitle": "Morton_Feldman",
+    "canonicalTitle": "Morton Feldman",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-morton-feldman",
+        "nodeTitle": "Morton Feldman"
+      }
+    ]
+  },
+  "Q315744": {
+    "wikidataId": "Q315744",
+    "wikipediaTitle": "Pierre_Schaeffer",
+    "canonicalTitle": "Pierre Schaeffer",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-pierre-schaeffer",
+        "nodeTitle": "Pierre Schaeffer"
+      }
+    ]
+  },
+  "Q333265": {
+    "wikidataId": "Q333265",
+    "wikipediaTitle": "Léon_Theremin",
+    "canonicalTitle": "Leon Theremin",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-leon-theremin",
+        "nodeTitle": "Leon Theremin"
+      }
+    ]
+  },
+  "Q364835": {
+    "wikidataId": "Q364835",
+    "wikipediaTitle": "Tristram_Cary",
+    "canonicalTitle": "Tristram Cary",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-tristram-cary",
+        "nodeTitle": "Tristram Cary"
+      }
+    ]
+  },
+  "Q391625": {
+    "wikidataId": "Q391625",
+    "wikipediaTitle": "Suzanne_Ciani",
+    "canonicalTitle": "Suzanne Ciani",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-suzanne-ciani",
+        "nodeTitle": "Suzanne Ciani"
+      }
+    ]
+  },
+  "Q372438": {
+    "wikidataId": "Q372438",
+    "wikipediaTitle": "Ralf_Hütter",
+    "canonicalTitle": "Ralf Hütter",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-ralf-hutter",
+        "nodeTitle": "Ralf Hütter"
+      }
+    ]
+  },
+  "Q313639": {
+    "wikidataId": "Q313639",
+    "wikipediaTitle": "Michael_Nyman",
+    "canonicalTitle": "Michael Nyman",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-michael-nyman",
+        "nodeTitle": "Michael Nyman"
+      }
+    ]
+  },
+  "Q365243": {
+    "wikidataId": "Q365243",
+    "wikipediaTitle": "Terry_Riley",
+    "canonicalTitle": "Terry Riley",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-terry-riley",
+        "nodeTitle": "Terry Riley"
+      }
+    ]
+  },
+  "Q369916": {
+    "wikidataId": "Q369916",
+    "wikipediaTitle": "Charlemagne_Palestine",
+    "canonicalTitle": "Charlemagne Palestine",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-charlemagne-palestine",
+        "nodeTitle": "Charlemagne Palestine"
+      }
+    ]
+  },
+  "Q315417": {
+    "wikidataId": "Q315417",
+    "wikipediaTitle": "Lee_\"Scratch\"_Perry",
+    "canonicalTitle": "Lee \"Scratch\" Perry",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-lee-scratch-perry",
+        "nodeTitle": "Lee \"Scratch\" Perry"
+      }
+    ]
+  },
+  "Q345494": {
+    "wikidataId": "Q345494",
+    "wikipediaTitle": "Ryuichi_Sakamoto",
+    "canonicalTitle": "Ryuichi Sakamoto",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-ryuichi-sakamoto",
+        "nodeTitle": "Ryuichi Sakamoto"
+      }
+    ]
+  },
+  "Q334648": {
+    "wikidataId": "Q334648",
+    "wikipediaTitle": "Roxy_Music",
+    "canonicalTitle": "Roxy Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-roxy-music",
+        "nodeTitle": "Roxy Music"
+      }
+    ]
+  },
+  "Q320592": {
+    "wikidataId": "Q320592",
+    "wikipediaTitle": "Krautrock",
+    "canonicalTitle": "Krautrock",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-krautrock",
+        "nodeTitle": "Krautrock"
+      }
+    ]
+  },
+  "Q355395": {
+    "wikidataId": "Q355395",
+    "wikipediaTitle": "Chill_Out_(The_KLF_album)",
+    "canonicalTitle": "Chill Out",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-klf-chill-out",
+        "nodeTitle": "Chill Out"
+      }
+    ]
+  },
+  "Q332616": {
+    "wikidataId": "Q332616",
+    "wikipediaTitle": "Jacques_Lefèvre_d'Étaples",
+    "canonicalTitle": "Jacques Lefèvre d'Étaples",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-jacques-lefevre-detaples",
+        "nodeTitle": "Jacques Lefèvre d'Étaples"
+      }
+    ]
+  },
+  "Q328741": {
+    "wikidataId": "Q328741",
+    "wikipediaTitle": "Three_Books_of_Occult_Philosophy",
+    "canonicalTitle": "De Occulta Philosophia libri tres",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-occulta-philosophia",
+        "nodeTitle": "De Occulta Philosophia libri tres"
+      }
+    ]
+  },
+  "Q314252": {
+    "wikidataId": "Q314252",
+    "wikipediaTitle": "Gregory_Bateson",
+    "canonicalTitle": "Gregory Bateson",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-gregory-bateson",
+        "nodeTitle": "Gregory Bateson"
+      }
+    ]
+  },
+  "Q382207": {
+    "wikidataId": "Q382207",
+    "wikipediaTitle": "John_Tukey",
+    "canonicalTitle": "John Tukey",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-john-tukey",
+        "nodeTitle": "John Tukey"
+      }
+    ]
+  },
+  "Q316022": {
+    "wikidataId": "Q316022",
+    "wikipediaTitle": "Harry_Nyquist",
+    "canonicalTitle": "Harry Nyquist",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-harry-nyquist",
+        "nodeTitle": "Harry Nyquist"
+      }
+    ]
+  },
+  "Q328632": {
+    "wikidataId": "Q328632",
+    "wikipediaTitle": "Julian_Bigelow",
+    "canonicalTitle": "Julian Bigelow",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-julian-bigelow",
+        "nodeTitle": "Julian Bigelow"
+      }
+    ]
+  },
+  "Q370461": {
+    "wikidataId": "Q370461",
+    "wikipediaTitle": "Gordon_Pask",
+    "canonicalTitle": "Gordon Pask",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-gordon-pask",
+        "nodeTitle": "Gordon Pask"
+      }
+    ]
+  },
+  "Q376452": {
+    "wikidataId": "Q376452",
+    "wikipediaTitle": "Humberto_Maturana",
+    "canonicalTitle": "Humberto Maturana",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-humberto-maturana",
+        "nodeTitle": "Humberto Maturana"
+      }
+    ]
+  },
+  "Q335027": {
+    "wikidataId": "Q335027",
+    "wikipediaTitle": "Seymour_Papert",
+    "canonicalTitle": "Seymour Papert",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-seymour-papert",
+        "nodeTitle": "Seymour Papert"
+      }
+    ]
+  },
+  "Q379848": {
+    "wikidataId": "Q379848",
+    "wikipediaTitle": "Los_Alamos_National_Laboratory",
+    "canonicalTitle": "Los Alamos National Laboratory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-los-alamos",
+        "nodeTitle": "Los Alamos National Laboratory"
+      }
+    ]
+  },
+  "Q358532": {
+    "wikidataId": "Q358532",
+    "wikipediaTitle": "Second-order_cybernetics",
+    "canonicalTitle": "Second-Order Cybernetics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-second-order-cybernetics",
+        "nodeTitle": "Second-Order Cybernetics"
+      }
+    ]
+  },
+  "Q316367": {
+    "wikidataId": "Q316367",
+    "wikipediaTitle": "Francis_Hutcheson_(philosopher)",
+    "canonicalTitle": "Francis Hutcheson",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-hutcheson",
+        "nodeTitle": "Francis Hutcheson"
+      }
+    ]
+  },
+  "Q316347": {
+    "wikidataId": "Q316347",
+    "wikipediaTitle": "Thomas_Reid",
+    "canonicalTitle": "Thomas Reid",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-thomas-reid",
+        "nodeTitle": "Thomas Reid"
+      }
+    ]
+  },
+  "Q335112": {
+    "wikidataId": "Q335112",
+    "wikipediaTitle": "Anthony_Ashley-Cooper,_3rd_Earl_of_Shaftesbury",
+    "canonicalTitle": "Anthony Ashley Cooper, 3rd Earl of Shaftesbury",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-shaftesbury",
+        "nodeTitle": "Anthony Ashley Cooper, 3rd Earl of Shaftesbury"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-characteristics",
+        "nodeTitle": "Characteristics of Men, Manners, Opinions, Times"
+      }
+    ]
+  },
+  "Q379912": {
+    "wikidataId": "Q379912",
+    "wikipediaTitle": "Bernard_Mandeville",
+    "canonicalTitle": "Bernard Mandeville",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-mandeville",
+        "nodeTitle": "Bernard Mandeville"
+      }
+    ]
+  },
+  "Q329464": {
+    "wikidataId": "Q329464",
+    "wikipediaTitle": "Prussian_Academy_of_Sciences",
+    "canonicalTitle": "Berlin Academy",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-berlin-academy",
+        "nodeTitle": "Berlin Academy"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-berlin-academy",
+        "nodeTitle": "Berlin Academy (Institution)"
+      }
+    ]
+  },
+  "Q313587": {
+    "wikidataId": "Q313587",
+    "wikipediaTitle": "Piero_di_Cosimo_de'_Medici",
+    "canonicalTitle": "Piero di Cosimo de' Medici",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-piero-di-cosimo-de-medici",
+        "nodeTitle": "Piero di Cosimo de' Medici"
+      }
+    ]
+  },
+  "Q316650": {
+    "wikidataId": "Q316650",
+    "wikipediaTitle": "Giuliano_de'_Medici",
+    "canonicalTitle": "Giuliano de' Medici",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-giuliano-de-medici",
+        "nodeTitle": "Giuliano de' Medici"
+      }
+    ]
+  },
+  "Q310405": {
+    "wikidataId": "Q310405",
+    "wikipediaTitle": "Piero_di_Lorenzo_de'_Medici",
+    "canonicalTitle": "Piero de' Medici",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-piero-de-medici-the-unfortunate",
+        "nodeTitle": "Piero de' Medici"
+      }
+    ]
+  },
+  "Q310318": {
+    "wikidataId": "Q310318",
+    "wikipediaTitle": "Gemistus_Pletho",
+    "canonicalTitle": "Gemistus Pletho",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-gemistus-pletho",
+        "nodeTitle": "Gemistus Pletho"
+      }
+    ]
+  },
+  "Q352619": {
+    "wikidataId": "Q352619",
+    "wikipediaTitle": "Basilios_Bessarion",
+    "canonicalTitle": "Cardinal Bessarion",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-bessarion",
+        "nodeTitle": "Cardinal Bessarion"
+      }
+    ]
+  },
+  "Q380417": {
+    "wikidataId": "Q380417",
+    "wikipediaTitle": "Manuel_Chrysoloras",
+    "canonicalTitle": "Manuel Chrysoloras",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-manuel-chrysoloras",
+        "nodeTitle": "Manuel Chrysoloras"
+      }
+    ]
+  },
+  "Q315466": {
+    "wikidataId": "Q315466",
+    "wikipediaTitle": "Heinrich_Cornelius_Agrippa",
+    "canonicalTitle": "Heinrich Cornelius Agrippa",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-cornelius-agrippa",
+        "nodeTitle": "Heinrich Cornelius Agrippa"
+      }
+    ]
+  },
+  "Q364945": {
+    "wikidataId": "Q364945",
+    "wikipediaTitle": "Francesco_Patrizi_(philosopher)",
+    "canonicalTitle": "Francesco Patrizi",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-francesco-patrizi",
+        "nodeTitle": "Francesco Patrizi"
+      }
+    ]
+  },
+  "Q314981": {
+    "wikidataId": "Q314981",
+    "wikipediaTitle": "Theodore_Beza",
+    "canonicalTitle": "Theodore Beza",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-theodore-beza",
+        "nodeTitle": "Theodore Beza"
+      }
+    ]
+  },
+  "Q318622": {
+    "wikidataId": "Q318622",
+    "wikipediaTitle": "Martin_Bucer",
+    "canonicalTitle": "Martin Bucer",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-martin-bucer",
+        "nodeTitle": "Martin Bucer"
+      }
+    ]
+  },
+  "Q380961": {
+    "wikidataId": "Q380961",
+    "wikipediaTitle": "John_Foxe",
+    "canonicalTitle": "John Foxe",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-foxe",
+        "nodeTitle": "John Foxe"
+      }
+    ]
+  },
+  "Q335171": {
+    "wikidataId": "Q335171",
+    "wikipediaTitle": "Menno_Simons",
+    "canonicalTitle": "Menno Simons",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-menno-simons",
+        "nodeTitle": "Menno Simons"
+      }
+    ]
+  },
+  "Q388199": {
+    "wikidataId": "Q388199",
+    "wikipediaTitle": "Antoine_Froment",
+    "canonicalTitle": "Antoine Froment",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-antoine-froment",
+        "nodeTitle": "Antoine Froment"
+      }
+    ]
+  },
+  "Q371558": {
+    "wikidataId": "Q371558",
+    "wikipediaTitle": "Institutes_of_the_Christian_Religion",
+    "canonicalTitle": "Institutes of the Christian Religion",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-institutes",
+        "nodeTitle": "Institutes of the Christian Religion"
+      }
+    ]
+  },
+  "Q319300": {
+    "wikidataId": "Q319300",
+    "wikipediaTitle": "Tetrapolitan_Confession",
+    "canonicalTitle": "Tetrapolitan Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-tetrapolitan-confession",
+        "nodeTitle": "Tetrapolitan Confession"
+      }
+    ]
+  },
+  "Q327152": {
+    "wikidataId": "Q327152",
+    "wikipediaTitle": "Heidelberg_Catechism",
+    "canonicalTitle": "Heidelberg Catechism",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-heidelberg-catechism",
+        "nodeTitle": "Heidelberg Catechism"
+      }
+    ]
+  },
+  "Q372608": {
+    "wikidataId": "Q372608",
+    "wikipediaTitle": "University_of_Basel",
+    "canonicalTitle": "University of Basel",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-basel-university",
+        "nodeTitle": "University of Basel"
+      }
+    ]
+  },
+  "Q318418": {
+    "wikidataId": "Q318418",
+    "wikipediaTitle": "Vilvoorde",
+    "canonicalTitle": "Vilvoorde",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-vilvoorde",
+        "nodeTitle": "Vilvoorde"
+      }
+    ]
+  },
+  "Q314488": {
+    "wikidataId": "Q314488",
+    "wikipediaTitle": "Leonardo_Bruni",
+    "canonicalTitle": "Leonardo Bruni",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-leonardo-bruni",
+        "nodeTitle": "Leonardo Bruni"
+      }
+    ]
+  },
+  "Q318254": {
+    "wikidataId": "Q318254",
+    "wikipediaTitle": "Poggio_Bracciolini",
+    "canonicalTitle": "Poggio Bracciolini",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-poggio-bracciolini",
+        "nodeTitle": "Poggio Bracciolini"
+      }
+    ]
+  },
+  "Q334188": {
+    "wikidataId": "Q334188",
+    "wikipediaTitle": "Pietro_Bembo",
+    "canonicalTitle": "Pietro Bembo",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-pietro-bembo",
+        "nodeTitle": "Pietro Bembo"
+      }
+    ]
+  },
+  "Q318787": {
+    "wikidataId": "Q318787",
+    "wikipediaTitle": "Pietro_Pomponazzi",
+    "canonicalTitle": "Pietro Pomponazzi",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-pietro-pomponazzi",
+        "nodeTitle": "Pietro Pomponazzi"
+      }
+    ]
+  },
+  "Q316357": {
+    "wikidataId": "Q316357",
+    "wikipediaTitle": "Juan_Luis_Vives",
+    "canonicalTitle": "Juan Luis Vives",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-juan-luis-vives",
+        "nodeTitle": "Juan Luis Vives"
+      }
+    ]
+  },
+  "Q353668": {
+    "wikidataId": "Q353668",
+    "wikipediaTitle": "Guillaume_Budé",
+    "canonicalTitle": "Guillaume Budé",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-guillaume-bude",
+        "nodeTitle": "Guillaume Budé"
+      }
+    ]
+  },
+  "Q380804": {
+    "wikidataId": "Q380804",
+    "wikipediaTitle": "Antonio_de_Nebrija",
+    "canonicalTitle": "Antonio de Nebrija",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-antonio-nebrija",
+        "nodeTitle": "Antonio de Nebrija"
+      }
+    ]
+  },
+  "Q342392": {
+    "wikidataId": "Q342392",
+    "wikipediaTitle": "Francisco_Jiménez_de_Cisneros",
+    "canonicalTitle": "Cardinal Francisco Jiménez de Cisneros",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-cardinal-cisneros",
+        "nodeTitle": "Cardinal Francisco Jiménez de Cisneros"
+      }
+    ]
+  },
+  "Q346677": {
+    "wikidataId": "Q346677",
+    "wikipediaTitle": "Adagia",
+    "canonicalTitle": "Adagiorum chiliades (Adages)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-adages",
+        "nodeTitle": "Adagiorum chiliades (Adages)"
+      }
+    ]
+  },
+  "Q368346": {
+    "wikidataId": "Q368346",
+    "wikipediaTitle": "Villa_Medici_at_Careggi",
+    "canonicalTitle": "Medici Villa at Careggi",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-villa-careggi",
+        "nodeTitle": "Medici Villa at Careggi"
+      }
+    ]
+  },
+  "Q385092": {
+    "wikidataId": "Q385092",
+    "wikipediaTitle": "Salomon_de_Caus",
+    "canonicalTitle": "Salomon de Caus",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-salomon-de-caus",
+        "nodeTitle": "Salomon de Caus"
+      }
+    ]
+  },
+  "Q328441": {
+    "wikidataId": "Q328441",
+    "wikipediaTitle": "Giovanni_Alfonso_Borelli",
+    "canonicalTitle": "Giovanni Alfonso Borelli",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-giovanni-borelli",
+        "nodeTitle": "Giovanni Alfonso Borelli"
+      }
+    ]
+  },
+  "Q333527": {
+    "wikidataId": "Q333527",
+    "wikipediaTitle": "Philip_Wharton,_1st_Duke_of_Wharton",
+    "canonicalTitle": "Philip Wharton, 1st Duke of Wharton",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-philip-wharton",
+        "nodeTitle": "Philip Wharton, 1st Duke of Wharton"
+      }
+    ]
+  },
+  "Q318630": {
+    "wikidataId": "Q318630",
+    "wikipediaTitle": "Thomas_Bayes",
+    "canonicalTitle": "Thomas Bayes",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-thomas-bayes",
+        "nodeTitle": "Thomas Bayes"
+      }
+    ]
+  },
+  "Q310551": {
+    "wikidataId": "Q310551",
+    "wikipediaTitle": "Abraham_de_Moivre",
+    "canonicalTitle": "Abraham de Moivre",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-abraham-de-moivre",
+        "nodeTitle": "Abraham de Moivre"
+      }
+    ]
+  },
+  "Q317584": {
+    "wikidataId": "Q317584",
+    "wikipediaTitle": "William_Sealy_Gosset",
+    "canonicalTitle": "William Sealy Gosset",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-william-sealy-gosset",
+        "nodeTitle": "William Sealy Gosset"
+      },
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-william-farr",
+        "nodeTitle": "William Farr"
+      }
+    ]
+  },
+  "Q355607": {
+    "wikidataId": "Q355607",
+    "wikipediaTitle": "Francis_Ysidro_Edgeworth",
+    "canonicalTitle": "Francis Ysidro Edgeworth",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-francis-ysidro-edgeworth",
+        "nodeTitle": "Francis Ysidro Edgeworth"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q3000000-Q3099999.json
+++ b/public/cross-scene-index/by-wikidata/Q3000000-Q3099999.json
@@ -1,0 +1,67 @@
+{
+  "Q3036050": {
+    "wikidataId": "Q3036050",
+    "wikipediaTitle": "Donald_MacCrimmon_MacKay",
+    "canonicalTitle": "Donald MacKay",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-donald-mackay",
+        "nodeTitle": "Donald MacKay"
+      }
+    ]
+  },
+  "Q3030210": {
+    "wikidataId": "Q3030210",
+    "wikipediaTitle": "Preliminary_Discourse_to_the_Encyclopedia_of_Diderot",
+    "canonicalTitle": "Preliminary Discourse to the Encyclopedia",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-preliminary-discourse",
+        "nodeTitle": "Preliminary Discourse to the Encyclopedia"
+      }
+    ]
+  },
+  "Q3030191": {
+    "wikidataId": "Q3030191",
+    "wikipediaTitle": "Discourse_on_Voluntary_Servitude",
+    "canonicalTitle": "Discours de la servitude volontaire",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-servitude-volontaire",
+        "nodeTitle": "Discours de la servitude volontaire"
+      }
+    ]
+  },
+  "Q3020472": {
+    "wikidataId": "Q3020472",
+    "wikipediaTitle": "De_pictura",
+    "canonicalTitle": "De pictura",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-pictura",
+        "nodeTitle": "De pictura"
+      }
+    ]
+  },
+  "Q3062451": {
+    "wikidataId": "Q3062451",
+    "wikipediaTitle": "John_Montagu,_2nd_Duke_of_Montagu",
+    "canonicalTitle": "John Montagu, 2nd Duke of Montagu",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-john-montagu",
+        "nodeTitle": "John Montagu, 2nd Duke of Montagu"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q30500000-Q30599999.json
+++ b/public/cross-scene-index/by-wikidata/Q30500000-Q30599999.json
@@ -1,0 +1,15 @@
+{
+  "Q30593017": {
+    "wikidataId": "Q30593017",
+    "wikipediaTitle": "Mustafa_Suleyman",
+    "canonicalTitle": "Mustafa Suleyman",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-mustafa-suleyman",
+        "nodeTitle": "Mustafa Suleyman"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q3100000-Q3199999.json
+++ b/public/cross-scene-index/by-wikidata/Q3100000-Q3199999.json
@@ -1,0 +1,67 @@
+{
+  "Q3155783": {
+    "wikidataId": "Q3155783",
+    "wikipediaTitle": "It's_Gonna_Rain",
+    "canonicalTitle": "It's Gonna Rain",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-reich-its-gonna-rain",
+        "nodeTitle": "It's Gonna Rain"
+      }
+    ]
+  },
+  "Q3153674": {
+    "wikidataId": "Q3153674",
+    "wikipediaTitle": "Intonarumori",
+    "canonicalTitle": "Intonarumori",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-intonarumori",
+        "nodeTitle": "Intonarumori"
+      }
+    ]
+  },
+  "Q3123640": {
+    "wikidataId": "Q3123640",
+    "wikipediaTitle": "Ray_Solomonoff",
+    "canonicalTitle": "Ray Solomonoff",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ray-solomonoff",
+        "nodeTitle": "Ray Solomonoff"
+      }
+    ]
+  },
+  "Q3138032": {
+    "wikidataId": "Q3138032",
+    "wikipediaTitle": "Histoire_Naturelle",
+    "canonicalTitle": "Histoire naturelle",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-histoire-naturelle",
+        "nodeTitle": "Histoire naturelle"
+      }
+    ]
+  },
+  "Q3160845": {
+    "wikidataId": "Q3160845",
+    "wikipediaTitle": "James_Anderson_(Freemason)",
+    "canonicalTitle": "Rev. James Anderson",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-james-anderson",
+        "nodeTitle": "Rev. James Anderson"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q3200000-Q3299999.json
+++ b/public/cross-scene-index/by-wikidata/Q3200000-Q3299999.json
@@ -1,0 +1,54 @@
+{
+  "Q3282479": {
+    "wikidataId": "Q3282479",
+    "wikipediaTitle": "Apollo:_Atmospheres_&_Soundtracks",
+    "canonicalTitle": "Apollo: Atmospheres & Soundtracks",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-apollo",
+        "nodeTitle": "Apollo: Atmospheres & Soundtracks"
+      }
+    ]
+  },
+  "Q3283363": {
+    "wikidataId": "Q3283363",
+    "wikipediaTitle": "Switched-On_Bach",
+    "canonicalTitle": "Switched-On Bach",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-carlos-switched-on",
+        "nodeTitle": "Switched-On Bach"
+      }
+    ]
+  },
+  "Q3203583": {
+    "wikidataId": "Q3203583",
+    "wikipediaTitle": "Man_a_Machine",
+    "canonicalTitle": "Man a Machine",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-homme-machine",
+        "nodeTitle": "Man a Machine"
+      }
+    ]
+  },
+  "Q3267928": {
+    "wikidataId": "Q3267928",
+    "wikipediaTitle": "A_Treatise_Concerning_the_Principles_of_Human_Knowledge",
+    "canonicalTitle": "A Treatise Concerning the Principles of Human Knowledge",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-principles-human-knowledge",
+        "nodeTitle": "A Treatise Concerning the Principles of Human Knowledge"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q3300000-Q3399999.json
+++ b/public/cross-scene-index/by-wikidata/Q3300000-Q3399999.json
@@ -1,0 +1,28 @@
+{
+  "Q3389945": {
+    "wikidataId": "Q3389945",
+    "wikipediaTitle": "Obscure_Records",
+    "canonicalTitle": "Obscure Records",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-obscure-records",
+        "nodeTitle": "Obscure Records"
+      }
+    ]
+  },
+  "Q3397209": {
+    "wikidataId": "Q3397209",
+    "wikipediaTitle": "Thomas_Vaughan_(philosopher)",
+    "canonicalTitle": "Thomas Vaughan",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-thomas-vaughan",
+        "nodeTitle": "Thomas Vaughan"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q3400000-Q3499999.json
+++ b/public/cross-scene-index/by-wikidata/Q3400000-Q3499999.json
@@ -1,0 +1,47 @@
+{
+  "Q3471440": {
+    "wikidataId": "Q3471440",
+    "wikipediaTitle": "San_Francisco_Tape_Music_Center",
+    "canonicalTitle": "San Francisco Tape Music Center",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-sftmc",
+        "nodeTitle": "San Francisco Tape Music Center"
+      },
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-sftmc-org",
+        "nodeTitle": "San Francisco Tape Music Center"
+      }
+    ]
+  },
+  "Q3496301": {
+    "wikidataId": "Q3496301",
+    "wikipediaTitle": "Theatre_of_Eternal_Music",
+    "canonicalTitle": "Theatre of Eternal Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-theatre-eternal-music",
+        "nodeTitle": "Theatre of Eternal Music"
+      }
+    ]
+  },
+  "Q3420069": {
+    "wikidataId": "Q3420069",
+    "wikipediaTitle": "Ratio_Club",
+    "canonicalTitle": "Ratio Club",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-ratio-club",
+        "nodeTitle": "Ratio Club"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q3500000-Q3599999.json
+++ b/public/cross-scene-index/by-wikidata/Q3500000-Q3599999.json
@@ -1,0 +1,106 @@
+{
+  "Q3507883": {
+    "wikidataId": "Q3507883",
+    "wikipediaTitle": "Symphonie_pour_un_homme_seul",
+    "canonicalTitle": "Symphonie pour un homme seul",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-schaeffer-henry-symphonie",
+        "nodeTitle": "Symphonie pour un homme seul"
+      }
+    ]
+  },
+  "Q3523344": {
+    "wikidataId": "Q3523344",
+    "wikipediaTitle": "The_Well-Tuned_Piano",
+    "canonicalTitle": "The Well-Tuned Piano",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-young-well-tuned-piano",
+        "nodeTitle": "The Well-Tuned Piano"
+      }
+    ]
+  },
+  "Q3522197": {
+    "wikidataId": "Q3522197",
+    "wikipediaTitle": "The_Pearl_(album)",
+    "canonicalTitle": "The Pearl",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-budd-pearl",
+        "nodeTitle": "The Pearl"
+      }
+    ]
+  },
+  "Q3522191": {
+    "wikidataId": "Q3522191",
+    "wikipediaTitle": "The_Pavilion_of_Dreams",
+    "canonicalTitle": "The Pavilion of Dreams",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-budd-pavilion",
+        "nodeTitle": "The Pavilion of Dreams"
+      }
+    ]
+  },
+  "Q3532550": {
+    "wikidataId": "Q3532550",
+    "wikipediaTitle": "Turtle_(robot)",
+    "canonicalTitle": "Tortoise Robots (Elmer and Elsie)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-tortoise-robots-walter",
+        "nodeTitle": "Tortoise Robots (Elmer and Elsie)"
+      }
+    ]
+  },
+  "Q3592308": {
+    "wikidataId": "Q3592308",
+    "wikipediaTitle": "Étienne_Noël_Damilaville",
+    "canonicalTitle": "Étienne Noël Damilaville",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-damilaville",
+        "nodeTitle": "Étienne Noël Damilaville"
+      }
+    ]
+  },
+  "Q3530141": {
+    "wikidataId": "Q3530141",
+    "wikipediaTitle": "Tobias_Hess",
+    "canonicalTitle": "Tobias Hess",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-tobias-hess",
+        "nodeTitle": "Tobias Hess"
+      }
+    ]
+  },
+  "Q3527157": {
+    "wikidataId": "Q3527157",
+    "wikipediaTitle": "Théorie_analytique_des_probabilités",
+    "canonicalTitle": "Théorie analytique des probabilités",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-theorie-analytique-des-probabilites",
+        "nodeTitle": "Théorie analytique des probabilités"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q35000000-Q35099999.json
+++ b/public/cross-scene-index/by-wikidata/Q35000000-Q35099999.json
@@ -1,0 +1,15 @@
+{
+  "Q35064943": {
+    "wikidataId": "Q35064943",
+    "wikipediaTitle": "Oriol_Vinyals",
+    "canonicalTitle": "Oriol Vinyals",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-oriol-vinyals",
+        "nodeTitle": "Oriol Vinyals"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q3600000-Q3699999.json
+++ b/public/cross-scene-index/by-wikidata/Q3600000-Q3699999.json
@@ -1,0 +1,67 @@
+{
+  "Q3606120": {
+    "wikidataId": "Q3606120",
+    "wikipediaTitle": "Aesthetica",
+    "canonicalTitle": "Aesthetica",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-aesthetica",
+        "nodeTitle": "Aesthetica"
+      }
+    ]
+  },
+  "Q3643696": {
+    "wikidataId": "Q3643696",
+    "wikipediaTitle": "Fama_Fraternitatis",
+    "canonicalTitle": "Fama Fraternitatis",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-fama-fraternitatis",
+        "nodeTitle": "Fama Fraternitatis"
+      }
+    ]
+  },
+  "Q3643674": {
+    "wikidataId": "Q3643674",
+    "wikipediaTitle": "Confessio_Fraternitatis",
+    "canonicalTitle": "Confessio Fraternitatis",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-confessio-fraternitatis",
+        "nodeTitle": "Confessio Fraternitatis"
+      }
+    ]
+  },
+  "Q3627850": {
+    "wikidataId": "Q3627850",
+    "wikipediaTitle": "Atalanta_Fugiens",
+    "canonicalTitle": "Atalanta Fugiens",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-atalanta-fugiens",
+        "nodeTitle": "Atalanta Fugiens"
+      }
+    ]
+  },
+  "Q3618535": {
+    "wikidataId": "Q3618535",
+    "wikipediaTitle": "Anthony_Sayer",
+    "canonicalTitle": "Anthony Sayer",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-anthony-sayer",
+        "nodeTitle": "Anthony Sayer"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q3700000-Q3799999.json
+++ b/public/cross-scene-index/by-wikidata/Q3700000-Q3799999.json
@@ -1,0 +1,54 @@
+{
+  "Q3717397": {
+    "wikidataId": "Q3717397",
+    "wikipediaTitle": "EMS_Synthi_AKS",
+    "canonicalTitle": "Synthi AKS",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-ems-synthi-aks",
+        "nodeTitle": "Synthi AKS"
+      }
+    ]
+  },
+  "Q3765911": {
+    "wikidataId": "Q3765911",
+    "wikipediaTitle": "Girolamo_Benivieni",
+    "canonicalTitle": "Girolamo Benivieni",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-girolamo-benivieni",
+        "nodeTitle": "Girolamo Benivieni"
+      }
+    ]
+  },
+  "Q3749759": {
+    "wikidataId": "Q3749759",
+    "wikipediaTitle": "Francesco_Cattani_da_Diacceto",
+    "canonicalTitle": "Francesco Cattani da Diacceto",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-francesco-diacceto",
+        "nodeTitle": "Francesco Cattani da Diacceto"
+      }
+    ]
+  },
+  "Q3759459": {
+    "wikidataId": "Q3759459",
+    "wikipediaTitle": "Genealogia_Deorum_Gentilium",
+    "canonicalTitle": "Genealogia deorum gentilium",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-genealogia-deorum",
+        "nodeTitle": "Genealogia deorum gentilium"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q39000000-Q39099999.json
+++ b/public/cross-scene-index/by-wikidata/Q39000000-Q39099999.json
@@ -1,0 +1,15 @@
+{
+  "Q39076395": {
+    "wikidataId": "Q39076395",
+    "wikipediaTitle": "Vector_Institute",
+    "canonicalTitle": "Vector Institute",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-vector-institute",
+        "nodeTitle": "Vector Institute"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q400000-Q499999.json
+++ b/public/cross-scene-index/by-wikidata/Q400000-Q499999.json
@@ -1,0 +1,508 @@
+{
+  "Q450599": {
+    "wikidataId": "Q450599",
+    "wikipediaTitle": "Daphne_Koller",
+    "canonicalTitle": "Daphne Koller",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-daphne-koller",
+        "nodeTitle": "Daphne Koller"
+      }
+    ]
+  },
+  "Q486860": {
+    "wikidataId": "Q486860",
+    "wikipediaTitle": "Mountain_View,_California",
+    "canonicalTitle": "Mountain View, California",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-mountain-view",
+        "nodeTitle": "Mountain View, California"
+      }
+    ]
+  },
+  "Q456157": {
+    "wikidataId": "Q456157",
+    "wikipediaTitle": "Amazon_Web_Services",
+    "canonicalTitle": "Amazon AI / AWS",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-amazon-ai",
+        "nodeTitle": "Amazon AI / AWS"
+      }
+    ]
+  },
+  "Q434916": {
+    "wikidataId": "Q434916",
+    "wikipediaTitle": "Luigi_Russolo",
+    "canonicalTitle": "Luigi Russolo",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-luigi-russolo",
+        "nodeTitle": "Luigi Russolo"
+      }
+    ]
+  },
+  "Q432822": {
+    "wikidataId": "Q432822",
+    "wikipediaTitle": "La_Monte_Young",
+    "canonicalTitle": "La Monte Young",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-la-monte-young",
+        "nodeTitle": "La Monte Young"
+      }
+    ]
+  },
+  "Q444857": {
+    "wikidataId": "Q444857",
+    "wikipediaTitle": "Pauline_Oliveros",
+    "canonicalTitle": "Pauline Oliveros",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-pauline-oliveros",
+        "nodeTitle": "Pauline Oliveros"
+      }
+    ]
+  },
+  "Q481477": {
+    "wikidataId": "Q481477",
+    "wikipediaTitle": "Tony_Conrad",
+    "canonicalTitle": "Tony Conrad",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-tony-conrad",
+        "nodeTitle": "Tony Conrad"
+      }
+    ]
+  },
+  "Q427429": {
+    "wikidataId": "Q427429",
+    "wikipediaTitle": "Manuel_Göttsching",
+    "canonicalTitle": "Manuel Göttsching",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-manuel-gottsching",
+        "nodeTitle": "Manuel Göttsching"
+      }
+    ]
+  },
+  "Q435744": {
+    "wikidataId": "Q435744",
+    "wikipediaTitle": "Florian_Schneider",
+    "canonicalTitle": "Florian Schneider",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-florian-schneider",
+        "nodeTitle": "Florian Schneider"
+      }
+    ]
+  },
+  "Q451858": {
+    "wikidataId": "Q451858",
+    "wikipediaTitle": "King_Tubby",
+    "canonicalTitle": "King Tubby",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-king-tubby",
+        "nodeTitle": "King Tubby"
+      }
+    ]
+  },
+  "Q426035": {
+    "wikidataId": "Q426035",
+    "wikipediaTitle": "Moog_synthesizer",
+    "canonicalTitle": "Moog Modular Synthesizer",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-moog-modular",
+        "nodeTitle": "Moog Modular Synthesizer"
+      }
+    ]
+  },
+  "Q453595": {
+    "wikidataId": "Q453595",
+    "wikipediaTitle": "Giles_of_Viterbo",
+    "canonicalTitle": "Egidio da Viterbo",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-egidio-da-viterbo",
+        "nodeTitle": "Egidio da Viterbo"
+      }
+    ]
+  },
+  "Q457906": {
+    "wikidataId": "Q457906",
+    "wikipediaTitle": "J._Presper_Eckert",
+    "canonicalTitle": "J. Presper Eckert",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-presper-eckert",
+        "nodeTitle": "J. Presper Eckert"
+      }
+    ]
+  },
+  "Q487453": {
+    "wikidataId": "Q487453",
+    "wikipediaTitle": "Anatol_Rapoport",
+    "canonicalTitle": "Anatol Rapoport",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-anatol-rapoport",
+        "nodeTitle": "Anatol Rapoport"
+      }
+    ]
+  },
+  "Q439245": {
+    "wikidataId": "Q439245",
+    "wikipediaTitle": "Allen_Newell",
+    "canonicalTitle": "Allen Newell",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-allen-newell",
+        "nodeTitle": "Allen Newell"
+      }
+    ]
+  },
+  "Q450354": {
+    "wikidataId": "Q450354",
+    "wikipediaTitle": "Julie_de_Lespinasse",
+    "canonicalTitle": "Julie de Lespinasse",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-julie-de-lespinasse",
+        "nodeTitle": "Julie de Lespinasse"
+      }
+    ]
+  },
+  "Q461961": {
+    "wikidataId": "Q461961",
+    "wikipediaTitle": "Anne-Catherine_de_Ligniville",
+    "canonicalTitle": "Anne-Catherine de Ligniville",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-madame-helvetius",
+        "nodeTitle": "Anne-Catherine de Ligniville"
+      }
+    ]
+  },
+  "Q482438": {
+    "wikidataId": "Q482438",
+    "wikipediaTitle": "An_Essay_Concerning_Human_Understanding",
+    "canonicalTitle": "Essay Concerning Human Understanding",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-essay-human-understanding",
+        "nodeTitle": "Essay Concerning Human Understanding"
+      }
+    ]
+  },
+  "Q466089": {
+    "wikidataId": "Q466089",
+    "wikipediaTitle": "American_Philosophical_Society",
+    "canonicalTitle": "American Philosophical Society",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-amer-phil-society",
+        "nodeTitle": "American Philosophical Society"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-amer-phil-society",
+        "nodeTitle": "American Philosophical Society (Institution)"
+      }
+    ]
+  },
+  "Q472670": {
+    "wikidataId": "Q472670",
+    "wikipediaTitle": "Haskalah",
+    "canonicalTitle": "Haskalah (Jewish Enlightenment)",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-haskalah",
+        "nodeTitle": "Haskalah (Jewish Enlightenment)"
+      }
+    ]
+  },
+  "Q483024": {
+    "wikidataId": "Q483024",
+    "wikipediaTitle": "Rationalism",
+    "canonicalTitle": "Continental Rationalism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-continental-rationalism",
+        "nodeTitle": "Continental Rationalism"
+      }
+    ]
+  },
+  "Q499851": {
+    "wikidataId": "Q499851",
+    "wikipediaTitle": "Corpus_Hermeticum",
+    "canonicalTitle": "Corpus Hermeticum",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-corpus-hermeticum",
+        "nodeTitle": "Corpus Hermeticum"
+      }
+    ]
+  },
+  "Q435456": {
+    "wikidataId": "Q435456",
+    "wikipediaTitle": "William_Farel",
+    "canonicalTitle": "Guillaume Farel",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-guillaume-farel",
+        "nodeTitle": "Guillaume Farel"
+      }
+    ]
+  },
+  "Q447170": {
+    "wikidataId": "Q447170",
+    "wikipediaTitle": "Marie_Dentière",
+    "canonicalTitle": "Marie Dentière",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-marie-dentiere",
+        "nodeTitle": "Marie Dentière"
+      }
+    ]
+  },
+  "Q435853": {
+    "wikidataId": "Q435853",
+    "wikipediaTitle": "Thomas_Cajetan",
+    "canonicalTitle": "Cardinal Thomas Cajetan",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-cardinal-thomas-cajetan",
+        "nodeTitle": "Cardinal Thomas Cajetan"
+      }
+    ]
+  },
+  "Q493726": {
+    "wikidataId": "Q493726",
+    "wikipediaTitle": "Genevan_Psalter",
+    "canonicalTitle": "Genevan Psalter",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-genevan-psalter",
+        "nodeTitle": "Genevan Psalter"
+      }
+    ]
+  },
+  "Q484870": {
+    "wikidataId": "Q484870",
+    "wikipediaTitle": "Eisleben",
+    "canonicalTitle": "Eisleben",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-eisleben",
+        "nodeTitle": "Eisleben"
+      }
+    ]
+  },
+  "Q474889": {
+    "wikidataId": "Q474889",
+    "wikipediaTitle": "Swiss_Brethren",
+    "canonicalTitle": "Swiss Brethren",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-swiss-brethren",
+        "nodeTitle": "Swiss Brethren"
+      }
+    ]
+  },
+  "Q435583": {
+    "wikidataId": "Q435583",
+    "wikipediaTitle": "Old_Swiss_Confederacy",
+    "canonicalTitle": "Swiss Confederacy",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-swiss-confederacy",
+        "nodeTitle": "Swiss Confederacy"
+      }
+    ]
+  },
+  "Q434356": {
+    "wikidataId": "Q434356",
+    "wikipediaTitle": "Manuel_Chrysoloras",
+    "canonicalTitle": "Manuel Chrysoloras",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-manuel-chrysoloras",
+        "nodeTitle": "Manuel Chrysoloras"
+      }
+    ]
+  },
+  "Q434834": {
+    "wikidataId": "Q434834",
+    "wikipediaTitle": "Flavio_Biondo",
+    "canonicalTitle": "Flavio Biondo",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-flavio-biondo",
+        "nodeTitle": "Flavio Biondo"
+      }
+    ]
+  },
+  "Q455140": {
+    "wikidataId": "Q455140",
+    "wikipediaTitle": "Bartolomeo_Platina",
+    "canonicalTitle": "Bartolomeo Platina",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-bartolomeo-platina",
+        "nodeTitle": "Bartolomeo Platina"
+      }
+    ]
+  },
+  "Q437543": {
+    "wikidataId": "Q437543",
+    "wikipediaTitle": "Paolo_Giovio",
+    "canonicalTitle": "Paolo Giovio",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-paolo-giovio",
+        "nodeTitle": "Paolo Giovio"
+      }
+    ]
+  },
+  "Q425606": {
+    "wikidataId": "Q425606",
+    "wikipediaTitle": "De_viris_illustribus_(Petrarch)",
+    "canonicalTitle": "De viris illustribus",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-viris-illustribus",
+        "nodeTitle": "De viris illustribus"
+      }
+    ]
+  },
+  "Q404158": {
+    "wikidataId": "Q404158",
+    "wikipediaTitle": "Utopia_(book)",
+    "canonicalTitle": "Utopia",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-utopia",
+        "nodeTitle": "Utopia"
+      }
+    ]
+  },
+  "Q453697": {
+    "wikidataId": "Q453697",
+    "wikipediaTitle": "Robert_Fludd",
+    "canonicalTitle": "Robert Fludd",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-robert-fludd",
+        "nodeTitle": "Robert Fludd"
+      }
+    ]
+  },
+  "Q471406": {
+    "wikidataId": "Q471406",
+    "wikipediaTitle": "Elias_Ashmole",
+    "canonicalTitle": "Elias Ashmole",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-elias-ashmole",
+        "nodeTitle": "Elias Ashmole"
+      },
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-elias-ashmole",
+        "nodeTitle": "Elias Ashmole"
+      }
+    ]
+  },
+  "Q440568": {
+    "wikidataId": "Q440568",
+    "wikipediaTitle": "Jerzy_Neyman",
+    "canonicalTitle": "Jerzy Neyman",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-jerzy-neyman",
+        "nodeTitle": "Jerzy Neyman"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q4000000-Q4099999.json
+++ b/public/cross-scene-index/by-wikidata/Q4000000-Q4099999.json
@@ -1,0 +1,15 @@
+{
+  "Q4086736": {
+    "wikidataId": "Q4086736",
+    "wikipediaTitle": "Virginia_Statute_for_Religious_Freedom",
+    "canonicalTitle": "Virginia Statute for Religious Freedom",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-virginia-statute",
+        "nodeTitle": "Virginia Statute for Religious Freedom"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q4100000-Q4199999.json
+++ b/public/cross-scene-index/by-wikidata/Q4100000-Q4199999.json
@@ -1,0 +1,15 @@
+{
+  "Q4120832": {
+    "wikidataId": "Q4120832",
+    "wikipediaTitle": "Königsberg",
+    "canonicalTitle": "Königsberg",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-konigsberg",
+        "nodeTitle": "Königsberg"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q4200000-Q4299999.json
+++ b/public/cross-scene-index/by-wikidata/Q4200000-Q4299999.json
@@ -1,0 +1,15 @@
+{
+  "Q4261404": {
+    "wikidataId": "Q4261404",
+    "wikipediaTitle": "Notes_on_the_State_of_Virginia",
+    "canonicalTitle": "Notes on the State of Virginia",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-notes-virginia",
+        "nodeTitle": "Notes on the State of Virginia"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q42300000-Q42399999.json
+++ b/public/cross-scene-index/by-wikidata/Q42300000-Q42399999.json
@@ -1,0 +1,15 @@
+{
+  "Q42378114": {
+    "wikidataId": "Q42378114",
+    "wikipediaTitle": "Karl_Widemann",
+    "canonicalTitle": "Karl Widemann",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-karl-widemann",
+        "nodeTitle": "Karl Widemann"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q4300000-Q4399999.json
+++ b/public/cross-scene-index/by-wikidata/Q4300000-Q4399999.json
@@ -1,0 +1,41 @@
+{
+  "Q4359403": {
+    "wikidataId": "Q4359403",
+    "wikipediaTitle": "Perceptrons_(book)",
+    "canonicalTitle": "Perceptrons: An Introduction to Computational Geometry",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-perceptrons-minsky-papert",
+        "nodeTitle": "Perceptrons: An Introduction to Computational Geometry"
+      }
+    ]
+  },
+  "Q4330297": {
+    "wikidataId": "Q4330297",
+    "wikipediaTitle": "International_Society_for_the_Systems_Sciences",
+    "canonicalTitle": "Society for General Systems Research",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-sgsr",
+        "nodeTitle": "Society for General Systems Research"
+      }
+    ]
+  },
+  "Q4356652": {
+    "wikidataId": "Q4356652",
+    "wikipediaTitle": "Theatrum_Chemicum_Britannicum",
+    "canonicalTitle": "Theatrum Chemicum Britannicum",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-theatrum-chemicum-britannicum",
+        "nodeTitle": "Theatrum Chemicum Britannicum"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q43600000-Q43699999.json
+++ b/public/cross-scene-index/by-wikidata/Q43600000-Q43699999.json
@@ -1,0 +1,15 @@
+{
+  "Q43637545": {
+    "wikidataId": "Q43637545",
+    "wikipediaTitle": "Silver_Apples_of_the_Moon",
+    "canonicalTitle": "Silver Apples of the Moon",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-subotnick-silver-apples",
+        "nodeTitle": "Silver Apples of the Moon"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q4600000-Q4699999.json
+++ b/public/cross-scene-index/by-wikidata/Q4600000-Q4699999.json
@@ -1,0 +1,47 @@
+{
+  "Q4690656": {
+    "wikidataId": "Q4690656",
+    "wikipediaTitle": "After_the_Heat",
+    "canonicalTitle": "After the Heat",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-after-the-heat",
+        "nodeTitle": "After the Heat"
+      }
+    ]
+  },
+  "Q4676716": {
+    "wikidataId": "Q4676716",
+    "wikipediaTitle": "Buchla_Electronic_Musical_Instruments",
+    "canonicalTitle": "Buchla 100 Series",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-buchla-100",
+        "nodeTitle": "Buchla 100 Series"
+      },
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-buchla",
+        "nodeTitle": "Buchla and Associates"
+      }
+    ]
+  },
+  "Q4679195": {
+    "wikidataId": "Q4679195",
+    "wikipediaTitle": "Adam_Haslmayr",
+    "canonicalTitle": "Adam Haslmayr",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-adam-haslmayr",
+        "nodeTitle": "Adam Haslmayr"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q4700000-Q4799999.json
+++ b/public/cross-scene-index/by-wikidata/Q4700000-Q4799999.json
@@ -1,0 +1,54 @@
+{
+  "Q4717608": {
+    "wikidataId": "Q4717608",
+    "wikipediaTitle": "Alex_Paterson",
+    "canonicalTitle": "Alex Paterson (The Orb)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-alex-paterson",
+        "nodeTitle": "Alex Paterson (The Orb)"
+      }
+    ]
+  },
+  "Q4745015": {
+    "wikidataId": "Q4745015",
+    "wikipediaTitle": "American_Society_for_Cybernetics",
+    "canonicalTitle": "American Society for Cybernetics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-american-cybernetics",
+        "nodeTitle": "American Society for Cybernetics"
+      }
+    ]
+  },
+  "Q4749931": {
+    "wikidataId": "Q4749931",
+    "wikipediaTitle": "An_Essay_on_the_History_of_Civil_Society",
+    "canonicalTitle": "Essay on the History of Civil Society",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-essay-civil-society",
+        "nodeTitle": "Essay on the History of Civil Society"
+      }
+    ]
+  },
+  "Q4749933": {
+    "wikidataId": "Q4749933",
+    "wikipediaTitle": "An_Essay_towards_solving_a_Problem_in_the_Doctrine_of_Chances",
+    "canonicalTitle": "An Essay towards solving a Problem in the Doctrine of Chances",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-essay-towards-solving-a-problem",
+        "nodeTitle": "An Essay towards solving a Problem in the Doctrine of Chances"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q47400000-Q47499999.json
+++ b/public/cross-scene-index/by-wikidata/Q47400000-Q47499999.json
@@ -1,0 +1,15 @@
+{
+  "Q47488089": {
+    "wikidataId": "Q47488089",
+    "wikipediaTitle": "Timnit_Gebru",
+    "canonicalTitle": "Timnit Gebru",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-timnit-gebru",
+        "nodeTitle": "Timnit Gebru"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q48700000-Q48799999.json
+++ b/public/cross-scene-index/by-wikidata/Q48700000-Q48799999.json
@@ -1,0 +1,15 @@
+{
+  "Q48765523": {
+    "wikidataId": "Q48765523",
+    "wikipediaTitle": "Async_(album)",
+    "canonicalTitle": "async",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-sakamoto-async",
+        "nodeTitle": "async"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q4900000-Q4999999.json
+++ b/public/cross-scene-index/by-wikidata/Q4900000-Q4999999.json
@@ -1,0 +1,15 @@
+{
+  "Q4908833": {
+    "wikidataId": "Q4908833",
+    "wikipediaTitle": "Bill_Drummond",
+    "canonicalTitle": "Bill Drummond",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-bill-drummond",
+        "nodeTitle": "Bill Drummond"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q500000-Q599999.json
+++ b/public/cross-scene-index/by-wikidata/Q500000-Q599999.json
@@ -1,0 +1,463 @@
+{
+  "Q544469": {
+    "wikidataId": "Q544469",
+    "wikipediaTitle": "Pierre_Henry",
+    "canonicalTitle": "Pierre Henry",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-pierre-henry",
+        "nodeTitle": "Pierre Henry"
+      }
+    ]
+  },
+  "Q505957": {
+    "wikidataId": "Q505957",
+    "wikipediaTitle": "Edgar_Froese",
+    "canonicalTitle": "Edgar Froese",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-edgar-froese",
+        "nodeTitle": "Edgar Froese"
+      }
+    ]
+  },
+  "Q571477": {
+    "wikidataId": "Q571477",
+    "wikipediaTitle": "Conrad_Schnitzler",
+    "canonicalTitle": "Conrad Schnitzler",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-conrad-schnitzler",
+        "nodeTitle": "Conrad Schnitzler"
+      }
+    ]
+  },
+  "Q569003": {
+    "wikidataId": "Q569003",
+    "wikipediaTitle": "Brian_Eno",
+    "canonicalTitle": "Brian Eno",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-brian-eno",
+        "nodeTitle": "Brian Eno"
+      }
+    ]
+  },
+  "Q544099": {
+    "wikidataId": "Q544099",
+    "wikipediaTitle": "Autobahn_(album)",
+    "canonicalTitle": "Autobahn",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-kraftwerk-autobahn",
+        "nodeTitle": "Autobahn"
+      }
+    ]
+  },
+  "Q514109": {
+    "wikidataId": "Q514109",
+    "wikipediaTitle": "EMS_VCS_3",
+    "canonicalTitle": "VCS3 (Putney)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-ems-vcs3",
+        "nodeTitle": "VCS3 (Putney)"
+      }
+    ]
+  },
+  "Q568238": {
+    "wikidataId": "Q568238",
+    "wikipediaTitle": "Harmonia_(band)",
+    "canonicalTitle": "Harmonia",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-harmonia",
+        "nodeTitle": "Harmonia"
+      }
+    ]
+  },
+  "Q572901": {
+    "wikidataId": "Q572901",
+    "wikipediaTitle": "Minimal_music",
+    "canonicalTitle": "Minimalism",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-minimalism",
+        "nodeTitle": "Minimalism"
+      }
+    ]
+  },
+  "Q569604": {
+    "wikidataId": "Q569604",
+    "wikipediaTitle": "Sponheim_Abbey",
+    "canonicalTitle": "Sponheim Abbey",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-sponheim-abbey",
+        "nodeTitle": "Sponheim Abbey"
+      }
+    ]
+  },
+  "Q540500": {
+    "wikidataId": "Q540500",
+    "wikipediaTitle": "Charles_de_Bovelles",
+    "canonicalTitle": "Charles de Bovelles",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-charles-de-bovelles",
+        "nodeTitle": "Charles de Bovelles"
+      }
+    ]
+  },
+  "Q510591": {
+    "wikidataId": "Q510591",
+    "wikipediaTitle": "Warren_Weaver",
+    "canonicalTitle": "Warren Weaver",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-warren-weaver",
+        "nodeTitle": "Warren Weaver"
+      }
+    ]
+  },
+  "Q529886": {
+    "wikidataId": "Q529886",
+    "wikipediaTitle": "Ralph_Hartley",
+    "canonicalTitle": "Ralph Hartley",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ralph-hartley",
+        "nodeTitle": "Ralph Hartley"
+      }
+    ]
+  },
+  "Q522162": {
+    "wikidataId": "Q522162",
+    "wikipediaTitle": "John_Mauchly",
+    "canonicalTitle": "John Mauchly",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-john-mauchly",
+        "nodeTitle": "John Mauchly"
+      }
+    ]
+  },
+  "Q505520": {
+    "wikidataId": "Q505520",
+    "wikipediaTitle": "Kenneth_E._Boulding",
+    "canonicalTitle": "Kenneth Boulding",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-kenneth-boulding",
+        "nodeTitle": "Kenneth Boulding"
+      }
+    ]
+  },
+  "Q503806": {
+    "wikidataId": "Q503806",
+    "wikipediaTitle": "Peter_Checkland",
+    "canonicalTitle": "Peter Checkland",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-peter-checkland",
+        "nodeTitle": "Peter Checkland"
+      }
+    ]
+  },
+  "Q503192": {
+    "wikidataId": "Q503192",
+    "wikipediaTitle": "Walter_Bradford_Cannon",
+    "canonicalTitle": "Walter Cannon",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-walter-cannon",
+        "nodeTitle": "Walter Cannon"
+      }
+    ]
+  },
+  "Q598451": {
+    "wikidataId": "Q598451",
+    "wikipediaTitle": "System_dynamics",
+    "canonicalTitle": "System Dynamics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-system-dynamics",
+        "nodeTitle": "System Dynamics"
+      }
+    ]
+  },
+  "Q599967": {
+    "wikidataId": "Q599967",
+    "wikipediaTitle": "Autopoiesis",
+    "canonicalTitle": "Autopoiesis",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-autopoiesis",
+        "nodeTitle": "Autopoiesis"
+      }
+    ]
+  },
+  "Q584990": {
+    "wikidataId": "Q584990",
+    "wikipediaTitle": "Louis_de_Jaucourt",
+    "canonicalTitle": "Louis de Jaucourt",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-jaucourt",
+        "nodeTitle": "Louis de Jaucourt"
+      }
+    ]
+  },
+  "Q514727": {
+    "wikidataId": "Q514727",
+    "wikipediaTitle": "The_Spirit_of_the_Laws",
+    "canonicalTitle": "The Spirit of the Laws",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-spirit-laws",
+        "nodeTitle": "The Spirit of the Laws"
+      }
+    ]
+  },
+  "Q560436": {
+    "wikidataId": "Q560436",
+    "wikipediaTitle": "Cristoforo_Landino",
+    "canonicalTitle": "Cristoforo Landino",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-cristoforo-landino",
+        "nodeTitle": "Cristoforo Landino"
+      }
+    ]
+  },
+  "Q561458": {
+    "wikidataId": "Q561458",
+    "wikipediaTitle": "Demetrios_Chalkokondyles",
+    "canonicalTitle": "Demetrios Chalkokondyles",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-demetrios-chalkokondyles",
+        "nodeTitle": "Demetrios Chalkokondyles"
+      }
+    ]
+  },
+  "Q502592": {
+    "wikidataId": "Q502592",
+    "wikipediaTitle": "Hermes_Trismegistus",
+    "canonicalTitle": "Hermes Trismegistus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-hermes-trismegistus",
+        "nodeTitle": "Hermes Trismegistus"
+      }
+    ]
+  },
+  "Q579476": {
+    "wikidataId": "Q579476",
+    "wikipediaTitle": "Villa_Medici_at_Careggi",
+    "canonicalTitle": "Villa Medici at Careggi",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "location-villa-careggi",
+        "nodeTitle": "Villa Medici at Careggi"
+      }
+    ]
+  },
+  "Q506182": {
+    "wikidataId": "Q506182",
+    "wikipediaTitle": "John_Frederick_I,_Elector_of_Saxony",
+    "canonicalTitle": "John Frederick I",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-frederick-i",
+        "nodeTitle": "John Frederick I"
+      }
+    ]
+  },
+  "Q569330": {
+    "wikidataId": "Q569330",
+    "wikipediaTitle": "On_the_Freedom_of_a_Christian",
+    "canonicalTitle": "On the Freedom of a Christian",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-freedom-christian",
+        "nodeTitle": "On the Freedom of a Christian"
+      }
+    ]
+  },
+  "Q503473": {
+    "wikidataId": "Q503473",
+    "wikipediaTitle": "University_of_Geneva",
+    "canonicalTitle": "Geneva Academy",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-geneva-academy",
+        "nodeTitle": "Geneva Academy"
+      }
+    ]
+  },
+  "Q536822": {
+    "wikidataId": "Q536822",
+    "wikipediaTitle": "Diet_of_Worms",
+    "canonicalTitle": "Diet of Worms (1521)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-diet-of-worms",
+        "nodeTitle": "Diet of Worms (1521)"
+      }
+    ]
+  },
+  "Q510621": {
+    "wikidataId": "Q510621",
+    "wikipediaTitle": "Jacopo_Sannazaro",
+    "canonicalTitle": "Jacopo Sannazaro",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-jacopo-sannazaro",
+        "nodeTitle": "Jacopo Sannazaro"
+      }
+    ]
+  },
+  "Q539577": {
+    "wikidataId": "Q539577",
+    "wikipediaTitle": "Guarino_da_Verona",
+    "canonicalTitle": "Guarino da Verona",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-guarino-da-verona",
+        "nodeTitle": "Guarino da Verona"
+      }
+    ]
+  },
+  "Q533514": {
+    "wikidataId": "Q533514",
+    "wikipediaTitle": "George_of_Trebizond",
+    "canonicalTitle": "George of Trebizond",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-george-of-trebizond",
+        "nodeTitle": "George of Trebizond"
+      }
+    ]
+  },
+  "Q569869": {
+    "wikidataId": "Q569869",
+    "wikipediaTitle": "In_Praise_of_Folly",
+    "canonicalTitle": "Moriae encomium (Praise of Folly)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-praise-of-folly",
+        "nodeTitle": "Moriae encomium (Praise of Folly)"
+      }
+    ]
+  },
+  "Q567488": {
+    "wikidataId": "Q567488",
+    "wikipediaTitle": "Aldine_Press",
+    "canonicalTitle": "Aldine Press",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-aldine-press",
+        "nodeTitle": "Aldine Press"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-aldine-press",
+        "nodeTitle": "Aldine Press"
+      }
+    ]
+  },
+  "Q551420": {
+    "wikidataId": "Q551420",
+    "wikipediaTitle": "Maurice,_Landgrave_of_Hesse-Kassel",
+    "canonicalTitle": "Moritz of Hesse-Kassel",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-moritz-hesse-kassel",
+        "nodeTitle": "Moritz of Hesse-Kassel"
+      }
+    ]
+  },
+  "Q557652": {
+    "wikidataId": "Q557652",
+    "wikipediaTitle": "John_Wilkins",
+    "canonicalTitle": "John Wilkins",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-john-wilkins",
+        "nodeTitle": "John Wilkins"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q5100000-Q5199999.json
+++ b/public/cross-scene-index/by-wikidata/Q5100000-Q5199999.json
@@ -1,0 +1,28 @@
+{
+  "Q5154756": {
+    "wikidataId": "Q5154756",
+    "wikipediaTitle": "Commentary_on_Plato%27s_Symposium_on_Love",
+    "canonicalTitle": "De Amore (Commentary on Plato's Symposium)",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-de-amore",
+        "nodeTitle": "De Amore (Commentary on Plato's Symposium)"
+      }
+    ]
+  },
+  "Q5128354": {
+    "wikidataId": "Q5128354",
+    "wikipediaTitle": "Civic_humanism",
+    "canonicalTitle": "Civic Humanism",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-civic-humanism",
+        "nodeTitle": "Civic Humanism"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q51500000-Q51599999.json
+++ b/public/cross-scene-index/by-wikidata/Q51500000-Q51599999.json
@@ -1,0 +1,15 @@
+{
+  "Q51508521": {
+    "wikidataId": "Q51508521",
+    "wikipediaTitle": "Natural_Inheritance",
+    "canonicalTitle": "Natural Inheritance",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-natural-inheritance",
+        "nodeTitle": "Natural Inheritance"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q5200000-Q5299999.json
+++ b/public/cross-scene-index/by-wikidata/Q5200000-Q5299999.json
@@ -1,0 +1,54 @@
+{
+  "Q5250235": {
+    "wikidataId": "Q5250235",
+    "wikipediaTitle": "Deep_Listening_Band",
+    "canonicalTitle": "Deep Listening Band",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-deep-listening-band",
+        "nodeTitle": "Deep Listening Band"
+      }
+    ]
+  },
+  "Q5247052": {
+    "wikidataId": "Q5247052",
+    "wikipediaTitle": "De_harmonia_mundi",
+    "canonicalTitle": "De Harmonia Mundi totius cantica tria",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-harmonia-mundi",
+        "nodeTitle": "De Harmonia Mundi totius cantica tria"
+      }
+    ]
+  },
+  "Q5226156": {
+    "wikidataId": "Q5226156",
+    "wikipediaTitle": "Theory_of_Games_and_Economic_Behavior",
+    "canonicalTitle": "Theory of Games and Economic Behavior",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-game-theory-neumann-morgenstern",
+        "nodeTitle": "Theory of Games and Economic Behavior"
+      }
+    ]
+  },
+  "Q5244229": {
+    "wikidataId": "Q5244229",
+    "wikipediaTitle": "De_Arte_Cabalistica",
+    "canonicalTitle": "De arte cabalistica",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-arte-cabalistica",
+        "nodeTitle": "De arte cabalistica"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q5300000-Q5399999.json
+++ b/public/cross-scene-index/by-wikidata/Q5300000-Q5399999.json
@@ -1,0 +1,15 @@
+{
+  "Q5358503": {
+    "wikidataId": "Q5358503",
+    "wikipediaTitle": "Electronium",
+    "canonicalTitle": "Electronium",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-electronium",
+        "nodeTitle": "Electronium"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q5400000-Q5499999.json
+++ b/public/cross-scene-index/by-wikidata/Q5400000-Q5499999.json
@@ -1,0 +1,41 @@
+{
+  "Q5486704": {
+    "wikidataId": "Q5486704",
+    "wikipediaTitle": "Frank_Fremont-Smith",
+    "canonicalTitle": "Frank Fremont-Smith",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-frank-fremont-smith",
+        "nodeTitle": "Frank Fremont-Smith"
+      }
+    ]
+  },
+  "Q5452926": {
+    "wikidataId": "Q5452926",
+    "wikipediaTitle": "First_Draft_of_a_Report_on_the_EDVAC",
+    "canonicalTitle": "First Draft of a Report on the EDVAC",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-edvac-report-neumann",
+        "nodeTitle": "First Draft of a Report on the EDVAC"
+      }
+    ]
+  },
+  "Q5407573": {
+    "wikidataId": "Q5407573",
+    "wikipediaTitle": "Eugenics_Society",
+    "canonicalTitle": "Eugenics Education Society",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "entity-eugenics-education-society",
+        "nodeTitle": "Eugenics Education Society"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q5500000-Q5599999.json
+++ b/public/cross-scene-index/by-wikidata/Q5500000-Q5599999.json
@@ -1,0 +1,15 @@
+{
+  "Q5514059": {
+    "wikidataId": "Q5514059",
+    "wikipediaTitle": "Symbolic_artificial_intelligence",
+    "canonicalTitle": "Symbolic AI / GOFAI",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-symbolic-ai",
+        "nodeTitle": "Symbolic AI / GOFAI"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q55400000-Q55499999.json
+++ b/public/cross-scene-index/by-wikidata/Q55400000-Q55499999.json
@@ -1,0 +1,15 @@
+{
+  "Q55416434": {
+    "wikidataId": "Q55416434",
+    "wikipediaTitle": "Daniel_Mögling",
+    "canonicalTitle": "Daniel Mögling",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-daniel-mogling",
+        "nodeTitle": "Daniel Mögling"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q55600000-Q55699999.json
+++ b/public/cross-scene-index/by-wikidata/Q55600000-Q55699999.json
@@ -1,0 +1,41 @@
+{
+  "Q55609966": {
+    "wikidataId": "Q55609966",
+    "wikipediaTitle": "Wojciech_Zaremba",
+    "canonicalTitle": "Wojciech Zaremba",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-wojciech-zaremba",
+        "nodeTitle": "Wojciech Zaremba"
+      }
+    ]
+  },
+  "Q55641992": {
+    "wikidataId": "Q55641992",
+    "wikipediaTitle": "Pushmeet_Kohli",
+    "canonicalTitle": "Pushmeet Kohli",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-pushmeet-kohli",
+        "nodeTitle": "Pushmeet Kohli"
+      }
+    ]
+  },
+  "Q55635660": {
+    "wikidataId": "Q55635660",
+    "wikipediaTitle": "Christian_theosophy",
+    "canonicalTitle": "Christian Theosophy",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-christian-theosophy",
+        "nodeTitle": "Christian Theosophy"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q5600000-Q5699999.json
+++ b/public/cross-scene-index/by-wikidata/Q5600000-Q5699999.json
@@ -1,0 +1,28 @@
+{
+  "Q5605106": {
+    "wikidataId": "Q5605106",
+    "wikipediaTitle": "Jimmy_Cauty",
+    "canonicalTitle": "Jimmy Cauty",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-jimmy-cauty",
+        "nodeTitle": "Jimmy Cauty"
+      }
+    ]
+  },
+  "Q5676046": {
+    "wikidataId": "Q5676046",
+    "wikipediaTitle": "Hartlib_Circle",
+    "canonicalTitle": "Hartlib Circle",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-hartlib-circle",
+        "nodeTitle": "Hartlib Circle"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q56000000-Q56099999.json
+++ b/public/cross-scene-index/by-wikidata/Q56000000-Q56099999.json
@@ -1,0 +1,28 @@
+{
+  "Q56034965": {
+    "wikidataId": "Q56034965",
+    "wikipediaTitle": "Diederik_P._Kingma",
+    "canonicalTitle": "Durk Kingma",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-durk-kingma",
+        "nodeTitle": "Durk Kingma"
+      }
+    ]
+  },
+  "Q56062424": {
+    "wikidataId": "Q56062424",
+    "wikipediaTitle": "Ashish_Vaswani",
+    "canonicalTitle": "Ashish Vaswani",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-ashish-vaswani",
+        "nodeTitle": "Ashish Vaswani"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q56600000-Q56699999.json
+++ b/public/cross-scene-index/by-wikidata/Q56600000-Q56699999.json
@@ -1,0 +1,28 @@
+{
+  "Q56603936": {
+    "wikidataId": "Q56603936",
+    "wikipediaTitle": "Joelle_Pineau",
+    "canonicalTitle": "Joelle Pineau",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-joelle-pineau",
+        "nodeTitle": "Joelle Pineau"
+      }
+    ]
+  },
+  "Q56677851": {
+    "wikidataId": "Q56677851",
+    "wikipediaTitle": "Percy_Liang",
+    "canonicalTitle": "Percy Liang",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-percy-liang",
+        "nodeTitle": "Percy Liang"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q5700000-Q5799999.json
+++ b/public/cross-scene-index/by-wikidata/Q5700000-Q5799999.json
@@ -1,0 +1,54 @@
+{
+  "Q5753247": {
+    "wikidataId": "Q5753247",
+    "wikipediaTitle": "Three_Books_on_Life",
+    "canonicalTitle": "De Vita Libri Tres (Three Books on Life)",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-de-vita-libri-tres",
+        "nodeTitle": "De Vita Libri Tres (Three Books on Life)"
+      }
+    ]
+  },
+  "Q5732857": {
+    "wikidataId": "Q5732857",
+    "wikipediaTitle": "Heptaplus",
+    "canonicalTitle": "Heptaplus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-heptaplus",
+        "nodeTitle": "Heptaplus"
+      }
+    ]
+  },
+  "Q5700295": {
+    "wikidataId": "Q5700295",
+    "wikipediaTitle": "Heinrich_Petraeus",
+    "canonicalTitle": "Heinrich Petraeus",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-heinrich-petraeus",
+        "nodeTitle": "Heinrich Petraeus"
+      }
+    ]
+  },
+  "Q5734888": {
+    "wikidataId": "Q5734888",
+    "wikipediaTitle": "Hereditary_Genius",
+    "canonicalTitle": "Hereditary Genius",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-hereditary-genius",
+        "nodeTitle": "Hereditary Genius"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q57000000-Q57099999.json
+++ b/public/cross-scene-index/by-wikidata/Q57000000-Q57099999.json
@@ -1,0 +1,15 @@
+{
+  "Q57085111": {
+    "wikidataId": "Q57085111",
+    "wikipediaTitle": "International_Conference_on_Learning_Representations",
+    "canonicalTitle": "ICLR",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-iclr",
+        "nodeTitle": "ICLR"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q57400000-Q57499999.json
+++ b/public/cross-scene-index/by-wikidata/Q57400000-Q57499999.json
@@ -1,0 +1,80 @@
+{
+  "Q57430008": {
+    "wikidataId": "Q57430008",
+    "wikipediaTitle": "Łukasz_Kaiser",
+    "canonicalTitle": "Łukasz Kaiser",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-lukasz-kaiser",
+        "nodeTitle": "Łukasz Kaiser"
+      }
+    ]
+  },
+  "Q57431260": {
+    "wikidataId": "Q57431260",
+    "wikipediaTitle": "Noam_Shazeer",
+    "canonicalTitle": "Noam Shazeer",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-noam-shazeer",
+        "nodeTitle": "Noam Shazeer"
+      }
+    ]
+  },
+  "Q57430055": {
+    "wikidataId": "Q57430055",
+    "wikipediaTitle": "Jakob_Uszkoreit",
+    "canonicalTitle": "Jakob Uszkoreit",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jakob-uszkoreit",
+        "nodeTitle": "Jakob Uszkoreit"
+      }
+    ]
+  },
+  "Q57430117": {
+    "wikidataId": "Q57430117",
+    "wikipediaTitle": "Llion_Jones",
+    "canonicalTitle": "Llion Jones",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-llion-jones",
+        "nodeTitle": "Llion Jones"
+      }
+    ]
+  },
+  "Q57430148": {
+    "wikidataId": "Q57430148",
+    "wikipediaTitle": "Aidan_Gomez",
+    "canonicalTitle": "Aidan Gomez",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-aidan-gomez",
+        "nodeTitle": "Aidan Gomez"
+      }
+    ]
+  },
+  "Q57430190": {
+    "wikidataId": "Q57430190",
+    "wikipediaTitle": "Illia_Polosukhin",
+    "canonicalTitle": "Illia Polosukhin",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-illia-polosukhin",
+        "nodeTitle": "Illia Polosukhin"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q5900000-Q5999999.json
+++ b/public/cross-scene-index/by-wikidata/Q5900000-Q5999999.json
@@ -1,0 +1,15 @@
+{
+  "Q5987936": {
+    "wikidataId": "Q5987936",
+    "wikipediaTitle": "Yoshua_Bengio",
+    "canonicalTitle": "Yoshua Bengio",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-yoshua-bengio",
+        "nodeTitle": "Yoshua Bengio"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q600000-Q699999.json
+++ b/public/cross-scene-index/by-wikidata/Q600000-Q699999.json
@@ -1,0 +1,496 @@
+{
+  "Q690282": {
+    "wikidataId": "Q690282",
+    "wikipediaTitle": "Klaus_Dinger",
+    "canonicalTitle": "Klaus Dinger",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-klaus-dinger",
+        "nodeTitle": "Klaus Dinger"
+      }
+    ]
+  },
+  "Q642815": {
+    "wikidataId": "Q642815",
+    "wikipediaTitle": "Phaedra_(album)",
+    "canonicalTitle": "Phaedra",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-td-phaedra",
+        "nodeTitle": "Phaedra"
+      }
+    ]
+  },
+  "Q656796": {
+    "wikidataId": "Q656796",
+    "wikipediaTitle": "New_Age_of_Earth",
+    "canonicalTitle": "New Age of Earth",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-gottsching-new-age",
+        "nodeTitle": "New Age of Earth"
+      }
+    ]
+  },
+  "Q667023": {
+    "wikidataId": "Q667023",
+    "wikipediaTitle": "Hansa_Tonstudio",
+    "canonicalTitle": "Hansa Studio",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-hansa",
+        "nodeTitle": "Hansa Studio"
+      }
+    ]
+  },
+  "Q638859": {
+    "wikidataId": "Q638859",
+    "wikipediaTitle": "Mills_College",
+    "canonicalTitle": "Mills College",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-mills",
+        "nodeTitle": "Mills College"
+      }
+    ]
+  },
+  "Q662355": {
+    "wikidataId": "Q662355",
+    "wikipediaTitle": "Kunstakademie_Düsseldorf",
+    "canonicalTitle": "Düsseldorf Art Academy",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-dusseldorf-academy",
+        "nodeTitle": "Düsseldorf Art Academy"
+      }
+    ]
+  },
+  "Q679697": {
+    "wikidataId": "Q679697",
+    "wikipediaTitle": "Faust_(band)",
+    "canonicalTitle": "Faust",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-faust",
+        "nodeTitle": "Faust"
+      }
+    ]
+  },
+  "Q699355": {
+    "wikidataId": "Q699355",
+    "wikipediaTitle": "Holger_Czukay",
+    "canonicalTitle": "Holger Czukay",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-holger-czukay",
+        "nodeTitle": "Holger Czukay"
+      }
+    ]
+  },
+  "Q699096": {
+    "wikidataId": "Q699096",
+    "wikipediaTitle": "Elijah_Levita",
+    "canonicalTitle": "Elijah Levita",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-elijah-levita",
+        "nodeTitle": "Elijah Levita"
+      }
+    ]
+  },
+  "Q646795": {
+    "wikidataId": "Q646795",
+    "wikipediaTitle": "Steganographia",
+    "canonicalTitle": "Steganographia",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-steganographia",
+        "nodeTitle": "Steganographia"
+      }
+    ]
+  },
+  "Q672269": {
+    "wikidataId": "Q672269",
+    "wikipediaTitle": "Letters_of_Obscure_Men",
+    "canonicalTitle": "Epistolae Obscurorum Virorum",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-letters-obscure-men",
+        "nodeTitle": "Epistolae Obscurorum Virorum"
+      }
+    ]
+  },
+  "Q683246": {
+    "wikidataId": "Q683246",
+    "wikipediaTitle": "Donald_O._Hebb",
+    "canonicalTitle": "Donald Hebb",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-donald-hebb",
+        "nodeTitle": "Donald Hebb"
+      }
+    ]
+  },
+  "Q690207": {
+    "wikidataId": "Q690207",
+    "wikipediaTitle": "Perceptron",
+    "canonicalTitle": "Mark I Perceptron",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-perceptron-hardware",
+        "nodeTitle": "Mark I Perceptron"
+      }
+    ]
+  },
+  "Q635642": {
+    "wikidataId": "Q635642",
+    "wikipediaTitle": "Institute_for_Advanced_Study",
+    "canonicalTitle": "Institute for Advanced Study",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-ias-princeton",
+        "nodeTitle": "Institute for Advanced Study"
+      }
+    ]
+  },
+  "Q604924": {
+    "wikidataId": "Q604924",
+    "wikipediaTitle": "SRI_International",
+    "canonicalTitle": "Stanford Research Institute (SRI)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-sri",
+        "nodeTitle": "Stanford Research Institute (SRI)"
+      }
+    ]
+  },
+  "Q656976": {
+    "wikidataId": "Q656976",
+    "wikipediaTitle": "Dictionnaire_philosophique",
+    "canonicalTitle": "Philosophical Dictionary",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-philosophical-dictionary",
+        "nodeTitle": "Philosophical Dictionary"
+      }
+    ]
+  },
+  "Q672420": {
+    "wikidataId": "Q672420",
+    "wikipediaTitle": "University_of_Königsberg",
+    "canonicalTitle": "University of Königsberg",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-univ-konigsberg",
+        "nodeTitle": "University of Königsberg"
+      }
+    ]
+  },
+  "Q620629": {
+    "wikidataId": "Q620629",
+    "wikipediaTitle": "Deism",
+    "canonicalTitle": "Deism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-deism",
+        "nodeTitle": "Deism"
+      }
+    ]
+  },
+  "Q606879": {
+    "wikidataId": "Q606879",
+    "wikipediaTitle": "Enneads",
+    "canonicalTitle": "Enneads",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-enneads",
+        "nodeTitle": "Enneads"
+      }
+    ]
+  },
+  "Q647264": {
+    "wikidataId": "Q647264",
+    "wikipediaTitle": "John_Hooper_(bishop)",
+    "canonicalTitle": "John Hooper",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-hooper",
+        "nodeTitle": "John Hooper"
+      }
+    ]
+  },
+  "Q619586": {
+    "wikidataId": "Q619586",
+    "wikipediaTitle": "Apology_of_the_Augsburg_Confession",
+    "canonicalTitle": "Apology of the Augsburg Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-apology-augsburg",
+        "nodeTitle": "Apology of the Augsburg Confession"
+      }
+    ]
+  },
+  "Q676162": {
+    "wikidataId": "Q676162",
+    "wikipediaTitle": "Second_Helvetic_Confession",
+    "canonicalTitle": "Second Helvetic Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-second-helvetic-confession",
+        "nodeTitle": "Second Helvetic Confession"
+      }
+    ]
+  },
+  "Q684948": {
+    "wikidataId": "Q684948",
+    "wikipediaTitle": "Grossmünster",
+    "canonicalTitle": "Grossmünster",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-grossmunster",
+        "nodeTitle": "Grossmünster"
+      }
+    ]
+  },
+  "Q672138": {
+    "wikidataId": "Q672138",
+    "wikipediaTitle": "Marburg_Colloquy",
+    "canonicalTitle": "Marburg Colloquy",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-marburg-colloquy",
+        "nodeTitle": "Marburg Colloquy"
+      }
+    ]
+  },
+  "Q688998": {
+    "wikidataId": "Q688998",
+    "wikipediaTitle": "Leipzig_Debate",
+    "canonicalTitle": "Leipzig Debate",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-leipzig-debate",
+        "nodeTitle": "Leipzig Debate"
+      }
+    ]
+  },
+  "Q668134": {
+    "wikidataId": "Q668134",
+    "wikipediaTitle": "Pier_Paolo_Vergerio",
+    "canonicalTitle": "Pier Paolo Vergerio the Elder",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-pier-paolo-vergerio",
+        "nodeTitle": "Pier Paolo Vergerio the Elder"
+      }
+    ]
+  },
+  "Q646092": {
+    "wikidataId": "Q646092",
+    "wikipediaTitle": "Beatus_Rhenanus",
+    "canonicalTitle": "Beatus Rhenanus",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-beatus-rhenanus",
+        "nodeTitle": "Beatus Rhenanus"
+      }
+    ]
+  },
+  "Q666687": {
+    "wikidataId": "Q666687",
+    "wikipediaTitle": "Juan_de_Valdés",
+    "canonicalTitle": "Juan de Valdés",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-juan-de-valdes",
+        "nodeTitle": "Juan de Valdés"
+      }
+    ]
+  },
+  "Q691766": {
+    "wikidataId": "Q691766",
+    "wikipediaTitle": "Florentine_Histories",
+    "canonicalTitle": "Istorie fiorentine",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-istorie-fiorentine",
+        "nodeTitle": "Istorie fiorentine"
+      }
+    ]
+  },
+  "Q624852": {
+    "wikidataId": "Q624852",
+    "wikipediaTitle": "Essays_(Montaigne)",
+    "canonicalTitle": "Essais",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-essais",
+        "nodeTitle": "Essais"
+      }
+    ]
+  },
+  "Q677173": {
+    "wikidataId": "Q677173",
+    "wikipediaTitle": "House_of_Este",
+    "canonicalTitle": "Este Patronage (Ferrara)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-este-patronage",
+        "nodeTitle": "Este Patronage (Ferrara)"
+      }
+    ]
+  },
+  "Q672023": {
+    "wikidataId": "Q672023",
+    "wikipediaTitle": "Schwenkfelder_Church",
+    "canonicalTitle": "Schwenckfelder Movement",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-schwenckfelder-movement",
+        "nodeTitle": "Schwenckfelder Movement"
+      }
+    ]
+  },
+  "Q604837": {
+    "wikidataId": "Q604837",
+    "wikipediaTitle": "Hartlib_Circle",
+    "canonicalTitle": "Hartlib Circle",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-hartlib-circle",
+        "nodeTitle": "Hartlib Circle"
+      }
+    ]
+  },
+  "Q652054": {
+    "wikidataId": "Q652054",
+    "wikipediaTitle": "Sidereus_Nuncius",
+    "canonicalTitle": "Sidereus Nuncius",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-sidereus-nuncius",
+        "nodeTitle": "Sidereus Nuncius"
+      }
+    ]
+  },
+  "Q658008": {
+    "wikidataId": "Q658008",
+    "wikipediaTitle": "John_Theophilus_Desaguliers",
+    "canonicalTitle": "John Theophilus Desaguliers",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-john-desaguliers",
+        "nodeTitle": "John Theophilus Desaguliers"
+      }
+    ]
+  },
+  "Q653553": {
+    "wikidataId": "Q653553",
+    "wikipediaTitle": "Society_of_Antiquaries_of_London",
+    "canonicalTitle": "Society of Antiquaries of London",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "entity-society-antiquaries",
+        "nodeTitle": "Society of Antiquaries of London"
+      }
+    ]
+  },
+  "Q623586": {
+    "wikidataId": "Q623586",
+    "wikipediaTitle": "Ars_Conjectandi",
+    "canonicalTitle": "Ars Conjectandi",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-ars-conjectandi",
+        "nodeTitle": "Ars Conjectandi"
+      }
+    ]
+  },
+  "Q673175": {
+    "wikidataId": "Q673175",
+    "wikipediaTitle": "Biometrika",
+    "canonicalTitle": "Biometrika",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "entity-biometrika",
+        "nodeTitle": "Biometrika"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q6000000-Q6099999.json
+++ b/public/cross-scene-index/by-wikidata/Q6000000-Q6099999.json
@@ -1,0 +1,15 @@
+{
+  "Q6030770": {
+    "wikidataId": "Q6030770",
+    "wikipediaTitle": "Information_Processing_Techniques_Office",
+    "canonicalTitle": "ARPA Information Processing Techniques Office",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-arpa-ipto",
+        "nodeTitle": "ARPA Information Processing Techniques Office"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q60700000-Q60799999.json
+++ b/public/cross-scene-index/by-wikidata/Q60700000-Q60799999.json
@@ -1,0 +1,54 @@
+{
+  "Q60740282": {
+    "wikidataId": "Q60740282",
+    "wikipediaTitle": "Samy_Bengio",
+    "canonicalTitle": "Samy Bengio",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-samy-bengio",
+        "nodeTitle": "Samy Bengio"
+      }
+    ]
+  },
+  "Q60740345": {
+    "wikidataId": "Q60740345",
+    "wikipediaTitle": "Kyunghyun_Cho",
+    "canonicalTitle": "Kyunghyun Cho",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-kyunghyun-cho",
+        "nodeTitle": "Kyunghyun Cho"
+      }
+    ]
+  },
+  "Q60751127": {
+    "wikidataId": "Q60751127",
+    "wikipediaTitle": "BERT_(language_model)",
+    "canonicalTitle": "BERT",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-bert",
+        "nodeTitle": "BERT"
+      }
+    ]
+  },
+  "Q60767453": {
+    "wikidataId": "Q60767453",
+    "wikipediaTitle": "Theologia_Platonica",
+    "canonicalTitle": "Theologia Platonica (Platonic Theology)",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-theologia-platonica",
+        "nodeTitle": "Theologia Platonica (Platonic Theology)"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q6100000-Q6199999.json
+++ b/public/cross-scene-index/by-wikidata/Q6100000-Q6199999.json
@@ -1,0 +1,54 @@
+{
+  "Q6176204": {
+    "wikidataId": "Q6176204",
+    "wikipediaTitle": "Jeff_Dean",
+    "canonicalTitle": "Jeff Dean",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jeff-dean",
+        "nodeTitle": "Jeff Dean"
+      }
+    ]
+  },
+  "Q6181986": {
+    "wikidataId": "Q6181986",
+    "wikipediaTitle": "Jerome_Pesenti",
+    "canonicalTitle": "Jerome Pesenti",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jerome-pesenti",
+        "nodeTitle": "Jerome Pesenti"
+      }
+    ]
+  },
+  "Q6188046": {
+    "wikidataId": "Q6188046",
+    "wikipediaTitle": "Jesus'_Blood_Never_Failed_Me_Yet",
+    "canonicalTitle": "Jesus' Blood Never Failed Me Yet",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-bryars-jesus-blood",
+        "nodeTitle": "Jesus' Blood Never Failed Me Yet"
+      }
+    ]
+  },
+  "Q6182818": {
+    "wikidataId": "Q6182818",
+    "wikipediaTitle": "Jerome_Lettvin",
+    "canonicalTitle": "Jerome Lettvin",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-jerome-lettvin",
+        "nodeTitle": "Jerome Lettvin"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q6200000-Q6299999.json
+++ b/public/cross-scene-index/by-wikidata/Q6200000-Q6299999.json
@@ -1,0 +1,28 @@
+{
+  "Q6290556": {
+    "wikidataId": "Q6290556",
+    "wikipediaTitle": "Josiah_Macy_Jr._Foundation",
+    "canonicalTitle": "Josiah Macy Jr. Foundation",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-macy-foundation",
+        "nodeTitle": "Josiah Macy Jr. Foundation"
+      }
+    ]
+  },
+  "Q6252938": {
+    "wikidataId": "Q6252938",
+    "wikipediaTitle": "John_Pine",
+    "canonicalTitle": "John Pine",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-john-pine",
+        "nodeTitle": "John Pine"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q6300000-Q6399999.json
+++ b/public/cross-scene-index/by-wikidata/Q6300000-Q6399999.json
@@ -1,0 +1,15 @@
+{
+  "Q6318209": {
+    "wikidataId": "Q6318209",
+    "wikipediaTitle": "Private_Music",
+    "canonicalTitle": "Private Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-private-music",
+        "nodeTitle": "Private Music"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q63400000-Q63499999.json
+++ b/public/cross-scene-index/by-wikidata/Q63400000-Q63499999.json
@@ -1,0 +1,15 @@
+{
+  "Q63405023": {
+    "wikidataId": "Q63405023",
+    "wikipediaTitle": "Distill_(journal)",
+    "canonicalTitle": "Distill.pub",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-distill",
+        "nodeTitle": "Distill.pub"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q64900000-Q64999999.json
+++ b/public/cross-scene-index/by-wikidata/Q64900000-Q64999999.json
@@ -1,0 +1,15 @@
+{
+  "Q64944657": {
+    "wikidataId": "Q64944657",
+    "wikipediaTitle": "John_Schulman_(computer_scientist)",
+    "canonicalTitle": "John Schulman",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-john-schulman",
+        "nodeTitle": "John Schulman"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q65000000-Q65099999.json
+++ b/public/cross-scene-index/by-wikidata/Q65000000-Q65099999.json
@@ -1,0 +1,28 @@
+{
+  "Q65089522": {
+    "wikidataId": "Q65089522",
+    "wikipediaTitle": "GPT-2",
+    "canonicalTitle": "GPT-2",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt2",
+        "nodeTitle": "GPT-2"
+      }
+    ]
+  },
+  "Q65048378": {
+    "wikidataId": "Q65048378",
+    "wikipediaTitle": "Albert_Uttley",
+    "canonicalTitle": "Albert Uttley",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-albert-uttley",
+        "nodeTitle": "Albert Uttley"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q66000000-Q66099999.json
+++ b/public/cross-scene-index/by-wikidata/Q66000000-Q66099999.json
@@ -1,0 +1,15 @@
+{
+  "Q66091709": {
+    "wikidataId": "Q66091709",
+    "wikipediaTitle": "AlphaFold",
+    "canonicalTitle": "AlphaFold 2",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-alphafold2",
+        "nodeTitle": "AlphaFold 2"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q6700000-Q6799999.json
+++ b/public/cross-scene-index/by-wikidata/Q6700000-Q6799999.json
@@ -1,0 +1,15 @@
+{
+  "Q6795393": {
+    "wikidataId": "Q6795393",
+    "wikipediaTitle": "Max_Welling",
+    "canonicalTitle": "Max Welling",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-max-welling",
+        "nodeTitle": "Max Welling"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q6900000-Q6999999.json
+++ b/public/cross-scene-index/by-wikidata/Q6900000-Q6999999.json
@@ -1,0 +1,54 @@
+{
+  "Q6942662": {
+    "wikidataId": "Q6942662",
+    "wikipediaTitle": "Musik_von_Harmonia",
+    "canonicalTitle": "Musik von Harmonia",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-harmonia-musik",
+        "nodeTitle": "Musik von Harmonia"
+      }
+    ]
+  },
+  "Q6969830": {
+    "wikidataId": "Q6969830",
+    "wikipediaTitle": "Nathaniel_Rochester_(computer_scientist)",
+    "canonicalTitle": "Nathaniel Rochester",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-nathaniel-rochester",
+        "nodeTitle": "Nathaniel Rochester"
+      }
+    ]
+  },
+  "Q6908229": {
+    "wikidataId": "Q6908229",
+    "wikipediaTitle": "Moore_School_of_Electrical_Engineering",
+    "canonicalTitle": "Moore School of Electrical Engineering",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-moore-school",
+        "nodeTitle": "Moore School of Electrical Engineering"
+      }
+    ]
+  },
+  "Q6948791": {
+    "wikidataId": "Q6948791",
+    "wikipediaTitle": "Mysterium_Magnum",
+    "canonicalTitle": "Mysterium Magnum",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-mysterium-magnum",
+        "nodeTitle": "Mysterium Magnum"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q700000-Q799999.json
+++ b/public/cross-scene-index/by-wikidata/Q700000-Q799999.json
@@ -1,0 +1,606 @@
+{
+  "Q729390": {
+    "wikidataId": "Q729390",
+    "wikipediaTitle": "Michael_Rother",
+    "canonicalTitle": "Michael Rother",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-michael-rother",
+        "nodeTitle": "Michael Rother"
+      }
+    ]
+  },
+  "Q728029": {
+    "wikidataId": "Q728029",
+    "wikipediaTitle": "Harold_Budd",
+    "canonicalTitle": "Harold Budd",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-harold-budd",
+        "nodeTitle": "Harold Budd"
+      }
+    ]
+  },
+  "Q713939": {
+    "wikidataId": "Q713939",
+    "wikipediaTitle": "Gavin_Bryars",
+    "canonicalTitle": "Gavin Bryars",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-gavin-bryars",
+        "nodeTitle": "Gavin Bryars"
+      }
+    ]
+  },
+  "Q782528": {
+    "wikidataId": "Q782528",
+    "wikipediaTitle": "Jon_Hassell",
+    "canonicalTitle": "Jon Hassell",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-jon-hassell",
+        "nodeTitle": "Jon Hassell"
+      }
+    ]
+  },
+  "Q705221": {
+    "wikidataId": "Q705221",
+    "wikipediaTitle": "Haruomi_Hosono",
+    "canonicalTitle": "Haruomi Hosono",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-haruomi-hosono",
+        "nodeTitle": "Haruomi Hosono"
+      }
+    ]
+  },
+  "Q729361": {
+    "wikidataId": "Q729361",
+    "wikipediaTitle": "Rubycon_(album)",
+    "canonicalTitle": "Rubycon",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-td-rubycon",
+        "nodeTitle": "Rubycon"
+      }
+    ]
+  },
+  "Q771427": {
+    "wikidataId": "Q771427",
+    "wikipediaTitle": "Another_Green_World",
+    "canonicalTitle": "Another Green World",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-another-green-world",
+        "nodeTitle": "Another Green World"
+      }
+    ]
+  },
+  "Q719189": {
+    "wikidataId": "Q719189",
+    "wikipediaTitle": "Super_Ape",
+    "canonicalTitle": "Super Ape",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-perry-super-ape",
+        "nodeTitle": "Super Ape"
+      }
+    ]
+  },
+  "Q734687": {
+    "wikidataId": "Q734687",
+    "wikipediaTitle": "Minimoog",
+    "canonicalTitle": "Minimoog",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-minimoog",
+        "nodeTitle": "Minimoog"
+      }
+    ]
+  },
+  "Q705382": {
+    "wikidataId": "Q705382",
+    "wikipediaTitle": "Cluster_(band)",
+    "canonicalTitle": "Cluster",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-cluster",
+        "nodeTitle": "Cluster"
+      }
+    ]
+  },
+  "Q700817": {
+    "wikidataId": "Q700817",
+    "wikipediaTitle": "Ash_Ra_Tempel",
+    "canonicalTitle": "Ash Ra Tempel",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-ash-ra-tempel",
+        "nodeTitle": "Ash Ra Tempel"
+      }
+    ]
+  },
+  "Q741316": {
+    "wikidataId": "Q741316",
+    "wikipediaTitle": "The_KLF",
+    "canonicalTitle": "The KLF",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-klf",
+        "nodeTitle": "The KLF"
+      }
+    ]
+  },
+  "Q723036": {
+    "wikidataId": "Q723036",
+    "wikipediaTitle": "Guillaume_Postel",
+    "canonicalTitle": "Guillaume Postel",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-guillaume-postel",
+        "nodeTitle": "Guillaume Postel"
+      }
+    ]
+  },
+  "Q702058": {
+    "wikidataId": "Q702058",
+    "wikipediaTitle": "Jakob_van_Hoogstraten",
+    "canonicalTitle": "Jakob van Hoogstraten",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-jakob-hoogstraten",
+        "nodeTitle": "Jakob van Hoogstraten"
+      }
+    ]
+  },
+  "Q711172": {
+    "wikidataId": "Q711172",
+    "wikipediaTitle": "W._Ross_Ashby",
+    "canonicalTitle": "W. Ross Ashby",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ross-ashby",
+        "nodeTitle": "W. Ross Ashby"
+      }
+    ]
+  },
+  "Q796226": {
+    "wikidataId": "Q796226",
+    "wikipediaTitle": "Stafford_Beer",
+    "canonicalTitle": "Stafford Beer",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-stafford-beer",
+        "nodeTitle": "Stafford Beer"
+      }
+    ]
+  },
+  "Q714462": {
+    "wikidataId": "Q714462",
+    "wikipediaTitle": "Hendrik_Wade_Bode",
+    "canonicalTitle": "Hendrik Bode",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-hendrik-bode",
+        "nodeTitle": "Hendrik Bode"
+      }
+    ]
+  },
+  "Q707155": {
+    "wikidataId": "Q707155",
+    "wikipediaTitle": "Max_Newman",
+    "canonicalTitle": "Max Newman",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-max-newman",
+        "nodeTitle": "Max Newman"
+      }
+    ]
+  },
+  "Q705010": {
+    "wikidataId": "Q705010",
+    "wikipediaTitle": "Walter_Pitts",
+    "canonicalTitle": "Walter Pitts",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-walter-pitts",
+        "nodeTitle": "Walter Pitts"
+      }
+    ]
+  },
+  "Q710266": {
+    "wikidataId": "Q710266",
+    "wikipediaTitle": "Arthur_Samuel_(computer_scientist)",
+    "canonicalTitle": "Arthur Samuel",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-arthur-samuel",
+        "nodeTitle": "Arthur Samuel"
+      }
+    ]
+  },
+  "Q724029": {
+    "wikidataId": "Q724029",
+    "wikipediaTitle": "A_Mathematical_Theory_of_Communication",
+    "canonicalTitle": "A Mathematical Theory of Communication",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-information-theory-shannon",
+        "nodeTitle": "A Mathematical Theory of Communication"
+      },
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-math-theory-communication-book",
+        "nodeTitle": "The Mathematical Theory of Communication (book)"
+      }
+    ]
+  },
+  "Q772056": {
+    "wikidataId": "Q772056",
+    "wikipediaTitle": "Computing_Machinery_and_Intelligence",
+    "canonicalTitle": "Computing Machinery and Intelligence",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-computing-machinery-turing",
+        "nodeTitle": "Computing Machinery and Intelligence"
+      }
+    ]
+  },
+  "Q770597": {
+    "wikidataId": "Q770597",
+    "wikipediaTitle": "Colossus_computer",
+    "canonicalTitle": "Colossus",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-colossus",
+        "nodeTitle": "Colossus"
+      }
+    ]
+  },
+  "Q751293": {
+    "wikidataId": "Q751293",
+    "wikipediaTitle": "Café_Procope",
+    "canonicalTitle": "Café Procope",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-cafe-procope",
+        "nodeTitle": "Café Procope"
+      }
+    ]
+  },
+  "Q720932": {
+    "wikidataId": "Q720932",
+    "wikipediaTitle": "John_Argyropoulos",
+    "canonicalTitle": "John Argyropoulos",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-john-argyropoulos",
+        "nodeTitle": "John Argyropoulos"
+      }
+    ]
+  },
+  "Q787046": {
+    "wikidataId": "Q787046",
+    "wikipediaTitle": "Asclepius_(treatise)",
+    "canonicalTitle": "Asclepius",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-asclepius",
+        "nodeTitle": "Asclepius"
+      }
+    ]
+  },
+  "Q710046": {
+    "wikidataId": "Q710046",
+    "wikipediaTitle": "Hugh_Latimer",
+    "canonicalTitle": "Hugh Latimer",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-hugh-latimer",
+        "nodeTitle": "Hugh Latimer"
+      }
+    ]
+  },
+  "Q741030": {
+    "wikidataId": "Q741030",
+    "wikipediaTitle": "Nicholas_Ridley_(martyr)",
+    "canonicalTitle": "Nicholas Ridley",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-nicholas-ridley",
+        "nodeTitle": "Nicholas Ridley"
+      }
+    ]
+  },
+  "Q711332": {
+    "wikidataId": "Q711332",
+    "wikipediaTitle": "Matthew_Parker",
+    "canonicalTitle": "Matthew Parker",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-matthew-parker",
+        "nodeTitle": "Matthew Parker"
+      }
+    ]
+  },
+  "Q708980": {
+    "wikidataId": "Q708980",
+    "wikipediaTitle": "Patrick_Hamilton_(martyr)",
+    "canonicalTitle": "Patrick Hamilton",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-patrick-hamilton",
+        "nodeTitle": "Patrick Hamilton"
+      }
+    ]
+  },
+  "Q703363": {
+    "wikidataId": "Q703363",
+    "wikipediaTitle": "Battle_of_Frankenhausen",
+    "canonicalTitle": "Frankenhausen",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-frankenhausen",
+        "nodeTitle": "Frankenhausen"
+      }
+    ]
+  },
+  "Q730505": {
+    "wikidataId": "Q730505",
+    "wikipediaTitle": "Niccolò_Niccoli",
+    "canonicalTitle": "Niccolò Niccoli",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-niccolo-niccoli",
+        "nodeTitle": "Niccolò Niccoli"
+      }
+    ]
+  },
+  "Q770787": {
+    "wikidataId": "Q770787",
+    "wikipediaTitle": "Giovanni_Aurispa",
+    "canonicalTitle": "Giovanni Aurispa",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giovanni-aurispa",
+        "nodeTitle": "Giovanni Aurispa"
+      }
+    ]
+  },
+  "Q711964": {
+    "wikidataId": "Q711964",
+    "wikipediaTitle": "Cristoforo_Landino",
+    "canonicalTitle": "Cristoforo Landino",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-cristoforo-landino",
+        "nodeTitle": "Cristoforo Landino"
+      }
+    ]
+  },
+  "Q714946": {
+    "wikidataId": "Q714946",
+    "wikipediaTitle": "Giovanni_Pontano",
+    "canonicalTitle": "Giovanni Pontano",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giovanni-pontano",
+        "nodeTitle": "Giovanni Pontano"
+      }
+    ]
+  },
+  "Q731879": {
+    "wikidataId": "Q731879",
+    "wikipediaTitle": "William_Grocyn",
+    "canonicalTitle": "William Grocyn",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-william-grocyn",
+        "nodeTitle": "William Grocyn"
+      }
+    ]
+  },
+  "Q730540": {
+    "wikidataId": "Q730540",
+    "wikipediaTitle": "Thomas_Linacre",
+    "canonicalTitle": "Thomas Linacre",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-thomas-linacre",
+        "nodeTitle": "Thomas Linacre"
+      }
+    ]
+  },
+  "Q725592": {
+    "wikidataId": "Q725592",
+    "wikipediaTitle": "Cuthbert_Tunstall",
+    "canonicalTitle": "Cuthbert Tunstall",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-cuthbert-tunstall",
+        "nodeTitle": "Cuthbert Tunstall"
+      }
+    ]
+  },
+  "Q706796": {
+    "wikidataId": "Q706796",
+    "wikipediaTitle": "Alexander_Hegius",
+    "canonicalTitle": "Alexander Hegius",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-alexander-hegius",
+        "nodeTitle": "Alexander Hegius"
+      }
+    ]
+  },
+  "Q725843": {
+    "wikidataId": "Q725843",
+    "wikipediaTitle": "Vittorino_da_Feltre",
+    "canonicalTitle": "Vittorino da Feltre",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-vittorino-da-feltre",
+        "nodeTitle": "Vittorino da Feltre"
+      }
+    ]
+  },
+  "Q756170": {
+    "wikidataId": "Q756170",
+    "wikipediaTitle": "Devotio_Moderna",
+    "canonicalTitle": "Devotio Moderna",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-devotio-moderna",
+        "nodeTitle": "Devotio Moderna"
+      }
+    ]
+  },
+  "Q773312": {
+    "wikidataId": "Q773312",
+    "wikipediaTitle": "Třeboň",
+    "canonicalTitle": "Třeboň",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-trebon",
+        "nodeTitle": "Třeboň"
+      }
+    ]
+  },
+  "Q710665": {
+    "wikidataId": "Q710665",
+    "wikipediaTitle": "John_Dury",
+    "canonicalTitle": "John Dury",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-john-dury",
+        "nodeTitle": "John Dury"
+      }
+    ]
+  },
+  "Q771349": {
+    "wikidataId": "Q771349",
+    "wikipediaTitle": "Pansophism",
+    "canonicalTitle": "Pansophiae Prodromus",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-pansophiae-prodromus",
+        "nodeTitle": "Pansophiae Prodromus"
+      }
+    ]
+  },
+  "Q720120": {
+    "wikidataId": "Q720120",
+    "wikipediaTitle": "Astronomia_nova",
+    "canonicalTitle": "Astronomia nova",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-astronomia-nova",
+        "nodeTitle": "Astronomia nova"
+      }
+    ]
+  },
+  "Q719623": {
+    "wikidataId": "Q719623",
+    "wikipediaTitle": "Robert_Moray",
+    "canonicalTitle": "Sir Robert Moray",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-robert-moray",
+        "nodeTitle": "Sir Robert Moray"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q7100000-Q7199999.json
+++ b/public/cross-scene-index/by-wikidata/Q7100000-Q7199999.json
@@ -1,0 +1,41 @@
+{
+  "Q7193306": {
+    "wikidataId": "Q7193306",
+    "wikipediaTitle": "Pieter_Abbeel",
+    "canonicalTitle": "Pieter Abbeel",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-pieter-abbeel",
+        "nodeTitle": "Pieter Abbeel"
+      }
+    ]
+  },
+  "Q7177851": {
+    "wikidataId": "Q7177851",
+    "wikipediaTitle": "Peter_Zinovieff",
+    "canonicalTitle": "Peter Zinovieff",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-peter-zinovieff",
+        "nodeTitle": "Peter Zinovieff"
+      }
+    ]
+  },
+  "Q7133818": {
+    "wikidataId": "Q7133818",
+    "wikipediaTitle": "Paracelsianism",
+    "canonicalTitle": "Paracelsianism",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-paracelsianism",
+        "nodeTitle": "Paracelsianism"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q7300000-Q7399999.json
+++ b/public/cross-scene-index/by-wikidata/Q7300000-Q7399999.json
@@ -1,0 +1,41 @@
+{
+  "Q7381579": {
+    "wikidataId": "Q7381579",
+    "wikipediaTitle": "Russ_Salakhutdinov",
+    "canonicalTitle": "Ruslan Salakhutdinov",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-ruslan-salakhutdinov",
+        "nodeTitle": "Ruslan Salakhutdinov"
+      }
+    ]
+  },
+  "Q7330296": {
+    "wikidataId": "Q7330296",
+    "wikipediaTitle": "Richard_S._Sutton",
+    "canonicalTitle": "Richard Sutton",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-richard-sutton",
+        "nodeTitle": "Richard Sutton"
+      }
+    ]
+  },
+  "Q7310217": {
+    "wikidataId": "Q7310217",
+    "wikipediaTitle": "Reinforcement_Learning:_An_Introduction",
+    "canonicalTitle": "Reinforcement Learning: An Introduction",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-rl-book",
+        "nodeTitle": "Reinforcement Learning: An Introduction"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q7400000-Q7499999.json
+++ b/public/cross-scene-index/by-wikidata/Q7400000-Q7499999.json
@@ -1,0 +1,28 @@
+{
+  "Q7407929": {
+    "wikidataId": "Q7407929",
+    "wikipediaTitle": "Sam_Altman",
+    "canonicalTitle": "Sam Altman",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-sam-altman",
+        "nodeTitle": "Sam Altman"
+      }
+    ]
+  },
+  "Q7489091": {
+    "wikidataId": "Q7489091",
+    "wikipediaTitle": "Shane_Legg",
+    "canonicalTitle": "Shane Legg",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-shane-legg",
+        "nodeTitle": "Shane Legg"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q7500000-Q7599999.json
+++ b/public/cross-scene-index/by-wikidata/Q7500000-Q7599999.json
@@ -1,0 +1,28 @@
+{
+  "Q7514348": {
+    "wikidataId": "Q7514348",
+    "wikipediaTitle": "Silence:_Lectures_and_Writings",
+    "canonicalTitle": "Silence",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-cage-silence",
+        "nodeTitle": "Silence"
+      }
+    ]
+  },
+  "Q7534728": {
+    "wikidataId": "Q7534728",
+    "wikipediaTitle": "Sketch_for_a_Historical_Picture_of_the_Progress_of_the_Human_Mind",
+    "canonicalTitle": "Sketch for a Historical Picture of the Progress of the Human Mind",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-sketch-progress",
+        "nodeTitle": "Sketch for a Historical Picture of the Progress of the Human Mind"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q76100000-Q76199999.json
+++ b/public/cross-scene-index/by-wikidata/Q76100000-Q76199999.json
@@ -1,0 +1,15 @@
+{
+  "Q76186012": {
+    "wikidataId": "Q76186012",
+    "wikipediaTitle": "Kling_Klang_Studio",
+    "canonicalTitle": "Kling Klang Studio",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-kling-klang",
+        "nodeTitle": "Kling Klang Studio"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q7700000-Q7799999.json
+++ b/public/cross-scene-index/by-wikidata/Q7700000-Q7799999.json
@@ -1,0 +1,145 @@
+{
+  "Q7755273": {
+    "wikidataId": "Q7755273",
+    "wikipediaTitle": "The_Orb's_Adventures_Beyond_the_Ultraworld",
+    "canonicalTitle": "The Orb's Adventures Beyond the Ultraworld",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-orb-ultraworld",
+        "nodeTitle": "The Orb's Adventures Beyond the Ultraworld"
+      }
+    ]
+  },
+  "Q7781428": {
+    "wikidataId": "Q7781428",
+    "wikipediaTitle": "Theologia_Platonica",
+    "canonicalTitle": "Theologia Platonica",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-theologia-platonica",
+        "nodeTitle": "Theologia Platonica"
+      }
+    ]
+  },
+  "Q7740888": {
+    "wikidataId": "Q7740888",
+    "wikipediaTitle": "The_Human_Use_of_Human_Beings",
+    "canonicalTitle": "The Human Use of Human Beings",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-human-use-wiener",
+        "nodeTitle": "The Human Use of Human Beings"
+      }
+    ]
+  },
+  "Q7727248": {
+    "wikidataId": "Q7727248",
+    "wikipediaTitle": "The_Computer_and_the_Brain",
+    "canonicalTitle": "The Computer and the Brain",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-computer-brain-neumann",
+        "nodeTitle": "The Computer and the Brain"
+      }
+    ]
+  },
+  "Q7739783": {
+    "wikidataId": "Q7739783",
+    "wikipediaTitle": "The_History_of_England_(Hume)",
+    "canonicalTitle": "History of England",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-history-england",
+        "nodeTitle": "History of England"
+      }
+    ]
+  },
+  "Q7757623": {
+    "wikidataId": "Q7757623",
+    "wikipediaTitle": "The_Poker_Club",
+    "canonicalTitle": "Poker Club",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-poker-club",
+        "nodeTitle": "Poker Club"
+      }
+    ]
+  },
+  "Q7754622": {
+    "wikidataId": "Q7754622",
+    "wikipediaTitle": "The_Obedience_of_a_Christian_Man",
+    "canonicalTitle": "The Obedience of a Christian Man",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-obedience-christian-man",
+        "nodeTitle": "The Obedience of a Christian Man"
+      }
+    ]
+  },
+  "Q7777000": {
+    "wikidataId": "Q7777000",
+    "wikipediaTitle": "The_First_Blast_of_the_Trumpet_Against_the_Monstrous_Regiment_of_Women",
+    "canonicalTitle": "First Blast of the Trumpet",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-first-blast",
+        "nodeTitle": "First Blast of the Trumpet"
+      }
+    ]
+  },
+  "Q7790627": {
+    "wikidataId": "Q7790627",
+    "wikipediaTitle": "Thomas_Henshaw_(alchemist)",
+    "canonicalTitle": "Thomas Henshaw",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-thomas-henshaw",
+        "nodeTitle": "Thomas Henshaw"
+      }
+    ]
+  },
+  "Q7726887": {
+    "wikidataId": "Q7726887",
+    "wikipediaTitle": "The_Design_of_Experiments",
+    "canonicalTitle": "The Design of Experiments",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-design-of-experiments",
+        "nodeTitle": "The Design of Experiments"
+      }
+    ]
+  },
+  "Q7734628": {
+    "wikidataId": "Q7734628",
+    "wikipediaTitle": "The_Grammar_of_Science",
+    "canonicalTitle": "The Grammar of Science",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-grammar-of-science",
+        "nodeTitle": "The Grammar of Science"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q7800000-Q7899999.json
+++ b/public/cross-scene-index/by-wikidata/Q7800000-Q7899999.json
@@ -1,0 +1,80 @@
+{
+  "Q7841039": {
+    "wikidataId": "Q7841039",
+    "wikipediaTitle": "Geoffrey_Hinton",
+    "canonicalTitle": "Geoffrey Hinton",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-geoffrey-hinton",
+        "nodeTitle": "Geoffrey Hinton"
+      }
+    ]
+  },
+  "Q7838396": {
+    "wikidataId": "Q7838396",
+    "wikipediaTitle": "Trevor_Blackwell",
+    "canonicalTitle": "Trevor Blackwell",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-trevor-blackwell",
+        "nodeTitle": "Trevor Blackwell"
+      }
+    ]
+  },
+  "Q7831590": {
+    "wikidataId": "Q7831590",
+    "wikipediaTitle": "Tracks_and_Traces",
+    "canonicalTitle": "Tracks and Traces",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-harmonia-tracks-traces",
+        "nodeTitle": "Tracks and Traces"
+      }
+    ]
+  },
+  "Q7854954": {
+    "wikidataId": "Q7854954",
+    "wikipediaTitle": "On_Computable_Numbers,_with_an_Application_to_the_Entscheidungsproblem",
+    "canonicalTitle": "On Computable Numbers, with an Application to the Entscheidungsproblem",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-computable-numbers-turing",
+        "nodeTitle": "On Computable Numbers, with an Application to the Entscheidungsproblem"
+      }
+    ]
+  },
+  "Q7884967": {
+    "wikidataId": "Q7884967",
+    "wikipediaTitle": "Unified_Theories_of_Cognition",
+    "canonicalTitle": "Unified Theories of Cognition",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-unified-theories-newell",
+        "nodeTitle": "Unified Theories of Cognition"
+      }
+    ]
+  },
+  "Q7899795": {
+    "wikidataId": "Q7899795",
+    "wikipediaTitle": "Urania_propitia",
+    "canonicalTitle": "Urania Propitia",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-urania-propitia",
+        "nodeTitle": "Urania Propitia"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q800000-Q899999.json
+++ b/public/cross-scene-index/by-wikidata/Q800000-Q899999.json
@@ -1,0 +1,249 @@
+{
+  "Q862501": {
+    "wikidataId": "Q862501",
+    "wikipediaTitle": "Ondes_Martenot",
+    "canonicalTitle": "Ondes Martenot",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-ondes-martenot",
+        "nodeTitle": "Ondes Martenot"
+      }
+    ]
+  },
+  "Q854590": {
+    "wikidataId": "Q854590",
+    "wikipediaTitle": "Yellow_Magic_Orchestra",
+    "canonicalTitle": "Yellow Magic Orchestra",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-ymo",
+        "nodeTitle": "Yellow Magic Orchestra"
+      }
+    ]
+  },
+  "Q823560": {
+    "wikidataId": "Q823560",
+    "wikipediaTitle": "Musique_concrète",
+    "canonicalTitle": "Musique Concrète",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-musique-concrete",
+        "nodeTitle": "Musique Concrète"
+      }
+    ]
+  },
+  "Q862087": {
+    "wikidataId": "Q862087",
+    "wikipediaTitle": "Corpus_Hermeticum",
+    "canonicalTitle": "Corpus Hermeticum (Latin translation)",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-corpus-hermeticum-translation",
+        "nodeTitle": "Corpus Hermeticum (Latin translation)"
+      }
+    ]
+  },
+  "Q863565": {
+    "wikidataId": "Q863565",
+    "wikipediaTitle": "EDSAC",
+    "canonicalTitle": "EDSAC",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-edsac",
+        "nodeTitle": "EDSAC"
+      }
+    ]
+  },
+  "Q861141": {
+    "wikidataId": "Q861141",
+    "wikipediaTitle": "RAND_Corporation",
+    "canonicalTitle": "RAND Corporation",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-rand",
+        "nodeTitle": "RAND Corporation"
+      }
+    ]
+  },
+  "Q862034": {
+    "wikidataId": "Q862034",
+    "wikipediaTitle": "Rockefeller_Foundation",
+    "canonicalTitle": "Rockefeller Foundation",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-rockefeller-foundation",
+        "nodeTitle": "Rockefeller Foundation"
+      }
+    ]
+  },
+  "Q870851": {
+    "wikidataId": "Q870851",
+    "wikipediaTitle": "Critique_of_Practical_Reason",
+    "canonicalTitle": "Critique of Practical Reason",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-critique-practical-reason",
+        "nodeTitle": "Critique of Practical Reason"
+      }
+    ]
+  },
+  "Q843940": {
+    "wikidataId": "Q843940",
+    "wikipediaTitle": "Common_Sense",
+    "canonicalTitle": "Common Sense",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-common-sense",
+        "nodeTitle": "Common Sense"
+      }
+    ]
+  },
+  "Q858036": {
+    "wikidataId": "Q858036",
+    "wikipediaTitle": "The_Federalist_Papers",
+    "canonicalTitle": "The Federalist Papers",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-federalist-papers",
+        "nodeTitle": "The Federalist Papers"
+      }
+    ]
+  },
+  "Q821914": {
+    "wikidataId": "Q821914",
+    "wikipediaTitle": "Berlinische_Monatsschrift",
+    "canonicalTitle": "Berlinische Monatsschrift",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-berlinische-monatsschrift",
+        "nodeTitle": "Berlinische Monatsschrift"
+      }
+    ]
+  },
+  "Q846306": {
+    "wikidataId": "Q846306",
+    "wikipediaTitle": "De_libero_arbitrio_diatribe_sive_collatio",
+    "canonicalTitle": "On Free Will",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-free-will-erasmus",
+        "nodeTitle": "On Free Will"
+      }
+    ]
+  },
+  "Q855575": {
+    "wikidataId": "Q855575",
+    "wikipediaTitle": "A_Mighty_Fortress_Is_Our_God",
+    "canonicalTitle": "Luther's Hymns",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-luther-hymns",
+        "nodeTitle": "Luther's Hymns"
+      }
+    ]
+  },
+  "Q828750": {
+    "wikidataId": "Q828750",
+    "wikipediaTitle": "Diet_of_Augsburg",
+    "canonicalTitle": "Diet of Augsburg (1530)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-diet-of-augsburg",
+        "nodeTitle": "Diet of Augsburg (1530)"
+      }
+    ]
+  },
+  "Q810966": {
+    "wikidataId": "Q810966",
+    "wikipediaTitle": "Battista_Guarino",
+    "canonicalTitle": "Battista Guarino",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-battista-guarino",
+        "nodeTitle": "Battista Guarino"
+      }
+    ]
+  },
+  "Q820887": {
+    "wikidataId": "Q820887",
+    "wikipediaTitle": "University_of_Florence",
+    "canonicalTitle": "University of Florence (Studio Fiorentino)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-studio-fiorentino",
+        "nodeTitle": "University of Florence (Studio Fiorentino)"
+      }
+    ]
+  },
+  "Q899007": {
+    "wikidataId": "Q899007",
+    "wikipediaTitle": "Oswald_Croll",
+    "canonicalTitle": "Oswald Croll",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-oswald-croll",
+        "nodeTitle": "Oswald Croll"
+      }
+    ]
+  },
+  "Q841173": {
+    "wikidataId": "Q841173",
+    "wikipediaTitle": "Christian_Rosenkreuz",
+    "canonicalTitle": "Christian Rosenkreutz",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-christian-rosenkreutz",
+        "nodeTitle": "Christian Rosenkreutz"
+      }
+    ]
+  },
+  "Q896313": {
+    "wikidataId": "Q896313",
+    "wikipediaTitle": "Göttingen_Observatory",
+    "canonicalTitle": "Göttingen Observatory",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "location-gottingen-observatory",
+        "nodeTitle": "Göttingen Observatory"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q8000000-Q8099999.json
+++ b/public/cross-scene-index/by-wikidata/Q8000000-Q8099999.json
@@ -1,0 +1,28 @@
+{
+  "Q8050866": {
+    "wikidataId": "Q8050866",
+    "wikipediaTitle": "Yee-Whye_Teh",
+    "canonicalTitle": "Yee-Whye Teh",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-yee-whye-teh",
+        "nodeTitle": "Yee-Whye Teh"
+      }
+    ]
+  },
+  "Q8004902": {
+    "wikidataId": "Q8004902",
+    "wikipediaTitle": "William_Backhouse",
+    "canonicalTitle": "William Backhouse",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-william-backhouse",
+        "nodeTitle": "William Backhouse"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q8100000-Q8199999.json
+++ b/public/cross-scene-index/by-wikidata/Q8100000-Q8199999.json
@@ -1,0 +1,15 @@
+{
+  "Q8135341": {
+    "wikidataId": "Q8135341",
+    "wikipediaTitle": "Fourth_World,_Vol._1:_Possible_Musics",
+    "canonicalTitle": "Fourth World Vol. 1: Possible Musics",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-hassell-eno-fourth-world",
+        "nodeTitle": "Fourth World Vol. 1: Possible Musics"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q85700000-Q85799999.json
+++ b/public/cross-scene-index/by-wikidata/Q85700000-Q85799999.json
@@ -1,0 +1,28 @@
+{
+  "Q85787170": {
+    "wikidataId": "Q85787170",
+    "wikipediaTitle": "Music_for_Nine_Post_Cards",
+    "canonicalTitle": "Music for Nine Post Cards",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-yoshimura-postcards",
+        "nodeTitle": "Music for Nine Post Cards"
+      }
+    ]
+  },
+  "Q85748229": {
+    "wikidataId": "Q85748229",
+    "wikipediaTitle": "Book_of_Common_Prayer_(1549)",
+    "canonicalTitle": "Book of Common Prayer (1549)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-bcp-1549",
+        "nodeTitle": "Book of Common Prayer (1549)"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q8900000-Q8999999.json
+++ b/public/cross-scene-index/by-wikidata/Q8900000-Q8999999.json
@@ -1,0 +1,15 @@
+{
+  "Q8991031": {
+    "wikidataId": "Q8991031",
+    "wikipediaTitle": "Fei-Fei_Li",
+    "canonicalTitle": "Fei-Fei Li",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-fei-fei-li",
+        "nodeTitle": "Fei-Fei Li"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q900000-Q999999.json
+++ b/public/cross-scene-index/by-wikidata/Q900000-Q999999.json
@@ -1,0 +1,411 @@
+{
+  "Q973580": {
+    "wikidataId": "Q973580",
+    "wikipediaTitle": "Dieter_Moebius",
+    "canonicalTitle": "Dieter Moebius",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-dieter-moebius",
+        "nodeTitle": "Dieter Moebius"
+      }
+    ]
+  },
+  "Q935369": {
+    "wikidataId": "Q935369",
+    "wikipediaTitle": "Daniel_Lanois",
+    "canonicalTitle": "Daniel Lanois",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-daniel-lanois",
+        "nodeTitle": "Daniel Lanois"
+      }
+    ]
+  },
+  "Q912383": {
+    "wikidataId": "Q912383",
+    "wikipediaTitle": "Furniture_music",
+    "canonicalTitle": "Musique d'ameublement (Furniture Music)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-satie-furniture-music",
+        "nodeTitle": "Musique d'ameublement (Furniture Music)"
+      }
+    ]
+  },
+  "Q958618": {
+    "wikidataId": "Q958618",
+    "wikipediaTitle": "Ambient_4:_On_Land",
+    "canonicalTitle": "Ambient 4: On Land",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-on-land",
+        "nodeTitle": "Ambient 4: On Land"
+      }
+    ]
+  },
+  "Q909592": {
+    "wikidataId": "Q909592",
+    "wikipediaTitle": "Washington_Square_Park",
+    "canonicalTitle": "Washington Square Park",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-washington-square",
+        "nodeTitle": "Washington Square Park"
+      }
+    ]
+  },
+  "Q962366": {
+    "wikidataId": "Q962366",
+    "wikipediaTitle": "Morton_Subotnick",
+    "canonicalTitle": "Morton Subotnick",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-morton-subotnick",
+        "nodeTitle": "Morton Subotnick"
+      }
+    ]
+  },
+  "Q970352": {
+    "wikidataId": "Q970352",
+    "wikipediaTitle": "Selected_Ambient_Works_85–92",
+    "canonicalTitle": "Selected Ambient Works 85-92",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-aphex-saw-85-92",
+        "nodeTitle": "Selected Ambient Works 85-92"
+      }
+    ]
+  },
+  "Q924993": {
+    "wikidataId": "Q924993",
+    "wikipediaTitle": "The_Orb",
+    "canonicalTitle": "The Orb",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-the-orb",
+        "nodeTitle": "The Orb"
+      }
+    ]
+  },
+  "Q954437": {
+    "wikidataId": "Q954437",
+    "wikipediaTitle": "Tommy_Flowers",
+    "canonicalTitle": "Tommy Flowers",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-tommy-flowers",
+        "nodeTitle": "Tommy Flowers"
+      }
+    ]
+  },
+  "Q962174": {
+    "wikidataId": "Q962174",
+    "wikipediaTitle": "Warren_Sturgis_McCulloch",
+    "canonicalTitle": "Warren McCulloch",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-warren-mcculloch",
+        "nodeTitle": "Warren McCulloch"
+      }
+    ]
+  },
+  "Q959763": {
+    "wikidataId": "Q959763",
+    "wikipediaTitle": "C._West_Churchman",
+    "canonicalTitle": "C. West Churchman",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-c-west-churchman",
+        "nodeTitle": "C. West Churchman"
+      }
+    ]
+  },
+  "Q923582": {
+    "wikidataId": "Q923582",
+    "wikipediaTitle": "Francisco_Varela",
+    "canonicalTitle": "Francisco Varela",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-francisco-varela",
+        "nodeTitle": "Francisco Varela"
+      }
+    ]
+  },
+  "Q947485": {
+    "wikidataId": "Q947485",
+    "wikipediaTitle": "Victor_de_Riqueti,_marquis_de_Mirabeau",
+    "canonicalTitle": "Victor de Riqueti, Marquis de Mirabeau",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-mirabeau-elder",
+        "nodeTitle": "Victor de Riqueti, Marquis de Mirabeau"
+      }
+    ]
+  },
+  "Q914139": {
+    "wikidataId": "Q914139",
+    "wikipediaTitle": "A_Letter_Concerning_Toleration",
+    "canonicalTitle": "A Letter Concerning Toleration",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-letter-toleration",
+        "nodeTitle": "A Letter Concerning Toleration"
+      }
+    ]
+  },
+  "Q913599": {
+    "wikidataId": "Q913599",
+    "wikipediaTitle": "Emile,_or_On_Education",
+    "canonicalTitle": "Emile, or On Education",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-emile",
+        "nodeTitle": "Emile, or On Education"
+      }
+    ]
+  },
+  "Q947972": {
+    "wikidataId": "Q947972",
+    "wikipediaTitle": "A_Philosophical_Enquiry_into_the_Origin_of_Our_Ideas_of_the_Sublime_and_Beautiful",
+    "canonicalTitle": "A Philosophical Enquiry into the Sublime and Beautiful",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-sublime-beautiful",
+        "nodeTitle": "A Philosophical Enquiry into the Sublime and Beautiful"
+      }
+    ]
+  },
+  "Q965564": {
+    "wikidataId": "Q965564",
+    "wikipediaTitle": "Dialogues_Concerning_Natural_Religion",
+    "canonicalTitle": "Dialogues Concerning Natural Religion",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-dialogues-natural-religion",
+        "nodeTitle": "Dialogues Concerning Natural Religion"
+      }
+    ]
+  },
+  "Q979108": {
+    "wikidataId": "Q979108",
+    "wikipediaTitle": "Rights_of_Man",
+    "canonicalTitle": "Rights of Man",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-rights-man",
+        "nodeTitle": "Rights of Man"
+      }
+    ]
+  },
+  "Q927072": {
+    "wikidataId": "Q927072",
+    "wikipediaTitle": "Journal_des_sçavans",
+    "canonicalTitle": "Journal des savants",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-journal-savants",
+        "nodeTitle": "Journal des savants"
+      }
+    ]
+  },
+  "Q944027": {
+    "wikidataId": "Q944027",
+    "wikipediaTitle": "Oration_on_the_Dignity_of_Man",
+    "canonicalTitle": "Oration on the Dignity of Man",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-oration-dignity-of-man",
+        "nodeTitle": "Oration on the Dignity of Man"
+      }
+    ]
+  },
+  "Q921618": {
+    "wikidataId": "Q921618",
+    "wikipediaTitle": "Poimandres",
+    "canonicalTitle": "Pimander",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-pimander",
+        "nodeTitle": "Pimander"
+      }
+    ]
+  },
+  "Q957527": {
+    "wikidataId": "Q957527",
+    "wikipediaTitle": "John_Colet",
+    "canonicalTitle": "John Colet",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-colet",
+        "nodeTitle": "John Colet"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-john-colet",
+        "nodeTitle": "John Colet"
+      }
+    ]
+  },
+  "Q967700": {
+    "wikidataId": "Q967700",
+    "wikipediaTitle": "Guillaume_Briçonnet_(cardinal)",
+    "canonicalTitle": "Guillaume Briçonnet",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-guillaume-briconnet",
+        "nodeTitle": "Guillaume Briçonnet"
+      }
+    ]
+  },
+  "Q937617": {
+    "wikidataId": "Q937617",
+    "wikipediaTitle": "Thirty-nine_Articles",
+    "canonicalTitle": "Thirty-Nine Articles",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-thirty-nine-articles",
+        "nodeTitle": "Thirty-Nine Articles"
+      }
+    ]
+  },
+  "Q922480": {
+    "wikidataId": "Q922480",
+    "wikipediaTitle": "Church_of_Scotland",
+    "canonicalTitle": "Church of Scotland (The Kirk)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-church-of-scotland",
+        "nodeTitle": "Church of Scotland (The Kirk)"
+      }
+    ]
+  },
+  "Q948156": {
+    "wikidataId": "Q948156",
+    "wikipediaTitle": "Guillaume_Postel",
+    "canonicalTitle": "Guillaume Postel",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-guillaume-postel",
+        "nodeTitle": "Guillaume Postel"
+      }
+    ]
+  },
+  "Q995950": {
+    "wikidataId": "Q995950",
+    "wikipediaTitle": "Epistolae_familiares",
+    "canonicalTitle": "Epistolae familiares",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-epistolae-familiares",
+        "nodeTitle": "Epistolae familiares"
+      }
+    ]
+  },
+  "Q924424": {
+    "wikidataId": "Q924424",
+    "wikipediaTitle": "Discourses_on_Livy",
+    "canonicalTitle": "Discorsi sopra la prima deca di Tito Livio",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-discorsi-livy",
+        "nodeTitle": "Discorsi sopra la prima deca di Tito Livio"
+      }
+    ]
+  },
+  "Q901303": {
+    "wikidataId": "Q901303",
+    "wikipediaTitle": "Michael_Maier",
+    "canonicalTitle": "Michael Maier",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-michael-maier",
+        "nodeTitle": "Michael Maier"
+      }
+    ]
+  },
+  "Q908061": {
+    "wikidataId": "Q908061",
+    "wikipediaTitle": "Monas_Hieroglyphica",
+    "canonicalTitle": "Monas Hieroglyphica",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-monas-hieroglyphica",
+        "nodeTitle": "Monas Hieroglyphica"
+      }
+    ]
+  },
+  "Q991476": {
+    "wikidataId": "Q991476",
+    "wikipediaTitle": "Udny_Yule",
+    "canonicalTitle": "George Udny Yule",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-george-udny-yule",
+        "nodeTitle": "George Udny Yule"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q90700000-Q90799999.json
+++ b/public/cross-scene-index/by-wikidata/Q90700000-Q90799999.json
@@ -1,0 +1,15 @@
+{
+  "Q90727997": {
+    "wikidataId": "Q90727997",
+    "wikipediaTitle": "Hugging_Face",
+    "canonicalTitle": "Hugging Face",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-huggingface",
+        "nodeTitle": "Hugging Face"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q9300000-Q9399999.json
+++ b/public/cross-scene-index/by-wikidata/Q9300000-Q9399999.json
@@ -1,0 +1,15 @@
+{
+  "Q9381540": {
+    "wikidataId": "Q9381540",
+    "wikipediaTitle": "Andrew_Ng",
+    "canonicalTitle": "Andrew Ng",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-andrew-ng",
+        "nodeTitle": "Andrew Ng"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q97200000-Q97299999.json
+++ b/public/cross-scene-index/by-wikidata/Q97200000-Q97299999.json
@@ -1,0 +1,15 @@
+{
+  "Q97252119": {
+    "wikidataId": "Q97252119",
+    "wikipediaTitle": "GPT-3",
+    "canonicalTitle": "GPT-3",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt3",
+        "nodeTitle": "GPT-3"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikidata/Q97300000-Q97399999.json
+++ b/public/cross-scene-index/by-wikidata/Q97300000-Q97399999.json
@@ -1,0 +1,15 @@
+{
+  "Q97359298": {
+    "wikidataId": "Q97359298",
+    "wikipediaTitle": "An_Introduction_to_Cybernetics",
+    "canonicalTitle": "An Introduction to Cybernetics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-intro-cybernetics-ashby",
+        "nodeTitle": "An Introduction to Cybernetics"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/by-wikipedia/titles.json
+++ b/public/cross-scene-index/by-wikipedia/titles.json
@@ -1,0 +1,16422 @@
+{
+  "Geoffrey_Hinton": {
+    "wikidataId": "Q7841039",
+    "wikipediaTitle": "Geoffrey_Hinton",
+    "canonicalTitle": "Geoffrey Hinton",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-geoffrey-hinton",
+        "nodeTitle": "Geoffrey Hinton"
+      }
+    ]
+  },
+  "Yoshua_Bengio": {
+    "wikidataId": "Q5987936",
+    "wikipediaTitle": "Yoshua_Bengio",
+    "canonicalTitle": "Yoshua Bengio",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-yoshua-bengio",
+        "nodeTitle": "Yoshua Bengio"
+      }
+    ]
+  },
+  "Yann_LeCun": {
+    "wikidataId": "Q1371324",
+    "wikipediaTitle": "Yann_LeCun",
+    "canonicalTitle": "Yann LeCun",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-yann-lecun",
+        "nodeTitle": "Yann LeCun"
+      }
+    ]
+  },
+  "Sam_Altman": {
+    "wikidataId": "Q7407929",
+    "wikipediaTitle": "Sam_Altman",
+    "canonicalTitle": "Sam Altman",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-sam-altman",
+        "nodeTitle": "Sam Altman"
+      }
+    ]
+  },
+  "Elon_Musk": {
+    "wikidataId": "Q317521",
+    "wikipediaTitle": "Elon_Musk",
+    "canonicalTitle": "Elon Musk",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-elon-musk",
+        "nodeTitle": "Elon Musk"
+      }
+    ]
+  },
+  "Ilya_Sutskever": {
+    "wikidataId": "Q28738478",
+    "wikipediaTitle": "Ilya_Sutskever",
+    "canonicalTitle": "Ilya Sutskever",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-ilya-sutskever",
+        "nodeTitle": "Ilya Sutskever"
+      }
+    ]
+  },
+  "Greg_Brockman": {
+    "wikidataId": "Q28733656",
+    "wikipediaTitle": "Greg_Brockman",
+    "canonicalTitle": "Greg Brockman",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-greg-brockman",
+        "nodeTitle": "Greg Brockman"
+      }
+    ]
+  },
+  "Andrej_Karpathy": {
+    "wikidataId": "Q26884227",
+    "wikipediaTitle": "Andrej_Karpathy",
+    "canonicalTitle": "Andrej Karpathy",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-andrej-karpathy",
+        "nodeTitle": "Andrej Karpathy"
+      }
+    ]
+  },
+  "John_Schulman_(computer_scientist)": {
+    "wikidataId": "Q64944657",
+    "wikipediaTitle": "John_Schulman_(computer_scientist)",
+    "canonicalTitle": "John Schulman",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-john-schulman",
+        "nodeTitle": "John Schulman"
+      }
+    ]
+  },
+  "Wojciech_Zaremba": {
+    "wikidataId": "Q55609966",
+    "wikipediaTitle": "Wojciech_Zaremba",
+    "canonicalTitle": "Wojciech Zaremba",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-wojciech-zaremba",
+        "nodeTitle": "Wojciech Zaremba"
+      }
+    ]
+  },
+  "Diederik_P._Kingma": {
+    "wikidataId": "Q56034965",
+    "wikipediaTitle": "Diederik_P._Kingma",
+    "canonicalTitle": "Durk Kingma",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-durk-kingma",
+        "nodeTitle": "Durk Kingma"
+      }
+    ]
+  },
+  "Trevor_Blackwell": {
+    "wikidataId": "Q7838396",
+    "wikipediaTitle": "Trevor_Blackwell",
+    "canonicalTitle": "Trevor Blackwell",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-trevor-blackwell",
+        "nodeTitle": "Trevor Blackwell"
+      }
+    ]
+  },
+  "Mira_Murati": {
+    "wikidataId": "Q110560178",
+    "wikipediaTitle": "Mira_Murati",
+    "canonicalTitle": "Mira Murati",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-mira-murati",
+        "nodeTitle": "Mira Murati"
+      }
+    ]
+  },
+  "Jan_Leike": {
+    "wikidataId": "Q130449908",
+    "wikipediaTitle": "Jan_Leike",
+    "canonicalTitle": "Jan Leike",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jan-leike",
+        "nodeTitle": "Jan Leike"
+      }
+    ]
+  },
+  "Łukasz_Kaiser": {
+    "wikidataId": "Q57430008",
+    "wikipediaTitle": "Łukasz_Kaiser",
+    "canonicalTitle": "Łukasz Kaiser",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-lukasz-kaiser",
+        "nodeTitle": "Łukasz Kaiser"
+      }
+    ]
+  },
+  "Dario_Amodei": {
+    "wikidataId": "Q108741568",
+    "wikipediaTitle": "Dario_Amodei",
+    "canonicalTitle": "Dario Amodei",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-dario-amodei",
+        "nodeTitle": "Dario Amodei"
+      }
+    ]
+  },
+  "Daniela_Amodei": {
+    "wikidataId": "Q108743009",
+    "wikipediaTitle": "Daniela_Amodei",
+    "canonicalTitle": "Daniela Amodei",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-daniela-amodei",
+        "nodeTitle": "Daniela Amodei"
+      }
+    ]
+  },
+  "Jared_Kaplan_(physicist)": {
+    "wikidataId": "Q108742236",
+    "wikipediaTitle": "Jared_Kaplan_(physicist)",
+    "canonicalTitle": "Jared Kaplan",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jared-kaplan",
+        "nodeTitle": "Jared Kaplan"
+      }
+    ]
+  },
+  "Jack_Clark_(AI_researcher)": {
+    "wikidataId": "Q108742779",
+    "wikipediaTitle": "Jack_Clark_(AI_researcher)",
+    "canonicalTitle": "Jack Clark",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jack-clark",
+        "nodeTitle": "Jack Clark"
+      }
+    ]
+  },
+  "Tom_Brown_(AI_researcher)": {
+    "wikidataId": "Q108741880",
+    "wikipediaTitle": "Tom_Brown_(AI_researcher)",
+    "canonicalTitle": "Tom Brown",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-tom-brown",
+        "nodeTitle": "Tom Brown"
+      }
+    ]
+  },
+  "Christopher_Olah": {
+    "wikidataId": "Q108742500",
+    "wikipediaTitle": "Christopher_Olah",
+    "canonicalTitle": "Chris Olah",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-chris-olah",
+        "nodeTitle": "Chris Olah"
+      }
+    ]
+  },
+  "Demis_Hassabis": {
+    "wikidataId": "Q19845246",
+    "wikipediaTitle": "Demis_Hassabis",
+    "canonicalTitle": "Demis Hassabis",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-demis-hassabis",
+        "nodeTitle": "Demis Hassabis"
+      }
+    ]
+  },
+  "Shane_Legg": {
+    "wikidataId": "Q7489091",
+    "wikipediaTitle": "Shane_Legg",
+    "canonicalTitle": "Shane Legg",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-shane-legg",
+        "nodeTitle": "Shane Legg"
+      }
+    ]
+  },
+  "Mustafa_Suleyman": {
+    "wikidataId": "Q30593017",
+    "wikipediaTitle": "Mustafa_Suleyman",
+    "canonicalTitle": "Mustafa Suleyman",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-mustafa-suleyman",
+        "nodeTitle": "Mustafa Suleyman"
+      }
+    ]
+  },
+  "John_Jumper": {
+    "wikidataId": "Q115667430",
+    "wikipediaTitle": "John_Jumper",
+    "canonicalTitle": "John Jumper",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-john-jumper",
+        "nodeTitle": "John Jumper"
+      }
+    ]
+  },
+  "David_Silver_(computer_scientist)": {
+    "wikidataId": "Q23831774",
+    "wikipediaTitle": "David_Silver_(computer_scientist)",
+    "canonicalTitle": "David Silver",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-david-silver",
+        "nodeTitle": "David Silver"
+      }
+    ]
+  },
+  "Aja_Huang": {
+    "wikidataId": "Q23831959",
+    "wikipediaTitle": "Aja_Huang",
+    "canonicalTitle": "Aja Huang",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-aja-huang",
+        "nodeTitle": "Aja Huang"
+      }
+    ]
+  },
+  "Pushmeet_Kohli": {
+    "wikidataId": "Q55641992",
+    "wikipediaTitle": "Pushmeet_Kohli",
+    "canonicalTitle": "Pushmeet Kohli",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-pushmeet-kohli",
+        "nodeTitle": "Pushmeet Kohli"
+      }
+    ]
+  },
+  "Oriol_Vinyals": {
+    "wikidataId": "Q35064943",
+    "wikipediaTitle": "Oriol_Vinyals",
+    "canonicalTitle": "Oriol Vinyals",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-oriol-vinyals",
+        "nodeTitle": "Oriol Vinyals"
+      }
+    ]
+  },
+  "Jeff_Dean": {
+    "wikidataId": "Q6176204",
+    "wikipediaTitle": "Jeff_Dean",
+    "canonicalTitle": "Jeff Dean",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jeff-dean",
+        "nodeTitle": "Jeff Dean"
+      }
+    ]
+  },
+  "Andrew_Ng": {
+    "wikidataId": "Q9381540",
+    "wikipediaTitle": "Andrew_Ng",
+    "canonicalTitle": "Andrew Ng",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-andrew-ng",
+        "nodeTitle": "Andrew Ng"
+      }
+    ]
+  },
+  "Greg_Corrado": {
+    "wikidataId": "Q24709116",
+    "wikipediaTitle": "Greg_Corrado",
+    "canonicalTitle": "Greg Corrado",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-greg-corrado",
+        "nodeTitle": "Greg Corrado"
+      }
+    ]
+  },
+  "Quoc_Viet_Le": {
+    "wikidataId": "Q22908016",
+    "wikipediaTitle": "Quoc_Viet_Le",
+    "canonicalTitle": "Quoc V. Le",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-quoc-le",
+        "nodeTitle": "Quoc V. Le"
+      }
+    ]
+  },
+  "Samy_Bengio": {
+    "wikidataId": "Q60740282",
+    "wikipediaTitle": "Samy_Bengio",
+    "canonicalTitle": "Samy Bengio",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-samy-bengio",
+        "nodeTitle": "Samy Bengio"
+      }
+    ]
+  },
+  "Noam_Shazeer": {
+    "wikidataId": "Q57431260",
+    "wikipediaTitle": "Noam_Shazeer",
+    "canonicalTitle": "Noam Shazeer",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-noam-shazeer",
+        "nodeTitle": "Noam Shazeer"
+      }
+    ]
+  },
+  "Ashish_Vaswani": {
+    "wikidataId": "Q56062424",
+    "wikipediaTitle": "Ashish_Vaswani",
+    "canonicalTitle": "Ashish Vaswani",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-ashish-vaswani",
+        "nodeTitle": "Ashish Vaswani"
+      }
+    ]
+  },
+  "Jakob_Uszkoreit": {
+    "wikidataId": "Q57430055",
+    "wikipediaTitle": "Jakob_Uszkoreit",
+    "canonicalTitle": "Jakob Uszkoreit",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jakob-uszkoreit",
+        "nodeTitle": "Jakob Uszkoreit"
+      }
+    ]
+  },
+  "Llion_Jones": {
+    "wikidataId": "Q57430117",
+    "wikipediaTitle": "Llion_Jones",
+    "canonicalTitle": "Llion Jones",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-llion-jones",
+        "nodeTitle": "Llion Jones"
+      }
+    ]
+  },
+  "Aidan_Gomez": {
+    "wikidataId": "Q57430148",
+    "wikipediaTitle": "Aidan_Gomez",
+    "canonicalTitle": "Aidan Gomez",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-aidan-gomez",
+        "nodeTitle": "Aidan Gomez"
+      }
+    ]
+  },
+  "Illia_Polosukhin": {
+    "wikidataId": "Q57430190",
+    "wikipediaTitle": "Illia_Polosukhin",
+    "canonicalTitle": "Illia Polosukhin",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-illia-polosukhin",
+        "nodeTitle": "Illia Polosukhin"
+      }
+    ]
+  },
+  "Alex_Krizhevsky": {
+    "wikidataId": "Q22078899",
+    "wikipediaTitle": "Alex_Krizhevsky",
+    "canonicalTitle": "Alex Krizhevsky",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-alex-krizhevsky",
+        "nodeTitle": "Alex Krizhevsky"
+      }
+    ]
+  },
+  "Russ_Salakhutdinov": {
+    "wikidataId": "Q7381579",
+    "wikipediaTitle": "Russ_Salakhutdinov",
+    "canonicalTitle": "Ruslan Salakhutdinov",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-ruslan-salakhutdinov",
+        "nodeTitle": "Ruslan Salakhutdinov"
+      }
+    ]
+  },
+  "Yee-Whye_Teh": {
+    "wikidataId": "Q8050866",
+    "wikipediaTitle": "Yee-Whye_Teh",
+    "canonicalTitle": "Yee-Whye Teh",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-yee-whye-teh",
+        "nodeTitle": "Yee-Whye Teh"
+      }
+    ]
+  },
+  "Ian_Goodfellow": {
+    "wikidataId": "Q27311979",
+    "wikipediaTitle": "Ian_Goodfellow",
+    "canonicalTitle": "Ian Goodfellow",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-ian-goodfellow",
+        "nodeTitle": "Ian Goodfellow"
+      }
+    ]
+  },
+  "Aaron_Courville": {
+    "wikidataId": "Q27312191",
+    "wikipediaTitle": "Aaron_Courville",
+    "canonicalTitle": "Aaron Courville",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-aaron-courville",
+        "nodeTitle": "Aaron Courville"
+      }
+    ]
+  },
+  "Kyunghyun_Cho": {
+    "wikidataId": "Q60740345",
+    "wikipediaTitle": "Kyunghyun_Cho",
+    "canonicalTitle": "Kyunghyun Cho",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-kyunghyun-cho",
+        "nodeTitle": "Kyunghyun Cho"
+      }
+    ]
+  },
+  "Doina_Precup": {
+    "wikidataId": "Q29039302",
+    "wikipediaTitle": "Doina_Precup",
+    "canonicalTitle": "Doina Precup",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-doina-precup",
+        "nodeTitle": "Doina Precup"
+      }
+    ]
+  },
+  "Fei-Fei_Li": {
+    "wikidataId": "Q8991031",
+    "wikipediaTitle": "Fei-Fei_Li",
+    "canonicalTitle": "Fei-Fei Li",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-fei-fei-li",
+        "nodeTitle": "Fei-Fei Li"
+      }
+    ]
+  },
+  "Pieter_Abbeel": {
+    "wikidataId": "Q7193306",
+    "wikipediaTitle": "Pieter_Abbeel",
+    "canonicalTitle": "Pieter Abbeel",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-pieter-abbeel",
+        "nodeTitle": "Pieter Abbeel"
+      }
+    ]
+  },
+  "Daphne_Koller": {
+    "wikidataId": "Q450599",
+    "wikipediaTitle": "Daphne_Koller",
+    "canonicalTitle": "Daphne Koller",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-daphne-koller",
+        "nodeTitle": "Daphne Koller"
+      }
+    ]
+  },
+  "Timnit_Gebru": {
+    "wikidataId": "Q47488089",
+    "wikipediaTitle": "Timnit_Gebru",
+    "canonicalTitle": "Timnit Gebru",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-timnit-gebru",
+        "nodeTitle": "Timnit Gebru"
+      }
+    ]
+  },
+  "Olga_Russakovsky": {
+    "wikidataId": "Q21545259",
+    "wikipediaTitle": "Olga_Russakovsky",
+    "canonicalTitle": "Olga Russakovsky",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-olga-russakovsky",
+        "nodeTitle": "Olga Russakovsky"
+      }
+    ]
+  },
+  "Richard_Socher": {
+    "wikidataId": "Q25460599",
+    "wikipediaTitle": "Richard_Socher",
+    "canonicalTitle": "Richard Socher",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-richard-socher",
+        "nodeTitle": "Richard Socher"
+      }
+    ]
+  },
+  "Joelle_Pineau": {
+    "wikidataId": "Q56603936",
+    "wikipediaTitle": "Joelle_Pineau",
+    "canonicalTitle": "Joelle Pineau",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-joelle-pineau",
+        "nodeTitle": "Joelle Pineau"
+      }
+    ]
+  },
+  "Jerome_Pesenti": {
+    "wikidataId": "Q6181986",
+    "wikipediaTitle": "Jerome_Pesenti",
+    "canonicalTitle": "Jerome Pesenti",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jerome-pesenti",
+        "nodeTitle": "Jerome Pesenti"
+      }
+    ]
+  },
+  "Guillaume_Lample": {
+    "wikidataId": "Q118283055",
+    "wikipediaTitle": "Guillaume_Lample",
+    "canonicalTitle": "Guillaume Lample",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-guillaume-lample",
+        "nodeTitle": "Guillaume Lample"
+      }
+    ]
+  },
+  "Arthur_Mensch": {
+    "wikidataId": "Q118282911",
+    "wikipediaTitle": "Arthur_Mensch",
+    "canonicalTitle": "Arthur Mensch",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-arthur-mensch",
+        "nodeTitle": "Arthur Mensch"
+      }
+    ]
+  },
+  "Christian_Szegedy": {
+    "wikidataId": "Q21167448",
+    "wikipediaTitle": "Christian_Szegedy",
+    "canonicalTitle": "Christian Szegedy",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-christian-szegedy",
+        "nodeTitle": "Christian Szegedy"
+      }
+    ]
+  },
+  "Jimmy_Ba": {
+    "wikidataId": "Q115591629",
+    "wikipediaTitle": "Jimmy_Ba",
+    "canonicalTitle": "Jimmy Ba",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-jimmy-ba",
+        "nodeTitle": "Jimmy Ba"
+      }
+    ]
+  },
+  "Clem_Delangue": {
+    "wikidataId": "Q117270377",
+    "wikipediaTitle": "Clem_Delangue",
+    "canonicalTitle": "Clément Delangue",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-clement-delangue",
+        "nodeTitle": "Clément Delangue"
+      }
+    ]
+  },
+  "Margaret_Mitchell_(scientist)": {
+    "wikidataId": "Q106409817",
+    "wikipediaTitle": "Margaret_Mitchell_(scientist)",
+    "canonicalTitle": "Margaret Mitchell",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-margaret-mitchell",
+        "nodeTitle": "Margaret Mitchell"
+      }
+    ]
+  },
+  "Emad_Mostaque": {
+    "wikidataId": "Q113414756",
+    "wikipediaTitle": "Emad_Mostaque",
+    "canonicalTitle": "Emad Mostaque",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-emad-mostaque",
+        "nodeTitle": "Emad Mostaque"
+      }
+    ]
+  },
+  "Robin_Rombach": {
+    "wikidataId": "Q113500048",
+    "wikipediaTitle": "Robin_Rombach",
+    "canonicalTitle": "Robin Rombach",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-robin-rombach",
+        "nodeTitle": "Robin Rombach"
+      }
+    ]
+  },
+  "Richard_S._Sutton": {
+    "wikidataId": "Q7330296",
+    "wikipediaTitle": "Richard_S._Sutton",
+    "canonicalTitle": "Richard Sutton",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-richard-sutton",
+        "nodeTitle": "Richard Sutton"
+      }
+    ]
+  },
+  "Michael_I._Jordan": {
+    "wikidataId": "Q1927926",
+    "wikipediaTitle": "Michael_I._Jordan",
+    "canonicalTitle": "Michael I. Jordan",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-michael-jordan",
+        "nodeTitle": "Michael I. Jordan"
+      }
+    ]
+  },
+  "David_Ha_(computer_scientist)": {
+    "wikidataId": "Q126330684",
+    "wikipediaTitle": "David_Ha_(computer_scientist)",
+    "canonicalTitle": "David Ha",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-david-ha",
+        "nodeTitle": "David Ha"
+      }
+    ]
+  },
+  "Percy_Liang": {
+    "wikidataId": "Q56677851",
+    "wikipediaTitle": "Percy_Liang",
+    "canonicalTitle": "Percy Liang",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-percy-liang",
+        "nodeTitle": "Percy Liang"
+      }
+    ]
+  },
+  "Attention_Is_All_You_Need": {
+    "wikidataId": "Q108765213",
+    "wikipediaTitle": "Attention_Is_All_You_Need",
+    "canonicalTitle": "Attention Is All You Need",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-transformer-paper",
+        "nodeTitle": "Attention Is All You Need"
+      }
+    ]
+  },
+  "AlexNet": {
+    "wikidataId": "Q16520311",
+    "wikipediaTitle": "AlexNet",
+    "canonicalTitle": "ImageNet Classification with Deep Convolutional Neural Networks",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-alexnet-paper",
+        "nodeTitle": "ImageNet Classification with Deep Convolutional Neural Networks"
+      }
+    ]
+  },
+  "Generative_adversarial_network": {
+    "wikidataId": "Q25347847",
+    "wikipediaTitle": "Generative_adversarial_network",
+    "canonicalTitle": "Generative Adversarial Networks",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gan-paper",
+        "nodeTitle": "Generative Adversarial Networks"
+      }
+    ]
+  },
+  "Dropout_(neural_networks)": {
+    "wikidataId": "Q26903314",
+    "wikipediaTitle": "Dropout_(neural_networks)",
+    "canonicalTitle": "Dropout: A Simple Way to Prevent Neural Networks from Overfitting",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-dropout-paper",
+        "nodeTitle": "Dropout: A Simple Way to Prevent Neural Networks from Overfitting"
+      }
+    ]
+  },
+  "GPT-1": {
+    "wikidataId": "Q115646799",
+    "wikipediaTitle": "GPT-1",
+    "canonicalTitle": "GPT-1",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt1",
+        "nodeTitle": "GPT-1"
+      }
+    ]
+  },
+  "GPT-2": {
+    "wikidataId": "Q65089522",
+    "wikipediaTitle": "GPT-2",
+    "canonicalTitle": "GPT-2",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt2",
+        "nodeTitle": "GPT-2"
+      }
+    ]
+  },
+  "GPT-3": {
+    "wikidataId": "Q97252119",
+    "wikipediaTitle": "GPT-3",
+    "canonicalTitle": "GPT-3",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt3",
+        "nodeTitle": "GPT-3"
+      }
+    ]
+  },
+  "GPT-4": {
+    "wikidataId": "Q116709893",
+    "wikipediaTitle": "GPT-4",
+    "canonicalTitle": "GPT-4",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt4",
+        "nodeTitle": "GPT-4"
+      }
+    ]
+  },
+  "ChatGPT": {
+    "wikidataId": "Q115035180",
+    "wikipediaTitle": "ChatGPT",
+    "canonicalTitle": "ChatGPT",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-chatgpt",
+        "nodeTitle": "ChatGPT"
+      }
+    ]
+  },
+  "DALL-E": {
+    "wikidataId": "Q104831864",
+    "wikipediaTitle": "DALL-E",
+    "canonicalTitle": "DALL-E",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-dalle",
+        "nodeTitle": "DALL-E"
+      }
+    ]
+  },
+  "CLIP_(language_model)": {
+    "wikidataId": "Q120206584",
+    "wikipediaTitle": "CLIP_(language_model)",
+    "canonicalTitle": "CLIP",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-clip",
+        "nodeTitle": "CLIP"
+      }
+    ]
+  },
+  "OpenAI_Codex": {
+    "wikidataId": "Q107588589",
+    "wikipediaTitle": "OpenAI_Codex",
+    "canonicalTitle": "Codex / GitHub Copilot",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-codex",
+        "nodeTitle": "Codex / GitHub Copilot"
+      }
+    ]
+  },
+  "Claude_(language_model)": {
+    "wikidataId": "Q116965708",
+    "wikipediaTitle": "Claude_(language_model)",
+    "canonicalTitle": "Claude",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-claude",
+        "nodeTitle": "Claude"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-claude3",
+        "nodeTitle": "Claude 3"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-claude35-sonnet",
+        "nodeTitle": "Claude 3.5 Sonnet"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-claude4",
+        "nodeTitle": "Claude 4"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-claude45",
+        "nodeTitle": "Claude 4.5"
+      }
+    ]
+  },
+  "Constitutional_AI": {
+    "wikidataId": "Q120201695",
+    "wikipediaTitle": "Constitutional_AI",
+    "canonicalTitle": "Constitutional AI Paper",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-constitutional-ai",
+        "nodeTitle": "Constitutional AI Paper"
+      }
+    ]
+  },
+  "Neural_scaling_law": {
+    "wikidataId": "Q110561437",
+    "wikipediaTitle": "Neural_scaling_law",
+    "canonicalTitle": "Scaling Laws for Neural Language Models",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-scaling-laws",
+        "nodeTitle": "Scaling Laws for Neural Language Models"
+      }
+    ]
+  },
+  "Llama_(language_model)": {
+    "wikidataId": "Q117276906",
+    "wikipediaTitle": "Llama_(language_model)",
+    "canonicalTitle": "LLaMA",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama",
+        "nodeTitle": "LLaMA"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama2",
+        "nodeTitle": "LLaMA 2"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama3",
+        "nodeTitle": "LLaMA 3"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama31",
+        "nodeTitle": "LLaMA 3.1"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama32",
+        "nodeTitle": "LLaMA 3.2"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama33",
+        "nodeTitle": "LLaMA 3.3"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-llama4",
+        "nodeTitle": "LLaMA 4"
+      }
+    ]
+  },
+  "Code_Llama": {
+    "wikidataId": "Q120696689",
+    "wikipediaTitle": "Code_Llama",
+    "canonicalTitle": "Code Llama",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-code-llama",
+        "nodeTitle": "Code Llama"
+      }
+    ]
+  },
+  "AlphaGo": {
+    "wikidataId": "Q19829553",
+    "wikipediaTitle": "AlphaGo",
+    "canonicalTitle": "AlphaGo",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-alphago",
+        "nodeTitle": "AlphaGo"
+      }
+    ]
+  },
+  "AlphaFold": {
+    "wikidataId": "Q66091709",
+    "wikipediaTitle": "AlphaFold",
+    "canonicalTitle": "AlphaFold 2",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-alphafold2",
+        "nodeTitle": "AlphaFold 2"
+      }
+    ]
+  },
+  "Gemini_(chatbot)": {
+    "wikidataId": "Q118389636",
+    "wikipediaTitle": "Gemini_(chatbot)",
+    "canonicalTitle": "Gemini",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gemini",
+        "nodeTitle": "Gemini"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gemini15",
+        "nodeTitle": "Gemini 1.5 Pro"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gemini20",
+        "nodeTitle": "Gemini 2.0"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gemini25",
+        "nodeTitle": "Gemini 2.5"
+      }
+    ]
+  },
+  "TensorFlow": {
+    "wikidataId": "Q21447974",
+    "wikipediaTitle": "TensorFlow",
+    "canonicalTitle": "TensorFlow",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-tensorflow",
+        "nodeTitle": "TensorFlow"
+      }
+    ]
+  },
+  "BERT_(language_model)": {
+    "wikidataId": "Q60751127",
+    "wikipediaTitle": "BERT_(language_model)",
+    "canonicalTitle": "BERT",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-bert",
+        "nodeTitle": "BERT"
+      }
+    ]
+  },
+  "Word2vec": {
+    "wikidataId": "Q18685271",
+    "wikipediaTitle": "Word2vec",
+    "canonicalTitle": "Word2Vec",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-word2vec",
+        "nodeTitle": "Word2Vec"
+      }
+    ]
+  },
+  "Mistral_AI#Models": {
+    "wikidataId": "Q118473029",
+    "wikipediaTitle": "Mistral_AI#Models",
+    "canonicalTitle": "Mistral 7B",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-mistral-7b",
+        "nodeTitle": "Mistral 7B"
+      }
+    ]
+  },
+  "Stable_Diffusion": {
+    "wikidataId": "Q113414728",
+    "wikipediaTitle": "Stable_Diffusion",
+    "canonicalTitle": "Stable Diffusion",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-stable-diffusion",
+        "nodeTitle": "Stable Diffusion"
+      }
+    ]
+  },
+  "Grok_(chatbot)": {
+    "wikidataId": "Q122645637",
+    "wikipediaTitle": "Grok_(chatbot)",
+    "canonicalTitle": "Grok",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-grok",
+        "nodeTitle": "Grok"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-grok2",
+        "nodeTitle": "Grok 2"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-grok3",
+        "nodeTitle": "Grok 3"
+      }
+    ]
+  },
+  "Deep_Learning_(book)": {
+    "wikidataId": "Q28153721",
+    "wikipediaTitle": "Deep_Learning_(book)",
+    "canonicalTitle": "Deep Learning Textbook",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-deep-learning-book",
+        "nodeTitle": "Deep Learning Textbook"
+      }
+    ]
+  },
+  "Reinforcement_Learning:_An_Introduction": {
+    "wikidataId": "Q7310217",
+    "wikipediaTitle": "Reinforcement_Learning:_An_Introduction",
+    "canonicalTitle": "Reinforcement Learning: An Introduction",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-rl-book",
+        "nodeTitle": "Reinforcement Learning: An Introduction"
+      }
+    ]
+  },
+  "Distill_(journal)": {
+    "wikidataId": "Q63405023",
+    "wikipediaTitle": "Distill_(journal)",
+    "canonicalTitle": "Distill.pub",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-distill",
+        "nodeTitle": "Distill.pub"
+      }
+    ]
+  },
+  "New_York_City": {
+    "wikidataId": "Q60",
+    "wikipediaTitle": "New_York_City",
+    "canonicalTitle": "New York City, New York",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-new-york",
+        "nodeTitle": "New York City, New York"
+      },
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-new-york",
+        "nodeTitle": "New York City"
+      }
+    ]
+  },
+  "New_York_University": {
+    "wikidataId": "Q49210",
+    "wikipediaTitle": "New_York_University",
+    "canonicalTitle": "New York University",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-nyu",
+        "nodeTitle": "New York University"
+      }
+    ]
+  },
+  "San_Francisco": {
+    "wikidataId": "Q62",
+    "wikipediaTitle": "San_Francisco",
+    "canonicalTitle": "San Francisco, California",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-san-francisco",
+        "nodeTitle": "San Francisco, California"
+      }
+    ]
+  },
+  "Mountain_View,_California": {
+    "wikidataId": "Q486860",
+    "wikipediaTitle": "Mountain_View,_California",
+    "canonicalTitle": "Mountain View, California",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-mountain-view",
+        "nodeTitle": "Mountain View, California"
+      }
+    ]
+  },
+  "London": {
+    "wikidataId": "Q84",
+    "wikipediaTitle": "London",
+    "canonicalTitle": "London, United Kingdom",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-london",
+        "nodeTitle": "London, United Kingdom"
+      },
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-london",
+        "nodeTitle": "London"
+      },
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "loc-london",
+        "nodeTitle": "London"
+      }
+    ]
+  },
+  "Paris": {
+    "wikidataId": "Q90",
+    "wikipediaTitle": "Paris",
+    "canonicalTitle": "Paris, France",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris, France"
+      },
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-paris",
+        "nodeTitle": "Paris"
+      },
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-paris",
+        "nodeTitle": "Paris"
+      }
+    ]
+  },
+  "Toronto": {
+    "wikidataId": "Q172",
+    "wikipediaTitle": "Toronto",
+    "canonicalTitle": "Toronto, Canada",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-toronto",
+        "nodeTitle": "Toronto, Canada"
+      }
+    ]
+  },
+  "Montreal": {
+    "wikidataId": "Q340",
+    "wikipediaTitle": "Montreal",
+    "canonicalTitle": "Montreal, Canada",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-montreal",
+        "nodeTitle": "Montreal, Canada"
+      }
+    ]
+  },
+  "Stanford_University": {
+    "wikidataId": "Q41506",
+    "wikipediaTitle": "Stanford_University",
+    "canonicalTitle": "Stanford University",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-stanford",
+        "nodeTitle": "Stanford University"
+      },
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-stanford",
+        "nodeTitle": "Stanford University"
+      }
+    ]
+  },
+  "University_of_Toronto": {
+    "wikidataId": "Q180865",
+    "wikipediaTitle": "University_of_Toronto",
+    "canonicalTitle": "University of Toronto",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-utoronto",
+        "nodeTitle": "University of Toronto"
+      }
+    ]
+  },
+  "Université_de_Montréal": {
+    "wikidataId": "Q392189",
+    "wikipediaTitle": "Université_de_Montréal",
+    "canonicalTitle": "Université de Montréal",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-umontreal",
+        "nodeTitle": "Université de Montréal"
+      }
+    ]
+  },
+  "University_of_California,_Berkeley": {
+    "wikidataId": "Q168756",
+    "wikipediaTitle": "University_of_California,_Berkeley",
+    "canonicalTitle": "UC Berkeley",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-ucberkeley",
+        "nodeTitle": "UC Berkeley"
+      }
+    ]
+  },
+  "Carnegie_Mellon_University": {
+    "wikidataId": "Q190080",
+    "wikipediaTitle": "Carnegie_Mellon_University",
+    "canonicalTitle": "Carnegie Mellon University",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-cmu",
+        "nodeTitle": "Carnegie Mellon University"
+      },
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-carnegie-mellon",
+        "nodeTitle": "Carnegie Mellon University"
+      }
+    ]
+  },
+  "Tokyo": {
+    "wikidataId": "Q1490",
+    "wikipediaTitle": "Tokyo",
+    "canonicalTitle": "Tokyo, Japan",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-tokyo",
+        "nodeTitle": "Tokyo, Japan"
+      },
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-tokyo",
+        "nodeTitle": "Tokyo"
+      }
+    ]
+  },
+  "Edmonton": {
+    "wikidataId": "Q2096",
+    "wikipediaTitle": "Edmonton",
+    "canonicalTitle": "Edmonton, Canada",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-edmonton",
+        "nodeTitle": "Edmonton, Canada"
+      }
+    ]
+  },
+  "University_of_Alberta": {
+    "wikidataId": "Q38948",
+    "wikipediaTitle": "University_of_Alberta",
+    "canonicalTitle": "University of Alberta",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-ualberta",
+        "nodeTitle": "University of Alberta"
+      }
+    ]
+  },
+  "OpenAI": {
+    "wikidataId": "Q21708200",
+    "wikipediaTitle": "OpenAI",
+    "canonicalTitle": "OpenAI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-openai",
+        "nodeTitle": "OpenAI"
+      }
+    ]
+  },
+  "Anthropic": {
+    "wikidataId": "Q106006054",
+    "wikipediaTitle": "Anthropic",
+    "canonicalTitle": "Anthropic",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-anthropic",
+        "nodeTitle": "Anthropic"
+      }
+    ]
+  },
+  "Google_DeepMind": {
+    "wikidataId": "Q118358654",
+    "wikipediaTitle": "Google_DeepMind",
+    "canonicalTitle": "Google DeepMind",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-google-deepmind",
+        "nodeTitle": "Google DeepMind"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-deepmind",
+        "nodeTitle": "DeepMind"
+      }
+    ]
+  },
+  "Google_Brain": {
+    "wikidataId": "Q21072607",
+    "wikipediaTitle": "Google_Brain",
+    "canonicalTitle": "Google Brain",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-google-brain",
+        "nodeTitle": "Google Brain"
+      }
+    ]
+  },
+  "Meta_AI": {
+    "wikidataId": "Q19600170",
+    "wikipediaTitle": "Meta_AI",
+    "canonicalTitle": "Meta AI / FAIR",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-meta-ai",
+        "nodeTitle": "Meta AI / FAIR"
+      }
+    ]
+  },
+  "XAI_(company)": {
+    "wikidataId": "Q120303340",
+    "wikipediaTitle": "XAI_(company)",
+    "canonicalTitle": "xAI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-xai",
+        "nodeTitle": "xAI"
+      }
+    ]
+  },
+  "Mistral_AI": {
+    "wikidataId": "Q118473029",
+    "wikipediaTitle": "Mistral_AI",
+    "canonicalTitle": "Mistral AI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-mistral",
+        "nodeTitle": "Mistral AI"
+      }
+    ]
+  },
+  "Hugging_Face": {
+    "wikidataId": "Q90727997",
+    "wikipediaTitle": "Hugging_Face",
+    "canonicalTitle": "Hugging Face",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-huggingface",
+        "nodeTitle": "Hugging Face"
+      }
+    ]
+  },
+  "Stability_AI": {
+    "wikidataId": "Q113414756",
+    "wikipediaTitle": "Stability_AI",
+    "canonicalTitle": "Stability AI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-stability",
+        "nodeTitle": "Stability AI"
+      }
+    ]
+  },
+  "Cohere": {
+    "wikidataId": "Q117181040",
+    "wikipediaTitle": "Cohere",
+    "canonicalTitle": "Cohere",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-cohere",
+        "nodeTitle": "Cohere"
+      }
+    ]
+  },
+  "Sakana_AI": {
+    "wikidataId": "Q121668234",
+    "wikipediaTitle": "Sakana_AI",
+    "canonicalTitle": "Sakana AI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-sakana",
+        "nodeTitle": "Sakana AI"
+      }
+    ]
+  },
+  "Mila_(research_institute)": {
+    "wikidataId": "Q29056997",
+    "wikipediaTitle": "Mila_(research_institute)",
+    "canonicalTitle": "MILA",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-mila",
+        "nodeTitle": "MILA"
+      }
+    ]
+  },
+  "Vector_Institute": {
+    "wikidataId": "Q39076395",
+    "wikipediaTitle": "Vector_Institute",
+    "canonicalTitle": "Vector Institute",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-vector-institute",
+        "nodeTitle": "Vector Institute"
+      }
+    ]
+  },
+  "Stanford_Institute_for_Human-Centered_AI": {
+    "wikidataId": "Q106481889",
+    "wikipediaTitle": "Stanford_Institute_for_Human-Centered_AI",
+    "canonicalTitle": "Stanford HAI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-stanford-hai",
+        "nodeTitle": "Stanford HAI"
+      }
+    ]
+  },
+  "Conference_on_Neural_Information_Processing_Systems": {
+    "wikidataId": "Q2016462",
+    "wikipediaTitle": "Conference_on_Neural_Information_Processing_Systems",
+    "canonicalTitle": "NeurIPS",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-neurips",
+        "nodeTitle": "NeurIPS"
+      }
+    ]
+  },
+  "International_Conference_on_Learning_Representations": {
+    "wikidataId": "Q57085111",
+    "wikipediaTitle": "International_Conference_on_Learning_Representations",
+    "canonicalTitle": "ICLR",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-iclr",
+        "nodeTitle": "ICLR"
+      }
+    ]
+  },
+  "Safe_Superintelligence_Inc.": {
+    "wikidataId": "Q126055790",
+    "wikipediaTitle": "Safe_Superintelligence_Inc.",
+    "canonicalTitle": "Safe Superintelligence Inc.",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-ssi",
+        "nodeTitle": "Safe Superintelligence Inc."
+      }
+    ]
+  },
+  "Distributed_Artificial_Intelligence_Research_Institute": {
+    "wikidataId": "Q110131254",
+    "wikipediaTitle": "Distributed_Artificial_Intelligence_Research_Institute",
+    "canonicalTitle": "DAIR Institute",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-dair",
+        "nodeTitle": "DAIR Institute"
+      }
+    ]
+  },
+  "Tomáš_Mikolov": {
+    "wikidataId": "Q21658269",
+    "wikipediaTitle": "Tomáš_Mikolov",
+    "canonicalTitle": "Tomas Mikolov",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-tomas-mikolov",
+        "nodeTitle": "Tomas Mikolov"
+      }
+    ]
+  },
+  "Max_Welling": {
+    "wikidataId": "Q6795393",
+    "wikipediaTitle": "Max_Welling",
+    "canonicalTitle": "Max Welling",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "person-max-welling",
+        "nodeTitle": "Max Welling"
+      }
+    ]
+  },
+  "Variational_autoencoder": {
+    "wikidataId": "Q25348086",
+    "wikipediaTitle": "Variational_autoencoder",
+    "canonicalTitle": "Auto-Encoding Variational Bayes",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-vae-paper",
+        "nodeTitle": "Auto-Encoding Variational Bayes"
+      }
+    ]
+  },
+  "Proximal_policy_optimization": {
+    "wikidataId": "Q113503106",
+    "wikipediaTitle": "Proximal_policy_optimization",
+    "canonicalTitle": "Proximal Policy Optimization Algorithms",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-ppo-paper",
+        "nodeTitle": "Proximal Policy Optimization Algorithms"
+      }
+    ]
+  },
+  "Trust_region_policy_optimization": {
+    "wikidataId": "Q113503095",
+    "wikipediaTitle": "Trust_region_policy_optimization",
+    "canonicalTitle": "Trust Region Policy Optimization",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-trpo-paper",
+        "nodeTitle": "Trust Region Policy Optimization"
+      }
+    ]
+  },
+  "Inflection_AI": {
+    "wikidataId": "Q110894704",
+    "wikipediaTitle": "Inflection_AI",
+    "canonicalTitle": "Inflection AI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-inflection",
+        "nodeTitle": "Inflection AI"
+      }
+    ]
+  },
+  "Character.ai": {
+    "wikidataId": "Q110891631",
+    "wikipediaTitle": "Character.ai",
+    "canonicalTitle": "Character.AI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-character-ai",
+        "nodeTitle": "Character.AI"
+      }
+    ]
+  },
+  "Amazon_Web_Services": {
+    "wikidataId": "Q456157",
+    "wikipediaTitle": "Amazon_Web_Services",
+    "canonicalTitle": "Amazon AI / AWS",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-amazon-ai",
+        "nodeTitle": "Amazon AI / AWS"
+      }
+    ]
+  },
+  "Microsoft_Copilot": {
+    "wikidataId": "Q111449379",
+    "wikipediaTitle": "Microsoft_Copilot",
+    "canonicalTitle": "Microsoft AI",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "entity-microsoft-ai",
+        "nodeTitle": "Microsoft AI"
+      }
+    ]
+  },
+  "Seattle": {
+    "wikidataId": "Q5083",
+    "wikipediaTitle": "Seattle",
+    "canonicalTitle": "Seattle, Washington",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-seattle",
+        "nodeTitle": "Seattle, Washington"
+      }
+    ]
+  },
+  "Redmond,_Washington": {
+    "wikidataId": "Q108524",
+    "wikipediaTitle": "Redmond,_Washington",
+    "canonicalTitle": "Redmond, Washington",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "location-redmond",
+        "nodeTitle": "Redmond, Washington"
+      }
+    ]
+  },
+  "GPT-4o": {
+    "wikidataId": "Q126055869",
+    "wikipediaTitle": "GPT-4o",
+    "canonicalTitle": "GPT-4o",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt4o",
+        "nodeTitle": "GPT-4o"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-gpt4o-mini",
+        "nodeTitle": "GPT-4o mini"
+      }
+    ]
+  },
+  "OpenAI_o1": {
+    "wikidataId": "Q131065549",
+    "wikipediaTitle": "OpenAI_o1",
+    "canonicalTitle": "o1",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-o1",
+        "nodeTitle": "o1"
+      }
+    ]
+  },
+  "OpenAI_o3": {
+    "wikidataId": "Q133034217",
+    "wikipediaTitle": "OpenAI_o3",
+    "canonicalTitle": "o3",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-o3",
+        "nodeTitle": "o3"
+      }
+    ]
+  },
+  "Mixtral": {
+    "wikidataId": "Q122968991",
+    "wikipediaTitle": "Mixtral",
+    "canonicalTitle": "Mixtral 8x22B",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-mixtral-8x22b",
+        "nodeTitle": "Mixtral 8x22B"
+      }
+    ]
+  },
+  "Amazon_Nova": {
+    "wikidataId": "Q133138199",
+    "wikipediaTitle": "Amazon_Nova",
+    "canonicalTitle": "Amazon Nova",
+    "appearances": [
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-nova",
+        "nodeTitle": "Amazon Nova"
+      },
+      {
+        "datasetId": "ai-llm-research",
+        "datasetName": "AI & LLM Research Network",
+        "nodeId": "object-nova-premier",
+        "nodeTitle": "Nova Premier"
+      }
+    ]
+  },
+  "Erik_Satie": {
+    "wikidataId": "Q187192",
+    "wikipediaTitle": "Erik_Satie",
+    "canonicalTitle": "Erik Satie",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-erik-satie",
+        "nodeTitle": "Erik Satie"
+      }
+    ]
+  },
+  "Luigi_Russolo": {
+    "wikidataId": "Q434916",
+    "wikipediaTitle": "Luigi_Russolo",
+    "canonicalTitle": "Luigi Russolo",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-luigi-russolo",
+        "nodeTitle": "Luigi Russolo"
+      }
+    ]
+  },
+  "John_Cage": {
+    "wikidataId": "Q180727",
+    "wikipediaTitle": "John_Cage",
+    "canonicalTitle": "John Cage",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-john-cage",
+        "nodeTitle": "John Cage"
+      }
+    ]
+  },
+  "Morton_Feldman": {
+    "wikidataId": "Q316427",
+    "wikipediaTitle": "Morton_Feldman",
+    "canonicalTitle": "Morton Feldman",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-morton-feldman",
+        "nodeTitle": "Morton Feldman"
+      }
+    ]
+  },
+  "Pierre_Schaeffer": {
+    "wikidataId": "Q315744",
+    "wikipediaTitle": "Pierre_Schaeffer",
+    "canonicalTitle": "Pierre Schaeffer",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-pierre-schaeffer",
+        "nodeTitle": "Pierre Schaeffer"
+      }
+    ]
+  },
+  "Pierre_Henry": {
+    "wikidataId": "Q544469",
+    "wikipediaTitle": "Pierre_Henry",
+    "canonicalTitle": "Pierre Henry",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-pierre-henry",
+        "nodeTitle": "Pierre Henry"
+      }
+    ]
+  },
+  "François_Bayle": {
+    "wikidataId": "Q1450908",
+    "wikipediaTitle": "François_Bayle",
+    "canonicalTitle": "François Bayle",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-francois-bayle",
+        "nodeTitle": "François Bayle"
+      }
+    ]
+  },
+  "Karlheinz_Stockhausen": {
+    "wikidataId": "Q154556",
+    "wikipediaTitle": "Karlheinz_Stockhausen",
+    "canonicalTitle": "Karlheinz Stockhausen",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-karlheinz-stockhausen",
+        "nodeTitle": "Karlheinz Stockhausen"
+      }
+    ]
+  },
+  "La_Monte_Young": {
+    "wikidataId": "Q432822",
+    "wikipediaTitle": "La_Monte_Young",
+    "canonicalTitle": "La Monte Young",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-la-monte-young",
+        "nodeTitle": "La Monte Young"
+      }
+    ]
+  },
+  "Pauline_Oliveros": {
+    "wikidataId": "Q444857",
+    "wikipediaTitle": "Pauline_Oliveros",
+    "canonicalTitle": "Pauline Oliveros",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-pauline-oliveros",
+        "nodeTitle": "Pauline Oliveros"
+      }
+    ]
+  },
+  "Tony_Conrad": {
+    "wikidataId": "Q481477",
+    "wikipediaTitle": "Tony_Conrad",
+    "canonicalTitle": "Tony Conrad",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-tony-conrad",
+        "nodeTitle": "Tony Conrad"
+      }
+    ]
+  },
+  "David_Tudor": {
+    "wikidataId": "Q1176914",
+    "wikipediaTitle": "David_Tudor",
+    "canonicalTitle": "David Tudor",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-david-tudor",
+        "nodeTitle": "David Tudor"
+      }
+    ]
+  },
+  "Delia_Derbyshire": {
+    "wikidataId": "Q29544",
+    "wikipediaTitle": "Delia_Derbyshire",
+    "canonicalTitle": "Delia Derbyshire",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-delia-derbyshire",
+        "nodeTitle": "Delia Derbyshire"
+      }
+    ]
+  },
+  "Raymond_Scott": {
+    "wikidataId": "Q1334617",
+    "wikipediaTitle": "Raymond_Scott",
+    "canonicalTitle": "Raymond Scott",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-raymond-scott",
+        "nodeTitle": "Raymond Scott"
+      }
+    ]
+  },
+  "Léon_Theremin": {
+    "wikidataId": "Q333265",
+    "wikipediaTitle": "Léon_Theremin",
+    "canonicalTitle": "Leon Theremin",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-leon-theremin",
+        "nodeTitle": "Leon Theremin"
+      }
+    ]
+  },
+  "Clara_Rockmore": {
+    "wikidataId": "Q271187",
+    "wikipediaTitle": "Clara_Rockmore",
+    "canonicalTitle": "Clara Rockmore",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-clara-rockmore",
+        "nodeTitle": "Clara Rockmore"
+      }
+    ]
+  },
+  "Maurice_Martenot": {
+    "wikidataId": "Q1333326",
+    "wikipediaTitle": "Maurice_Martenot",
+    "canonicalTitle": "Maurice Martenot",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-maurice-martenot",
+        "nodeTitle": "Maurice Martenot"
+      }
+    ]
+  },
+  "Robert_Moog": {
+    "wikidataId": "Q200883",
+    "wikipediaTitle": "Robert_Moog",
+    "canonicalTitle": "Robert Moog",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-robert-moog",
+        "nodeTitle": "Robert Moog"
+      }
+    ]
+  },
+  "Herb_Deutsch": {
+    "wikidataId": "Q1608180",
+    "wikipediaTitle": "Herb_Deutsch",
+    "canonicalTitle": "Herb Deutsch",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-herb-deutsch",
+        "nodeTitle": "Herb Deutsch"
+      }
+    ]
+  },
+  "Don_Buchla": {
+    "wikidataId": "Q1238976",
+    "wikipediaTitle": "Don_Buchla",
+    "canonicalTitle": "Don Buchla",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-don-buchla",
+        "nodeTitle": "Don Buchla"
+      }
+    ]
+  },
+  "Peter_Zinovieff": {
+    "wikidataId": "Q7177851",
+    "wikipediaTitle": "Peter_Zinovieff",
+    "canonicalTitle": "Peter Zinovieff",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-peter-zinovieff",
+        "nodeTitle": "Peter Zinovieff"
+      }
+    ]
+  },
+  "David_Cockerell_(engineer)": {
+    "wikidataId": null,
+    "wikipediaTitle": "David_Cockerell_(engineer)",
+    "canonicalTitle": "David Cockerell",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-david-cockerell",
+        "nodeTitle": "David Cockerell"
+      }
+    ]
+  },
+  "Tristram_Cary": {
+    "wikidataId": "Q364835",
+    "wikipediaTitle": "Tristram_Cary",
+    "canonicalTitle": "Tristram Cary",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-tristram-cary",
+        "nodeTitle": "Tristram Cary"
+      }
+    ]
+  },
+  "Suzanne_Ciani": {
+    "wikidataId": "Q391625",
+    "wikipediaTitle": "Suzanne_Ciani",
+    "canonicalTitle": "Suzanne Ciani",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-suzanne-ciani",
+        "nodeTitle": "Suzanne Ciani"
+      }
+    ]
+  },
+  "Edgar_Froese": {
+    "wikidataId": "Q505957",
+    "wikipediaTitle": "Edgar_Froese",
+    "canonicalTitle": "Edgar Froese",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-edgar-froese",
+        "nodeTitle": "Edgar Froese"
+      }
+    ]
+  },
+  "Klaus_Schulze": {
+    "wikidataId": "Q168015",
+    "wikipediaTitle": "Klaus_Schulze",
+    "canonicalTitle": "Klaus Schulze",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-klaus-schulze",
+        "nodeTitle": "Klaus Schulze"
+      }
+    ]
+  },
+  "Conrad_Schnitzler": {
+    "wikidataId": "Q571477",
+    "wikipediaTitle": "Conrad_Schnitzler",
+    "canonicalTitle": "Conrad Schnitzler",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-conrad-schnitzler",
+        "nodeTitle": "Conrad Schnitzler"
+      }
+    ]
+  },
+  "Hans-Joachim_Roedelius": {
+    "wikidataId": "Q2655756",
+    "wikipediaTitle": "Hans-Joachim_Roedelius",
+    "canonicalTitle": "Hans-Joachim Roedelius",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-hans-joachim-roedelius",
+        "nodeTitle": "Hans-Joachim Roedelius"
+      }
+    ]
+  },
+  "Dieter_Moebius": {
+    "wikidataId": "Q973580",
+    "wikipediaTitle": "Dieter_Moebius",
+    "canonicalTitle": "Dieter Moebius",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-dieter-moebius",
+        "nodeTitle": "Dieter Moebius"
+      }
+    ]
+  },
+  "Michael_Rother": {
+    "wikidataId": "Q729390",
+    "wikipediaTitle": "Michael_Rother",
+    "canonicalTitle": "Michael Rother",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-michael-rother",
+        "nodeTitle": "Michael Rother"
+      }
+    ]
+  },
+  "Klaus_Dinger": {
+    "wikidataId": "Q690282",
+    "wikipediaTitle": "Klaus_Dinger",
+    "canonicalTitle": "Klaus Dinger",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-klaus-dinger",
+        "nodeTitle": "Klaus Dinger"
+      }
+    ]
+  },
+  "Manuel_Göttsching": {
+    "wikidataId": "Q427429",
+    "wikipediaTitle": "Manuel_Göttsching",
+    "canonicalTitle": "Manuel Göttsching",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-manuel-gottsching",
+        "nodeTitle": "Manuel Göttsching"
+      }
+    ]
+  },
+  "Ralf_Hütter": {
+    "wikidataId": "Q372438",
+    "wikipediaTitle": "Ralf_Hütter",
+    "canonicalTitle": "Ralf Hütter",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-ralf-hutter",
+        "nodeTitle": "Ralf Hütter"
+      }
+    ]
+  },
+  "Florian_Schneider": {
+    "wikidataId": "Q435744",
+    "wikipediaTitle": "Florian_Schneider",
+    "canonicalTitle": "Florian Schneider",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-florian-schneider",
+        "nodeTitle": "Florian Schneider"
+      }
+    ]
+  },
+  "Conny_Plank": {
+    "wikidataId": "Q61428",
+    "wikipediaTitle": "Conny_Plank",
+    "canonicalTitle": "Conny Plank",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-conny-plank",
+        "nodeTitle": "Conny Plank"
+      },
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-conny-studio",
+        "nodeTitle": "Conny Plank's Studio"
+      }
+    ]
+  },
+  "Christopher_Franke": {
+    "wikidataId": "Q61272",
+    "wikipediaTitle": "Christopher_Franke",
+    "canonicalTitle": "Christopher Franke",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-christopher-franke",
+        "nodeTitle": "Christopher Franke"
+      }
+    ]
+  },
+  "Peter_Baumann_(musician)": {
+    "wikidataId": null,
+    "wikipediaTitle": "Peter_Baumann_(musician)",
+    "canonicalTitle": "Peter Baumann",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-peter-baumann",
+        "nodeTitle": "Peter Baumann"
+      }
+    ]
+  },
+  "Brian_Eno": {
+    "wikidataId": "Q569003",
+    "wikipediaTitle": "Brian_Eno",
+    "canonicalTitle": "Brian Eno",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-brian-eno",
+        "nodeTitle": "Brian Eno"
+      }
+    ]
+  },
+  "Robert_Fripp": {
+    "wikidataId": "Q203185",
+    "wikipediaTitle": "Robert_Fripp",
+    "canonicalTitle": "Robert Fripp",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-robert-fripp",
+        "nodeTitle": "Robert Fripp"
+      }
+    ]
+  },
+  "Harold_Budd": {
+    "wikidataId": "Q728029",
+    "wikipediaTitle": "Harold_Budd",
+    "canonicalTitle": "Harold Budd",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-harold-budd",
+        "nodeTitle": "Harold Budd"
+      }
+    ]
+  },
+  "Daniel_Lanois": {
+    "wikidataId": "Q935369",
+    "wikipediaTitle": "Daniel_Lanois",
+    "canonicalTitle": "Daniel Lanois",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-daniel-lanois",
+        "nodeTitle": "Daniel Lanois"
+      }
+    ]
+  },
+  "Roger_Eno": {
+    "wikidataId": "Q1351281",
+    "wikipediaTitle": "Roger_Eno",
+    "canonicalTitle": "Roger Eno",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-roger-eno",
+        "nodeTitle": "Roger Eno"
+      }
+    ]
+  },
+  "Laraaji": {
+    "wikidataId": "Q13583325",
+    "wikipediaTitle": "Laraaji",
+    "canonicalTitle": "Laraaji",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-laraaji",
+        "nodeTitle": "Laraaji"
+      }
+    ]
+  },
+  "Gavin_Bryars": {
+    "wikidataId": "Q713939",
+    "wikipediaTitle": "Gavin_Bryars",
+    "canonicalTitle": "Gavin Bryars",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-gavin-bryars",
+        "nodeTitle": "Gavin Bryars"
+      }
+    ]
+  },
+  "Michael_Nyman": {
+    "wikidataId": "Q313639",
+    "wikipediaTitle": "Michael_Nyman",
+    "canonicalTitle": "Michael Nyman",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-michael-nyman",
+        "nodeTitle": "Michael Nyman"
+      }
+    ]
+  },
+  "Jon_Hassell": {
+    "wikidataId": "Q782528",
+    "wikipediaTitle": "Jon_Hassell",
+    "canonicalTitle": "Jon Hassell",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-jon-hassell",
+        "nodeTitle": "Jon Hassell"
+      }
+    ]
+  },
+  "Terry_Riley": {
+    "wikidataId": "Q365243",
+    "wikipediaTitle": "Terry_Riley",
+    "canonicalTitle": "Terry Riley",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-terry-riley",
+        "nodeTitle": "Terry Riley"
+      }
+    ]
+  },
+  "Steve_Reich": {
+    "wikidataId": "Q262791",
+    "wikipediaTitle": "Steve_Reich",
+    "canonicalTitle": "Steve Reich",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-steve-reich",
+        "nodeTitle": "Steve Reich"
+      }
+    ]
+  },
+  "Philip_Glass": {
+    "wikidataId": "Q189729",
+    "wikipediaTitle": "Philip_Glass",
+    "canonicalTitle": "Philip Glass",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-philip-glass",
+        "nodeTitle": "Philip Glass"
+      }
+    ]
+  },
+  "Charlemagne_Palestine": {
+    "wikidataId": "Q369916",
+    "wikipediaTitle": "Charlemagne_Palestine",
+    "canonicalTitle": "Charlemagne Palestine",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-charlemagne-palestine",
+        "nodeTitle": "Charlemagne Palestine"
+      }
+    ]
+  },
+  "King_Tubby": {
+    "wikidataId": "Q451858",
+    "wikipediaTitle": "King_Tubby",
+    "canonicalTitle": "King Tubby",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-king-tubby",
+        "nodeTitle": "King Tubby"
+      }
+    ]
+  },
+  "Lee_\"Scratch\"_Perry": {
+    "wikidataId": "Q315417",
+    "wikipediaTitle": "Lee_\"Scratch\"_Perry",
+    "canonicalTitle": "Lee \"Scratch\" Perry",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-lee-scratch-perry",
+        "nodeTitle": "Lee \"Scratch\" Perry"
+      }
+    ]
+  },
+  "Haruomi_Hosono": {
+    "wikidataId": "Q705221",
+    "wikipediaTitle": "Haruomi_Hosono",
+    "canonicalTitle": "Haruomi Hosono",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-haruomi-hosono",
+        "nodeTitle": "Haruomi Hosono"
+      }
+    ]
+  },
+  "Hiroshi_Yoshimura": {
+    "wikidataId": "Q11413264",
+    "wikipediaTitle": "Hiroshi_Yoshimura",
+    "canonicalTitle": "Hiroshi Yoshimura",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-hiroshi-yoshimura",
+        "nodeTitle": "Hiroshi Yoshimura"
+      }
+    ]
+  },
+  "Ryuichi_Sakamoto": {
+    "wikidataId": "Q345494",
+    "wikipediaTitle": "Ryuichi_Sakamoto",
+    "canonicalTitle": "Ryuichi Sakamoto",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-ryuichi-sakamoto",
+        "nodeTitle": "Ryuichi Sakamoto"
+      }
+    ]
+  },
+  "Wendy_Carlos": {
+    "wikidataId": "Q44641",
+    "wikipediaTitle": "Wendy_Carlos",
+    "canonicalTitle": "Wendy Carlos",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-wendy-carlos",
+        "nodeTitle": "Wendy Carlos"
+      }
+    ]
+  },
+  "Furniture_music": {
+    "wikidataId": "Q912383",
+    "wikipediaTitle": "Furniture_music",
+    "canonicalTitle": "Musique d'ameublement (Furniture Music)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-satie-furniture-music",
+        "nodeTitle": "Musique d'ameublement (Furniture Music)"
+      }
+    ]
+  },
+  "The_Art_of_Noises": {
+    "wikidataId": "Q2746944",
+    "wikipediaTitle": "The_Art_of_Noises",
+    "canonicalTitle": "The Art of Noises (L'arte dei Rumori)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-russolo-art-of-noises",
+        "nodeTitle": "The Art of Noises (L'arte dei Rumori)"
+      }
+    ]
+  },
+  "4′33″": {
+    "wikidataId": "Q12030",
+    "wikipediaTitle": "4′33″",
+    "canonicalTitle": "4'33\"",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-cage-433",
+        "nodeTitle": "4'33\""
+      }
+    ]
+  },
+  "Études_de_bruits": {
+    "wikidataId": null,
+    "wikipediaTitle": "Études_de_bruits",
+    "canonicalTitle": "Étude aux chemins de fer",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-schaeffer-etude-chemins-de-fer",
+        "nodeTitle": "Étude aux chemins de fer"
+      }
+    ]
+  },
+  "Symphonie_pour_un_homme_seul": {
+    "wikidataId": "Q3507883",
+    "wikipediaTitle": "Symphonie_pour_un_homme_seul",
+    "canonicalTitle": "Symphonie pour un homme seul",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-schaeffer-henry-symphonie",
+        "nodeTitle": "Symphonie pour un homme seul"
+      }
+    ]
+  },
+  "Gesang_der_Jünglinge": {
+    "wikidataId": "Q1129735",
+    "wikipediaTitle": "Gesang_der_Jünglinge",
+    "canonicalTitle": "Gesang der Jünglinge",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-stockhausen-gesang",
+        "nodeTitle": "Gesang der Jünglinge"
+      }
+    ]
+  },
+  "In_C": {
+    "wikidataId": "Q1500990",
+    "wikipediaTitle": "In_C",
+    "canonicalTitle": "In C",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-riley-in-c",
+        "nodeTitle": "In C"
+      }
+    ]
+  },
+  "A_Rainbow_in_Curved_Air": {
+    "wikidataId": "Q2819874",
+    "wikipediaTitle": "A_Rainbow_in_Curved_Air",
+    "canonicalTitle": "A Rainbow in Curved Air",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-riley-rainbow",
+        "nodeTitle": "A Rainbow in Curved Air"
+      }
+    ]
+  },
+  "It's_Gonna_Rain": {
+    "wikidataId": "Q3155783",
+    "wikipediaTitle": "It's_Gonna_Rain",
+    "canonicalTitle": "It's Gonna Rain",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-reich-its-gonna-rain",
+        "nodeTitle": "It's Gonna Rain"
+      }
+    ]
+  },
+  "Music_for_18_Musicians": {
+    "wikidataId": "Q2714697",
+    "wikipediaTitle": "Music_for_18_Musicians",
+    "canonicalTitle": "Music for 18 Musicians",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-reich-music-for-18",
+        "nodeTitle": "Music for 18 Musicians"
+      }
+    ]
+  },
+  "The_Well-Tuned_Piano": {
+    "wikidataId": "Q3523344",
+    "wikipediaTitle": "The_Well-Tuned_Piano",
+    "canonicalTitle": "The Well-Tuned Piano",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-young-well-tuned-piano",
+        "nodeTitle": "The Well-Tuned Piano"
+      }
+    ]
+  },
+  "Dream_House_(art_installation)": {
+    "wikidataId": null,
+    "wikipediaTitle": "Dream_House_(art_installation)",
+    "canonicalTitle": "Dream House",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-young-dream-house",
+        "nodeTitle": "Dream House"
+      },
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-dream-house-install",
+        "nodeTitle": "Dream House Installation"
+      }
+    ]
+  },
+  "Phaedra_(album)": {
+    "wikidataId": "Q642815",
+    "wikipediaTitle": "Phaedra_(album)",
+    "canonicalTitle": "Phaedra",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-td-phaedra",
+        "nodeTitle": "Phaedra"
+      }
+    ]
+  },
+  "Rubycon_(album)": {
+    "wikidataId": "Q729361",
+    "wikipediaTitle": "Rubycon_(album)",
+    "canonicalTitle": "Rubycon",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-td-rubycon",
+        "nodeTitle": "Rubycon"
+      }
+    ]
+  },
+  "Electronic_Meditation": {
+    "wikidataId": "Q2296309",
+    "wikipediaTitle": "Electronic_Meditation",
+    "canonicalTitle": "Electronic Meditation",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-td-electronic-meditation",
+        "nodeTitle": "Electronic Meditation"
+      }
+    ]
+  },
+  "Irrlicht": {
+    "wikidataId": "Q240785",
+    "wikipediaTitle": "Irrlicht",
+    "canonicalTitle": "Irrlicht",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-schulze-irrlicht",
+        "nodeTitle": "Irrlicht"
+      }
+    ]
+  },
+  "Timewind": {
+    "wikidataId": "Q1933643",
+    "wikipediaTitle": "Timewind",
+    "canonicalTitle": "Timewind",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-schulze-timewind",
+        "nodeTitle": "Timewind"
+      }
+    ]
+  },
+  "Zuckerzeit": {
+    "wikidataId": "Q31595",
+    "wikipediaTitle": "Zuckerzeit",
+    "canonicalTitle": "Zuckerzeit",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-cluster-zuckerzeit",
+        "nodeTitle": "Zuckerzeit"
+      }
+    ]
+  },
+  "Sowiesoso": {
+    "wikidataId": "Q31512",
+    "wikipediaTitle": "Sowiesoso",
+    "canonicalTitle": "Sowiesoso",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-cluster-sowiesoso",
+        "nodeTitle": "Sowiesoso"
+      }
+    ]
+  },
+  "Cluster_&_Eno": {
+    "wikidataId": "Q2980401",
+    "wikipediaTitle": "Cluster_&_Eno",
+    "canonicalTitle": "Cluster & Eno",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-cluster-eno",
+        "nodeTitle": "Cluster & Eno"
+      }
+    ]
+  },
+  "After_the_Heat": {
+    "wikidataId": "Q4690656",
+    "wikipediaTitle": "After_the_Heat",
+    "canonicalTitle": "After the Heat",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-after-the-heat",
+        "nodeTitle": "After the Heat"
+      }
+    ]
+  },
+  "Musik_von_Harmonia": {
+    "wikidataId": "Q6942662",
+    "wikipediaTitle": "Musik_von_Harmonia",
+    "canonicalTitle": "Musik von Harmonia",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-harmonia-musik",
+        "nodeTitle": "Musik von Harmonia"
+      }
+    ]
+  },
+  "Tracks_and_Traces": {
+    "wikidataId": "Q7831590",
+    "wikipediaTitle": "Tracks_and_Traces",
+    "canonicalTitle": "Tracks and Traces",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-harmonia-tracks-traces",
+        "nodeTitle": "Tracks and Traces"
+      }
+    ]
+  },
+  "Neu!_(album)": {
+    "wikidataId": "Q1566338",
+    "wikipediaTitle": "Neu!_(album)",
+    "canonicalTitle": "Neu!",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-neu-1",
+        "nodeTitle": "Neu!"
+      }
+    ]
+  },
+  "Neu!_'75": {
+    "wikidataId": "Q1065671",
+    "wikipediaTitle": "Neu!_'75",
+    "canonicalTitle": "Neu! 75",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-neu-75",
+        "nodeTitle": "Neu! 75"
+      }
+    ]
+  },
+  "E2-E4": {
+    "wikidataId": "Q1273664",
+    "wikipediaTitle": "E2-E4",
+    "canonicalTitle": "E2-E4",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-gottsching-e2e4",
+        "nodeTitle": "E2-E4"
+      }
+    ]
+  },
+  "New_Age_of_Earth": {
+    "wikidataId": "Q656796",
+    "wikipediaTitle": "New_Age_of_Earth",
+    "canonicalTitle": "New Age of Earth",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-gottsching-new-age",
+        "nodeTitle": "New Age of Earth"
+      }
+    ]
+  },
+  "Autobahn_(album)": {
+    "wikidataId": "Q544099",
+    "wikipediaTitle": "Autobahn_(album)",
+    "canonicalTitle": "Autobahn",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-kraftwerk-autobahn",
+        "nodeTitle": "Autobahn"
+      }
+    ]
+  },
+  "(No_Pussyfooting)": {
+    "wikidataId": "Q1815536",
+    "wikipediaTitle": "(No_Pussyfooting)",
+    "canonicalTitle": "(No Pussyfooting)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-fripp-eno-no-pussyfooting",
+        "nodeTitle": "(No Pussyfooting)"
+      }
+    ]
+  },
+  "Evening_Star_(album)": {
+    "wikidataId": "Q16928269",
+    "wikipediaTitle": "Evening_Star_(album)",
+    "canonicalTitle": "Evening Star",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-fripp-eno-evening-star",
+        "nodeTitle": "Evening Star"
+      }
+    ]
+  },
+  "Discreet_Music": {
+    "wikidataId": "Q2058212",
+    "wikipediaTitle": "Discreet_Music",
+    "canonicalTitle": "Discreet Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-discreet-music",
+        "nodeTitle": "Discreet Music"
+      }
+    ]
+  },
+  "Another_Green_World": {
+    "wikidataId": "Q771427",
+    "wikipediaTitle": "Another_Green_World",
+    "canonicalTitle": "Another Green World",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-another-green-world",
+        "nodeTitle": "Another Green World"
+      }
+    ]
+  },
+  "Ambient_1:_Music_for_Airports": {
+    "wikidataId": "Q127100",
+    "wikipediaTitle": "Ambient_1:_Music_for_Airports",
+    "canonicalTitle": "Ambient 1: Music for Airports",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-music-for-airports",
+        "nodeTitle": "Ambient 1: Music for Airports"
+      }
+    ]
+  },
+  "Ambient_2:_The_Plateaux_of_Mirror": {
+    "wikidataId": "Q2842051",
+    "wikipediaTitle": "Ambient_2:_The_Plateaux_of_Mirror",
+    "canonicalTitle": "Ambient 2: The Plateaux of Mirror",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-budd-plateaux",
+        "nodeTitle": "Ambient 2: The Plateaux of Mirror"
+      }
+    ]
+  },
+  "Ambient_3:_Day_of_Radiance": {
+    "wikidataId": "Q2842048",
+    "wikipediaTitle": "Ambient_3:_Day_of_Radiance",
+    "canonicalTitle": "Ambient 3: Day of Radiance",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-laraaji-day-of-radiance",
+        "nodeTitle": "Ambient 3: Day of Radiance"
+      }
+    ]
+  },
+  "Ambient_4:_On_Land": {
+    "wikidataId": "Q958618",
+    "wikipediaTitle": "Ambient_4:_On_Land",
+    "canonicalTitle": "Ambient 4: On Land",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-on-land",
+        "nodeTitle": "Ambient 4: On Land"
+      }
+    ]
+  },
+  "Apollo:_Atmospheres_&_Soundtracks": {
+    "wikidataId": "Q3282479",
+    "wikipediaTitle": "Apollo:_Atmospheres_&_Soundtracks",
+    "canonicalTitle": "Apollo: Atmospheres & Soundtracks",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-apollo",
+        "nodeTitle": "Apollo: Atmospheres & Soundtracks"
+      }
+    ]
+  },
+  "The_Pearl_(album)": {
+    "wikidataId": "Q3522197",
+    "wikipediaTitle": "The_Pearl_(album)",
+    "canonicalTitle": "The Pearl",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-eno-budd-pearl",
+        "nodeTitle": "The Pearl"
+      }
+    ]
+  },
+  "The_Pavilion_of_Dreams": {
+    "wikidataId": "Q3522191",
+    "wikipediaTitle": "The_Pavilion_of_Dreams",
+    "canonicalTitle": "The Pavilion of Dreams",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-budd-pavilion",
+        "nodeTitle": "The Pavilion of Dreams"
+      }
+    ]
+  },
+  "Fourth_World,_Vol._1:_Possible_Musics": {
+    "wikidataId": "Q8135341",
+    "wikipediaTitle": "Fourth_World,_Vol._1:_Possible_Musics",
+    "canonicalTitle": "Fourth World Vol. 1: Possible Musics",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-hassell-eno-fourth-world",
+        "nodeTitle": "Fourth World Vol. 1: Possible Musics"
+      }
+    ]
+  },
+  "The_Sinking_of_the_Titanic_(album)": {
+    "wikidataId": null,
+    "wikipediaTitle": "The_Sinking_of_the_Titanic_(album)",
+    "canonicalTitle": "The Sinking of the Titanic",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-bryars-titanic",
+        "nodeTitle": "The Sinking of the Titanic"
+      }
+    ]
+  },
+  "Jesus'_Blood_Never_Failed_Me_Yet": {
+    "wikidataId": "Q6188046",
+    "wikipediaTitle": "Jesus'_Blood_Never_Failed_Me_Yet",
+    "canonicalTitle": "Jesus' Blood Never Failed Me Yet",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-bryars-jesus-blood",
+        "nodeTitle": "Jesus' Blood Never Failed Me Yet"
+      }
+    ]
+  },
+  "Music_for_Nine_Post_Cards": {
+    "wikidataId": "Q85787170",
+    "wikipediaTitle": "Music_for_Nine_Post_Cards",
+    "canonicalTitle": "Music for Nine Post Cards",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-yoshimura-postcards",
+        "nodeTitle": "Music for Nine Post Cards"
+      }
+    ]
+  },
+  "Green_(Hiroshi_Yoshimura_album)": {
+    "wikidataId": "Q107388794",
+    "wikipediaTitle": "Green_(Hiroshi_Yoshimura_album)",
+    "canonicalTitle": "Green",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-yoshimura-green",
+        "nodeTitle": "Green"
+      }
+    ]
+  },
+  "Async_(album)": {
+    "wikidataId": "Q48765523",
+    "wikipediaTitle": "Async_(album)",
+    "canonicalTitle": "async",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-sakamoto-async",
+        "nodeTitle": "async"
+      }
+    ]
+  },
+  "Switched-On_Bach": {
+    "wikidataId": "Q3283363",
+    "wikipediaTitle": "Switched-On_Bach",
+    "canonicalTitle": "Switched-On Bach",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-carlos-switched-on",
+        "nodeTitle": "Switched-On Bach"
+      }
+    ]
+  },
+  "Super_Ape": {
+    "wikidataId": "Q719189",
+    "wikipediaTitle": "Super_Ape",
+    "canonicalTitle": "Super Ape",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-perry-super-ape",
+        "nodeTitle": "Super Ape"
+      }
+    ]
+  },
+  "Silence:_Lectures_and_Writings": {
+    "wikidataId": "Q7514348",
+    "wikipediaTitle": "Silence:_Lectures_and_Writings",
+    "canonicalTitle": "Silence",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-cage-silence",
+        "nodeTitle": "Silence"
+      }
+    ]
+  },
+  "Traité_des_objets_musicaux": {
+    "wikidataId": null,
+    "wikipediaTitle": "Traité_des_objets_musicaux",
+    "canonicalTitle": "Traité des objets musicaux",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-schaeffer-traite",
+        "nodeTitle": "Traité des objets musicaux"
+      }
+    ]
+  },
+  "Experimental_Music:_Cage_and_Beyond": {
+    "wikidataId": null,
+    "wikipediaTitle": "Experimental_Music:_Cage_and_Beyond",
+    "canonicalTitle": "Experimental Music: Cage and Beyond",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-nyman-experimental-music",
+        "nodeTitle": "Experimental Music: Cage and Beyond"
+      }
+    ]
+  },
+  "Moog_synthesizer": {
+    "wikidataId": "Q426035",
+    "wikipediaTitle": "Moog_synthesizer",
+    "canonicalTitle": "Moog Modular Synthesizer",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-moog-modular",
+        "nodeTitle": "Moog Modular Synthesizer"
+      }
+    ]
+  },
+  "Minimoog": {
+    "wikidataId": "Q734687",
+    "wikipediaTitle": "Minimoog",
+    "canonicalTitle": "Minimoog",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-minimoog",
+        "nodeTitle": "Minimoog"
+      }
+    ]
+  },
+  "Buchla_Electronic_Musical_Instruments": {
+    "wikidataId": "Q4676716",
+    "wikipediaTitle": "Buchla_Electronic_Musical_Instruments",
+    "canonicalTitle": "Buchla 100 Series",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-buchla-100",
+        "nodeTitle": "Buchla 100 Series"
+      },
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-buchla",
+        "nodeTitle": "Buchla and Associates"
+      }
+    ]
+  },
+  "Buchla_Music_Easel": {
+    "wikidataId": null,
+    "wikipediaTitle": "Buchla_Music_Easel",
+    "canonicalTitle": "Buchla Music Easel",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-buchla-easel",
+        "nodeTitle": "Buchla Music Easel"
+      }
+    ]
+  },
+  "EMS_VCS_3": {
+    "wikidataId": "Q514109",
+    "wikipediaTitle": "EMS_VCS_3",
+    "canonicalTitle": "VCS3 (Putney)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-ems-vcs3",
+        "nodeTitle": "VCS3 (Putney)"
+      }
+    ]
+  },
+  "EMS_Synthi_AKS": {
+    "wikidataId": "Q3717397",
+    "wikipediaTitle": "EMS_Synthi_AKS",
+    "canonicalTitle": "Synthi AKS",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-ems-synthi-aks",
+        "nodeTitle": "Synthi AKS"
+      }
+    ]
+  },
+  "Theremin": {
+    "wikidataId": "Q207691",
+    "wikipediaTitle": "Theremin",
+    "canonicalTitle": "Theremin",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-theremin",
+        "nodeTitle": "Theremin"
+      }
+    ]
+  },
+  "Ondes_Martenot": {
+    "wikidataId": "Q862501",
+    "wikipediaTitle": "Ondes_Martenot",
+    "canonicalTitle": "Ondes Martenot",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-ondes-martenot",
+        "nodeTitle": "Ondes Martenot"
+      }
+    ]
+  },
+  "Intonarumori": {
+    "wikidataId": "Q3153674",
+    "wikipediaTitle": "Intonarumori",
+    "canonicalTitle": "Intonarumori",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-intonarumori",
+        "nodeTitle": "Intonarumori"
+      }
+    ]
+  },
+  "Frippertronics": {
+    "wikidataId": "Q1054058",
+    "wikipediaTitle": "Frippertronics",
+    "canonicalTitle": "Frippertronics System",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-frippertronics",
+        "nodeTitle": "Frippertronics System"
+      }
+    ]
+  },
+  "Acousmonium": {
+    "wikidataId": "Q2823426",
+    "wikipediaTitle": "Acousmonium",
+    "canonicalTitle": "Acousmonium",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-acousmonium",
+        "nodeTitle": "Acousmonium"
+      }
+    ]
+  },
+  "Electronium": {
+    "wikidataId": "Q5358503",
+    "wikipediaTitle": "Electronium",
+    "canonicalTitle": "Electronium",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-electronium",
+        "nodeTitle": "Electronium"
+      }
+    ]
+  },
+  "Berlin": {
+    "wikidataId": "Q64",
+    "wikipediaTitle": "Berlin",
+    "canonicalTitle": "Berlin",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-berlin",
+        "nodeTitle": "Berlin"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-berlin",
+        "nodeTitle": "Berlin"
+      }
+    ]
+  },
+  "Düsseldorf": {
+    "wikidataId": "Q1718",
+    "wikipediaTitle": "Düsseldorf",
+    "canonicalTitle": "Düsseldorf",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-dusseldorf",
+        "nodeTitle": "Düsseldorf"
+      }
+    ]
+  },
+  "Cologne": {
+    "wikidataId": "Q365",
+    "wikipediaTitle": "Cologne",
+    "canonicalTitle": "Cologne",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-cologne",
+        "nodeTitle": "Cologne"
+      },
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-cologne",
+        "nodeTitle": "Cologne"
+      }
+    ]
+  },
+  "San_Francisco_Bay_Area": {
+    "wikidataId": "Q213205",
+    "wikipediaTitle": "San_Francisco_Bay_Area",
+    "canonicalTitle": "San Francisco Bay Area",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-san-francisco",
+        "nodeTitle": "San Francisco Bay Area"
+      }
+    ]
+  },
+  "Kingston,_Jamaica": {
+    "wikidataId": "Q34692",
+    "wikipediaTitle": "Kingston,_Jamaica",
+    "canonicalTitle": "Kingston",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-kingston",
+        "nodeTitle": "Kingston"
+      }
+    ]
+  },
+  "Milan": {
+    "wikidataId": "Q490",
+    "wikipediaTitle": "Milan",
+    "canonicalTitle": "Milan",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-milan",
+        "nodeTitle": "Milan"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-milan",
+        "nodeTitle": "Milan"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-milan",
+        "nodeTitle": "Milan"
+      }
+    ]
+  },
+  "Hamilton,_Ontario": {
+    "wikidataId": "Q133116",
+    "wikipediaTitle": "Hamilton,_Ontario",
+    "canonicalTitle": "Hamilton, Ontario",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-hamilton",
+        "nodeTitle": "Hamilton, Ontario"
+      }
+    ]
+  },
+  "Groupe_de_recherches_musicales": {
+    "wikidataId": null,
+    "wikipediaTitle": "Groupe_de_recherches_musicales",
+    "canonicalTitle": "GRM (Groupe de Recherches Musicales)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-grm",
+        "nodeTitle": "GRM (Groupe de Recherches Musicales)"
+      },
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-grm-org",
+        "nodeTitle": "GRM (Research Organization)"
+      }
+    ]
+  },
+  "Studio_for_Electronic_Music_(WDR)": {
+    "wikidataId": "Q2358704",
+    "wikipediaTitle": "Studio_for_Electronic_Music_(WDR)",
+    "canonicalTitle": "WDR Studio for Electronic Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-wdr-studio",
+        "nodeTitle": "WDR Studio for Electronic Music"
+      }
+    ]
+  },
+  "BBC_Radiophonic_Workshop": {
+    "wikidataId": "Q1778799",
+    "wikipediaTitle": "BBC_Radiophonic_Workshop",
+    "canonicalTitle": "BBC Radiophonic Workshop",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-bbc-radiophonic",
+        "nodeTitle": "BBC Radiophonic Workshop"
+      }
+    ]
+  },
+  "Black_Ark": {
+    "wikidataId": null,
+    "wikipediaTitle": "Black_Ark",
+    "canonicalTitle": "Black Ark Studio",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-black-ark",
+        "nodeTitle": "Black Ark Studio"
+      }
+    ]
+  },
+  "Kling_Klang_Studio": {
+    "wikidataId": "Q76186012",
+    "wikipediaTitle": "Kling_Klang_Studio",
+    "canonicalTitle": "Kling Klang Studio",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-kling-klang",
+        "nodeTitle": "Kling Klang Studio"
+      }
+    ]
+  },
+  "Grant_Avenue_Studio": {
+    "wikidataId": "Q118898952",
+    "wikipediaTitle": "Grant_Avenue_Studio",
+    "canonicalTitle": "Grant Avenue Studio",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-grant-avenue",
+        "nodeTitle": "Grant Avenue Studio"
+      }
+    ]
+  },
+  "Hansa_Tonstudio": {
+    "wikidataId": "Q667023",
+    "wikipediaTitle": "Hansa_Tonstudio",
+    "canonicalTitle": "Hansa Studio",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-hansa",
+        "nodeTitle": "Hansa Studio"
+      }
+    ]
+  },
+  "San_Francisco_Tape_Music_Center": {
+    "wikidataId": "Q3471440",
+    "wikipediaTitle": "San_Francisco_Tape_Music_Center",
+    "canonicalTitle": "San Francisco Tape Music Center",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-sftmc",
+        "nodeTitle": "San Francisco Tape Music Center"
+      },
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-sftmc-org",
+        "nodeTitle": "San Francisco Tape Music Center"
+      }
+    ]
+  },
+  "Mills_College": {
+    "wikidataId": "Q638859",
+    "wikipediaTitle": "Mills_College",
+    "canonicalTitle": "Mills College",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-mills",
+        "nodeTitle": "Mills College"
+      }
+    ]
+  },
+  "Darmstadt_International_Summer_Courses_for_New_Music": {
+    "wikidataId": null,
+    "wikipediaTitle": "Darmstadt_International_Summer_Courses_for_New_Music",
+    "canonicalTitle": "Darmstadt Summer Courses",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-darmstadt",
+        "nodeTitle": "Darmstadt Summer Courses"
+      }
+    ]
+  },
+  "Zodiak_Free_Arts_Lab": {
+    "wikidataId": "Q218160",
+    "wikipediaTitle": "Zodiak_Free_Arts_Lab",
+    "canonicalTitle": "Zodiak Free Arts Lab",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-zodiak",
+        "nodeTitle": "Zodiak Free Arts Lab"
+      }
+    ]
+  },
+  "Kunstakademie_Düsseldorf": {
+    "wikidataId": "Q662355",
+    "wikipediaTitle": "Kunstakademie_Düsseldorf",
+    "canonicalTitle": "Düsseldorf Art Academy",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-dusseldorf-academy",
+        "nodeTitle": "Düsseldorf Art Academy"
+      }
+    ]
+  },
+  "The_Kitchen": {
+    "wikidataId": null,
+    "wikipediaTitle": "The_Kitchen",
+    "canonicalTitle": "The Kitchen",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-kitchen",
+        "nodeTitle": "The Kitchen"
+      }
+    ]
+  },
+  "Washington_Square_Park": {
+    "wikidataId": "Q909592",
+    "wikipediaTitle": "Washington_Square_Park",
+    "canonicalTitle": "Washington Square Park",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "loc-washington-square",
+        "nodeTitle": "Washington Square Park"
+      }
+    ]
+  },
+  "Tangerine_Dream": {
+    "wikidataId": "Q153616",
+    "wikipediaTitle": "Tangerine_Dream",
+    "canonicalTitle": "Tangerine Dream",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-tangerine-dream",
+        "nodeTitle": "Tangerine Dream"
+      }
+    ]
+  },
+  "Cluster_(band)": {
+    "wikidataId": "Q705382",
+    "wikipediaTitle": "Cluster_(band)",
+    "canonicalTitle": "Cluster",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-cluster",
+        "nodeTitle": "Cluster"
+      }
+    ]
+  },
+  "Harmonia_(band)": {
+    "wikidataId": "Q568238",
+    "wikipediaTitle": "Harmonia_(band)",
+    "canonicalTitle": "Harmonia",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-harmonia",
+        "nodeTitle": "Harmonia"
+      }
+    ]
+  },
+  "Neu!": {
+    "wikidataId": "Q181874",
+    "wikipediaTitle": "Neu!",
+    "canonicalTitle": "Neu!",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-neu",
+        "nodeTitle": "Neu!"
+      }
+    ]
+  },
+  "Kraftwerk": {
+    "wikidataId": "Q44892",
+    "wikipediaTitle": "Kraftwerk",
+    "canonicalTitle": "Kraftwerk",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-kraftwerk",
+        "nodeTitle": "Kraftwerk"
+      }
+    ]
+  },
+  "Ash_Ra_Tempel": {
+    "wikidataId": "Q700817",
+    "wikipediaTitle": "Ash_Ra_Tempel",
+    "canonicalTitle": "Ash Ra Tempel",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-ash-ra-tempel",
+        "nodeTitle": "Ash Ra Tempel"
+      }
+    ]
+  },
+  "Theatre_of_Eternal_Music": {
+    "wikidataId": "Q3496301",
+    "wikipediaTitle": "Theatre_of_Eternal_Music",
+    "canonicalTitle": "Theatre of Eternal Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-theatre-eternal-music",
+        "nodeTitle": "Theatre of Eternal Music"
+      }
+    ]
+  },
+  "Roxy_Music": {
+    "wikidataId": "Q334648",
+    "wikipediaTitle": "Roxy_Music",
+    "canonicalTitle": "Roxy Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-roxy-music",
+        "nodeTitle": "Roxy Music"
+      }
+    ]
+  },
+  "King_Crimson": {
+    "wikidataId": "Q189382",
+    "wikipediaTitle": "King_Crimson",
+    "canonicalTitle": "King Crimson",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-king-crimson",
+        "nodeTitle": "King Crimson"
+      }
+    ]
+  },
+  "Yellow_Magic_Orchestra": {
+    "wikidataId": "Q854590",
+    "wikipediaTitle": "Yellow_Magic_Orchestra",
+    "canonicalTitle": "Yellow Magic Orchestra",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-ymo",
+        "nodeTitle": "Yellow Magic Orchestra"
+      }
+    ]
+  },
+  "New_York_School_(art)": {
+    "wikidataId": "Q1972942",
+    "wikipediaTitle": "New_York_School_(art)",
+    "canonicalTitle": "New York School",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-new-york-school",
+        "nodeTitle": "New York School"
+      }
+    ]
+  },
+  "Deep_Listening_Band": {
+    "wikidataId": "Q5250235",
+    "wikipediaTitle": "Deep_Listening_Band",
+    "canonicalTitle": "Deep Listening Band",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-deep-listening-band",
+        "nodeTitle": "Deep Listening Band"
+      }
+    ]
+  },
+  "Can_(band)": {
+    "wikidataId": "Q170132",
+    "wikipediaTitle": "Can_(band)",
+    "canonicalTitle": "Can",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-can",
+        "nodeTitle": "Can"
+      }
+    ]
+  },
+  "Faust_(band)": {
+    "wikidataId": "Q679697",
+    "wikipediaTitle": "Faust_(band)",
+    "canonicalTitle": "Faust",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-faust",
+        "nodeTitle": "Faust"
+      }
+    ]
+  },
+  "Obscure_Records": {
+    "wikidataId": "Q3389945",
+    "wikipediaTitle": "Obscure_Records",
+    "canonicalTitle": "Obscure Records",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-obscure-records",
+        "nodeTitle": "Obscure Records"
+      }
+    ]
+  },
+  "Ohr_(record_label)": {
+    "wikidataId": "Q1518623",
+    "wikipediaTitle": "Ohr_(record_label)",
+    "canonicalTitle": "Ohr Records",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-ohr",
+        "nodeTitle": "Ohr Records"
+      }
+    ]
+  },
+  "Brain_(record_label)": {
+    "wikidataId": null,
+    "wikipediaTitle": "Brain_(record_label)",
+    "canonicalTitle": "Brain Records",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-brain",
+        "nodeTitle": "Brain Records"
+      }
+    ]
+  },
+  "Virgin_Records": {
+    "wikidataId": "Q203059",
+    "wikipediaTitle": "Virgin_Records",
+    "canonicalTitle": "Virgin Records",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-virgin-german",
+        "nodeTitle": "Virgin Records"
+      }
+    ]
+  },
+  "Private_Music": {
+    "wikidataId": "Q6318209",
+    "wikipediaTitle": "Private_Music",
+    "canonicalTitle": "Private Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-private-music",
+        "nodeTitle": "Private Music"
+      }
+    ]
+  },
+  "E.G._Records": {
+    "wikidataId": "Q1611073",
+    "wikipediaTitle": "E.G._Records",
+    "canonicalTitle": "EG Records",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-eg-records",
+        "nodeTitle": "EG Records"
+      }
+    ]
+  },
+  "Ambient_music": {
+    "wikidataId": "Q193207",
+    "wikipediaTitle": "Ambient_music",
+    "canonicalTitle": "Ambient Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-ambient-movement",
+        "nodeTitle": "Ambient Music"
+      }
+    ]
+  },
+  "Musique_concrète": {
+    "wikidataId": "Q823560",
+    "wikipediaTitle": "Musique_concrète",
+    "canonicalTitle": "Musique Concrète",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-musique-concrete",
+        "nodeTitle": "Musique Concrète"
+      }
+    ]
+  },
+  "Minimal_music": {
+    "wikidataId": "Q572901",
+    "wikipediaTitle": "Minimal_music",
+    "canonicalTitle": "Minimalism",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-minimalism",
+        "nodeTitle": "Minimalism"
+      }
+    ]
+  },
+  "Berlin_School_(electronic_music)": {
+    "wikidataId": null,
+    "wikipediaTitle": "Berlin_School_(electronic_music)",
+    "canonicalTitle": "Berlin School",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-berlin-school",
+        "nodeTitle": "Berlin School"
+      }
+    ]
+  },
+  "Krautrock": {
+    "wikidataId": "Q320592",
+    "wikipediaTitle": "Krautrock",
+    "canonicalTitle": "Krautrock",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-krautrock",
+        "nodeTitle": "Krautrock"
+      }
+    ]
+  },
+  "Kankyō_ongaku": {
+    "wikidataId": null,
+    "wikipediaTitle": "Kankyō_ongaku",
+    "canonicalTitle": "Kankyō Ongaku",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-kankyo-ongaku",
+        "nodeTitle": "Kankyō Ongaku"
+      }
+    ]
+  },
+  "Dub_music": {
+    "wikidataId": "Q212688",
+    "wikipediaTitle": "Dub_music",
+    "canonicalTitle": "Dub",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-dub",
+        "nodeTitle": "Dub"
+      }
+    ]
+  },
+  "Futurism": {
+    "wikidataId": "Q131221",
+    "wikipediaTitle": "Futurism",
+    "canonicalTitle": "Futurism",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-futurism",
+        "nodeTitle": "Futurism"
+      }
+    ]
+  },
+  "Electronic_Music_Studios": {
+    "wikidataId": "Q1326103",
+    "wikipediaTitle": "Electronic_Music_Studios",
+    "canonicalTitle": "EMS (Electronic Music Studios)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-ems",
+        "nodeTitle": "EMS (Electronic Music Studios)"
+      }
+    ]
+  },
+  "Moog_Music": {
+    "wikidataId": "Q1650528",
+    "wikipediaTitle": "Moog_Music",
+    "canonicalTitle": "Moog Music",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-moog-music",
+        "nodeTitle": "Moog Music"
+      }
+    ]
+  },
+  "Morton_Subotnick": {
+    "wikidataId": "Q962366",
+    "wikipediaTitle": "Morton_Subotnick",
+    "canonicalTitle": "Morton Subotnick",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-morton-subotnick",
+        "nodeTitle": "Morton Subotnick"
+      }
+    ]
+  },
+  "Jeanne_Loriod": {
+    "wikidataId": "Q2574388",
+    "wikipediaTitle": "Jeanne_Loriod",
+    "canonicalTitle": "Jeanne Loriod",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-jeanne-loriod",
+        "nodeTitle": "Jeanne Loriod"
+      }
+    ]
+  },
+  "Holger_Czukay": {
+    "wikidataId": "Q699355",
+    "wikipediaTitle": "Holger_Czukay",
+    "canonicalTitle": "Holger Czukay",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-holger-czukay",
+        "nodeTitle": "Holger Czukay"
+      }
+    ]
+  },
+  "Midori_Takada": {
+    "wikidataId": "Q22341183",
+    "wikipediaTitle": "Midori_Takada",
+    "canonicalTitle": "Midori Takada",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-midori-takada",
+        "nodeTitle": "Midori Takada"
+      }
+    ]
+  },
+  "Aphex_Twin": {
+    "wikidataId": "Q223161",
+    "wikipediaTitle": "Aphex_Twin",
+    "canonicalTitle": "Richard D. James (Aphex Twin)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-richard-d-james",
+        "nodeTitle": "Richard D. James (Aphex Twin)"
+      }
+    ]
+  },
+  "Alex_Paterson": {
+    "wikidataId": "Q4717608",
+    "wikipediaTitle": "Alex_Paterson",
+    "canonicalTitle": "Alex Paterson (The Orb)",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-alex-paterson",
+        "nodeTitle": "Alex Paterson (The Orb)"
+      }
+    ]
+  },
+  "Bill_Drummond": {
+    "wikidataId": "Q4908833",
+    "wikipediaTitle": "Bill_Drummond",
+    "canonicalTitle": "Bill Drummond",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-bill-drummond",
+        "nodeTitle": "Bill Drummond"
+      }
+    ]
+  },
+  "Jimmy_Cauty": {
+    "wikidataId": "Q5605106",
+    "wikipediaTitle": "Jimmy_Cauty",
+    "canonicalTitle": "Jimmy Cauty",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "person-jimmy-cauty",
+        "nodeTitle": "Jimmy Cauty"
+      }
+    ]
+  },
+  "Silver_Apples_of_the_Moon": {
+    "wikidataId": "Q43637545",
+    "wikipediaTitle": "Silver_Apples_of_the_Moon",
+    "canonicalTitle": "Silver Apples of the Moon",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-subotnick-silver-apples",
+        "nodeTitle": "Silver Apples of the Moon"
+      }
+    ]
+  },
+  "Canaxis": {
+    "wikidataId": null,
+    "wikipediaTitle": "Canaxis",
+    "canonicalTitle": "Canaxis 5",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-czukay-canaxis",
+        "nodeTitle": "Canaxis 5"
+      }
+    ]
+  },
+  "Through_the_Looking_Glass_(Midori_Takada_album)": {
+    "wikidataId": null,
+    "wikipediaTitle": "Through_the_Looking_Glass_(Midori_Takada_album)",
+    "canonicalTitle": "Through the Looking Glass",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-takada-looking-glass",
+        "nodeTitle": "Through the Looking Glass"
+      }
+    ]
+  },
+  "Selected_Ambient_Works_85–92": {
+    "wikidataId": "Q970352",
+    "wikipediaTitle": "Selected_Ambient_Works_85–92",
+    "canonicalTitle": "Selected Ambient Works 85-92",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-aphex-saw-85-92",
+        "nodeTitle": "Selected Ambient Works 85-92"
+      }
+    ]
+  },
+  "Selected_Ambient_Works_Volume_II": {
+    "wikidataId": "Q1933629",
+    "wikipediaTitle": "Selected_Ambient_Works_Volume_II",
+    "canonicalTitle": "Selected Ambient Works Volume II",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-aphex-saw-ii",
+        "nodeTitle": "Selected Ambient Works Volume II"
+      }
+    ]
+  },
+  "The_Orb's_Adventures_Beyond_the_Ultraworld": {
+    "wikidataId": "Q7755273",
+    "wikipediaTitle": "The_Orb's_Adventures_Beyond_the_Ultraworld",
+    "canonicalTitle": "The Orb's Adventures Beyond the Ultraworld",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-orb-ultraworld",
+        "nodeTitle": "The Orb's Adventures Beyond the Ultraworld"
+      }
+    ]
+  },
+  "Chill_Out_(The_KLF_album)": {
+    "wikidataId": "Q355395",
+    "wikipediaTitle": "Chill_Out_(The_KLF_album)",
+    "canonicalTitle": "Chill Out",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "object-klf-chill-out",
+        "nodeTitle": "Chill Out"
+      }
+    ]
+  },
+  "The_Orb": {
+    "wikidataId": "Q924993",
+    "wikipediaTitle": "The_Orb",
+    "canonicalTitle": "The Orb",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-the-orb",
+        "nodeTitle": "The Orb"
+      }
+    ]
+  },
+  "The_KLF": {
+    "wikidataId": "Q741316",
+    "wikipediaTitle": "The_KLF",
+    "canonicalTitle": "The KLF",
+    "appearances": [
+      {
+        "datasetId": "ambient-music",
+        "datasetName": "Ambient Music Network",
+        "nodeId": "entity-klf",
+        "nodeTitle": "The KLF"
+      }
+    ]
+  },
+  "Johann_Reuchlin": {
+    "wikidataId": "Q60637",
+    "wikipediaTitle": "Johann_Reuchlin",
+    "canonicalTitle": "Johannes Reuchlin",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-johannes-reuchlin",
+        "nodeTitle": "Johannes Reuchlin"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-johannes-reuchlin",
+        "nodeTitle": "Johannes Reuchlin"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-johannes-reuchlin",
+        "nodeTitle": "Johannes Reuchlin"
+      }
+    ]
+  },
+  "Heinrich_Cornelius_Agrippa": {
+    "wikidataId": "Q60305",
+    "wikipediaTitle": "Heinrich_Cornelius_Agrippa",
+    "canonicalTitle": "Heinrich Cornelius Agrippa",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-heinrich-cornelius-agrippa",
+        "nodeTitle": "Heinrich Cornelius Agrippa"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-cornelius-agrippa",
+        "nodeTitle": "Heinrich Cornelius Agrippa"
+      }
+    ]
+  },
+  "Johannes_Trithemius": {
+    "wikidataId": "Q60373",
+    "wikipediaTitle": "Johannes_Trithemius",
+    "canonicalTitle": "Johannes Trithemius",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-johannes-trithemius",
+        "nodeTitle": "Johannes Trithemius"
+      }
+    ]
+  },
+  "Guillaume_Postel": {
+    "wikidataId": "Q723036",
+    "wikipediaTitle": "Guillaume_Postel",
+    "canonicalTitle": "Guillaume Postel",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-guillaume-postel",
+        "nodeTitle": "Guillaume Postel"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-guillaume-postel",
+        "nodeTitle": "Guillaume Postel"
+      }
+    ]
+  },
+  "Francesco_Giorgio_Veneto": {
+    "wikidataId": "Q1384845",
+    "wikipediaTitle": "Francesco_Giorgio_Veneto",
+    "canonicalTitle": "Francesco Giorgi",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-francesco-giorgi",
+        "nodeTitle": "Francesco Giorgi"
+      }
+    ]
+  },
+  "Giovanni_Pico_della_Mirandola": {
+    "wikidataId": "Q185977",
+    "wikipediaTitle": "Giovanni_Pico_della_Mirandola",
+    "canonicalTitle": "Giovanni Pico della Mirandola",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-giovanni-pico-della-mirandola",
+        "nodeTitle": "Giovanni Pico della Mirandola"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-giovanni-pico-della-mirandola",
+        "nodeTitle": "Giovanni Pico della Mirandola"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giovanni-pico",
+        "nodeTitle": "Giovanni Pico della Mirandola"
+      }
+    ]
+  },
+  "Marsilio_Ficino": {
+    "wikidataId": "Q154781",
+    "wikipediaTitle": "Marsilio_Ficino",
+    "canonicalTitle": "Marsilio Ficino",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-marsilio-ficino",
+        "nodeTitle": "Marsilio Ficino"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-marsilio-ficino",
+        "nodeTitle": "Marsilio Ficino"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-marsilio-ficino",
+        "nodeTitle": "Marsilio Ficino"
+      }
+    ]
+  },
+  "Paracelsus": {
+    "wikidataId": "Q83428",
+    "wikipediaTitle": "Paracelsus",
+    "canonicalTitle": "Paracelsus",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-paracelsus",
+        "nodeTitle": "Paracelsus"
+      },
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-paracelsus",
+        "nodeTitle": "Paracelsus"
+      }
+    ]
+  },
+  "Giles_of_Viterbo": {
+    "wikidataId": "Q453595",
+    "wikipediaTitle": "Giles_of_Viterbo",
+    "canonicalTitle": "Egidio da Viterbo",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-egidio-da-viterbo",
+        "nodeTitle": "Egidio da Viterbo"
+      }
+    ]
+  },
+  "Elijah_Levita": {
+    "wikidataId": "Q699096",
+    "wikipediaTitle": "Elijah_Levita",
+    "canonicalTitle": "Elijah Levita",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-elijah-levita",
+        "nodeTitle": "Elijah Levita"
+      }
+    ]
+  },
+  "Johannes_Pfefferkorn": {
+    "wikidataId": "Q63203",
+    "wikipediaTitle": "Johannes_Pfefferkorn",
+    "canonicalTitle": "Johannes Pfefferkorn",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-johannes-pfefferkorn",
+        "nodeTitle": "Johannes Pfefferkorn"
+      }
+    ]
+  },
+  "Jacques_Lefèvre_d'Étaples": {
+    "wikidataId": "Q332616",
+    "wikipediaTitle": "Jacques_Lefèvre_d'Étaples",
+    "canonicalTitle": "Jacques Lefèvre d'Étaples",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-jacques-lefevre-detaples",
+        "nodeTitle": "Jacques Lefèvre d'Étaples"
+      }
+    ]
+  },
+  "De_Arte_Cabalistica": {
+    "wikidataId": "Q1180147",
+    "wikipediaTitle": "De_Arte_Cabalistica",
+    "canonicalTitle": "De Arte Cabalistica",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-arte-cabalistica",
+        "nodeTitle": "De Arte Cabalistica"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-arte-cabalistica",
+        "nodeTitle": "De arte cabalistica"
+      }
+    ]
+  },
+  "De_verbo_mirifico": {
+    "wikidataId": "Q1180145",
+    "wikipediaTitle": "De_verbo_mirifico",
+    "canonicalTitle": "De Verbo Mirifico",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-verbo-mirifico",
+        "nodeTitle": "De Verbo Mirifico"
+      }
+    ]
+  },
+  "Three_Books_of_Occult_Philosophy": {
+    "wikidataId": "Q328741",
+    "wikipediaTitle": "Three_Books_of_Occult_Philosophy",
+    "canonicalTitle": "De Occulta Philosophia libri tres",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-occulta-philosophia",
+        "nodeTitle": "De Occulta Philosophia libri tres"
+      }
+    ]
+  },
+  "De_incertitudine_et_vanitate_scientiarum_et_artium": {
+    "wikidataId": "Q1182689",
+    "wikipediaTitle": "De_incertitudine_et_vanitate_scientiarum_et_artium",
+    "canonicalTitle": "De incertitudine et vanitate scientiarum",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-vanitate-scientiarum",
+        "nodeTitle": "De incertitudine et vanitate scientiarum"
+      }
+    ]
+  },
+  "Steganographia": {
+    "wikidataId": "Q646795",
+    "wikipediaTitle": "Steganographia",
+    "canonicalTitle": "Steganographia",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-steganographia",
+        "nodeTitle": "Steganographia"
+      }
+    ]
+  },
+  "Polygraphia_(book)": {
+    "wikidataId": "Q2101507",
+    "wikipediaTitle": "Polygraphia_(book)",
+    "canonicalTitle": "Polygraphia",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-polygraphia",
+        "nodeTitle": "Polygraphia"
+      }
+    ]
+  },
+  "De_harmonia_mundi": {
+    "wikidataId": "Q5247052",
+    "wikipediaTitle": "De_harmonia_mundi",
+    "canonicalTitle": "De Harmonia Mundi totius cantica tria",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-harmonia-mundi",
+        "nodeTitle": "De Harmonia Mundi totius cantica tria"
+      }
+    ]
+  },
+  "900_Theses": {
+    "wikidataId": "Q2674076",
+    "wikipediaTitle": "900_Theses",
+    "canonicalTitle": "Conclusiones philosophicae, cabalisticae et theologicae",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-900-theses",
+        "nodeTitle": "Conclusiones philosophicae, cabalisticae et theologicae"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-900-theses",
+        "nodeTitle": "900 Theses (Conclusiones)"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-900-theses",
+        "nodeTitle": "900 Theses"
+      }
+    ]
+  },
+  "Oration_on_the_Dignity_of_Man": {
+    "wikidataId": "Q2021193",
+    "wikipediaTitle": "Oration_on_the_Dignity_of_Man",
+    "canonicalTitle": "Oration on the Dignity of Man",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-oration-dignity-man",
+        "nodeTitle": "Oration on the Dignity of Man"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-oration-dignity-of-man",
+        "nodeTitle": "Oration on the Dignity of Man"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-oration-dignity-man",
+        "nodeTitle": "Oratio de hominis dignitate"
+      }
+    ]
+  },
+  "Theologia_Platonica": {
+    "wikidataId": "Q7781428",
+    "wikipediaTitle": "Theologia_Platonica",
+    "canonicalTitle": "Theologia Platonica",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-theologia-platonica",
+        "nodeTitle": "Theologia Platonica"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-theologia-platonica",
+        "nodeTitle": "Theologia Platonica (Platonic Theology)"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-theologia-platonica",
+        "nodeTitle": "Theologia Platonica"
+      }
+    ]
+  },
+  "De_vita_libri_tres": {
+    "wikidataId": "Q1181428",
+    "wikipediaTitle": "De_vita_libri_tres",
+    "canonicalTitle": "De vita libri tres",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-de-vita-libri-tres",
+        "nodeTitle": "De vita libri tres"
+      }
+    ]
+  },
+  "Corpus_Hermeticum": {
+    "wikidataId": "Q862087",
+    "wikipediaTitle": "Corpus_Hermeticum",
+    "canonicalTitle": "Corpus Hermeticum (Latin translation)",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-corpus-hermeticum-translation",
+        "nodeTitle": "Corpus Hermeticum (Latin translation)"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-corpus-hermeticum",
+        "nodeTitle": "Corpus Hermeticum"
+      }
+    ]
+  },
+  "Masoret_HaMasoret": {
+    "wikidataId": "Q1899088",
+    "wikipediaTitle": "Masoret_HaMasoret",
+    "canonicalTitle": "Masoret ha-Masoret",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-masoret-ha-masoret",
+        "nodeTitle": "Masoret ha-Masoret"
+      }
+    ]
+  },
+  "Letters_of_Obscure_Men": {
+    "wikidataId": "Q672269",
+    "wikipediaTitle": "Letters_of_Obscure_Men",
+    "canonicalTitle": "Epistolae Obscurorum Virorum",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "object-letters-obscure-men",
+        "nodeTitle": "Epistolae Obscurorum Virorum"
+      }
+    ]
+  },
+  "Florence": {
+    "wikidataId": "Q2044",
+    "wikipediaTitle": "Florence",
+    "canonicalTitle": "Florence",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-florence",
+        "nodeTitle": "Florence"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "location-florence",
+        "nodeTitle": "Florence"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-florence",
+        "nodeTitle": "Florence"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-florence",
+        "nodeTitle": "Florence"
+      }
+    ]
+  },
+  "Venice": {
+    "wikidataId": "Q641",
+    "wikipediaTitle": "Venice",
+    "canonicalTitle": "Venice",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-venice",
+        "nodeTitle": "Venice"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-venice",
+        "nodeTitle": "Venice"
+      }
+    ]
+  },
+  "Rome": {
+    "wikidataId": "Q220",
+    "wikipediaTitle": "Rome",
+    "canonicalTitle": "Rome",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-rome",
+        "nodeTitle": "Rome"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-rome",
+        "nodeTitle": "Rome"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-rome",
+        "nodeTitle": "Rome"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-rome",
+        "nodeTitle": "Rome"
+      }
+    ]
+  },
+  "Sponheim_Abbey": {
+    "wikidataId": "Q569604",
+    "wikipediaTitle": "Sponheim_Abbey",
+    "canonicalTitle": "Sponheim Abbey",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-sponheim-abbey",
+        "nodeTitle": "Sponheim Abbey"
+      }
+    ]
+  },
+  "Würzburg": {
+    "wikidataId": "Q1728",
+    "wikipediaTitle": "Würzburg",
+    "canonicalTitle": "Würzburg",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "location-wuerzburg",
+        "nodeTitle": "Würzburg"
+      }
+    ]
+  },
+  "Platonic_Academy_(Florence)": {
+    "wikidataId": "Q2046693",
+    "wikipediaTitle": "Platonic_Academy_(Florence)",
+    "canonicalTitle": "Platonic Academy of Florence",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "entity-platonic-academy-florence",
+        "nodeTitle": "Platonic Academy of Florence"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "entity-platonic-academy",
+        "nodeTitle": "Platonic Academy of Florence"
+      }
+    ]
+  },
+  "Collège_de_France": {
+    "wikidataId": "Q202660",
+    "wikipediaTitle": "Collège_de_France",
+    "canonicalTitle": "Collège de France",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "entity-college-de-france",
+        "nodeTitle": "Collège de France"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-college-de-france",
+        "nodeTitle": "Collège de France"
+      }
+    ]
+  },
+  "University_of_Cologne": {
+    "wikidataId": "Q151510",
+    "wikipediaTitle": "University_of_Cologne",
+    "canonicalTitle": "University of Cologne",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "entity-university-of-cologne",
+        "nodeTitle": "University of Cologne"
+      }
+    ]
+  },
+  "Dominican_Order": {
+    "wikidataId": "Q192632",
+    "wikipediaTitle": "Dominican_Order",
+    "canonicalTitle": "Dominican Order (Cologne)",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "entity-dominican-order",
+        "nodeTitle": "Dominican Order (Cologne)"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-dominican-order",
+        "nodeTitle": "Dominican Order"
+      }
+    ]
+  },
+  "Lorenzo_de'_Medici": {
+    "wikidataId": "Q177854",
+    "wikipediaTitle": "Lorenzo_de'_Medici",
+    "canonicalTitle": "Lorenzo de' Medici",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-lorenzo-de-medici",
+        "nodeTitle": "Lorenzo de' Medici"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-lorenzo-de-medici",
+        "nodeTitle": "Lorenzo de' Medici"
+      }
+    ]
+  },
+  "Cosimo_de'_Medici": {
+    "wikidataId": "Q188989",
+    "wikipediaTitle": "Cosimo_de'_Medici",
+    "canonicalTitle": "Cosimo de' Medici",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-cosimo-de-medici",
+        "nodeTitle": "Cosimo de' Medici"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-cosimo-de-medici",
+        "nodeTitle": "Cosimo de' Medici"
+      }
+    ]
+  },
+  "Maximilian_I,_Holy_Roman_Emperor": {
+    "wikidataId": "Q150726",
+    "wikipediaTitle": "Maximilian_I,_Holy_Roman_Emperor",
+    "canonicalTitle": "Maximilian I, Holy Roman Emperor",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-maximilian-i",
+        "nodeTitle": "Maximilian I, Holy Roman Emperor"
+      }
+    ]
+  },
+  "Jakob_van_Hoogstraten": {
+    "wikidataId": "Q702058",
+    "wikipediaTitle": "Jakob_van_Hoogstraten",
+    "canonicalTitle": "Jakob van Hoogstraten",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-jakob-hoogstraten",
+        "nodeTitle": "Jakob van Hoogstraten"
+      }
+    ]
+  },
+  "Flavius_Mithridates": {
+    "wikidataId": "Q1426689",
+    "wikipediaTitle": "Flavius_Mithridates",
+    "canonicalTitle": "Flavius Mithridates",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-flavius-mithridates",
+        "nodeTitle": "Flavius Mithridates"
+      }
+    ]
+  },
+  "Charles_de_Bovelles": {
+    "wikidataId": "Q540500",
+    "wikipediaTitle": "Charles_de_Bovelles",
+    "canonicalTitle": "Charles de Bovelles",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-charles-de-bovelles",
+        "nodeTitle": "Charles de Bovelles"
+      }
+    ]
+  },
+  "Pope_Leo_X": {
+    "wikidataId": "Q81520",
+    "wikipediaTitle": "Pope_Leo_X",
+    "canonicalTitle": "Pope Leo X",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-pope-leo-x",
+        "nodeTitle": "Pope Leo X"
+      },
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-giovanni-de-medici-pope-leo-x",
+        "nodeTitle": "Giovanni de' Medici (Pope Leo X)"
+      }
+    ]
+  },
+  "Pope_Innocent_VIII": {
+    "wikidataId": "Q170876",
+    "wikipediaTitle": "Pope_Innocent_VIII",
+    "canonicalTitle": "Pope Innocent VIII",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-pope-innocent-viii",
+        "nodeTitle": "Pope Innocent VIII"
+      }
+    ]
+  },
+  "Ulrich_von_Hutten": {
+    "wikidataId": "Q77107",
+    "wikipediaTitle": "Ulrich_von_Hutten",
+    "canonicalTitle": "Ulrich von Hutten",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-ulrich-von-hutten",
+        "nodeTitle": "Ulrich von Hutten"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-ulrich-von-hutten",
+        "nodeTitle": "Ulrich von Hutten"
+      }
+    ]
+  },
+  "Crotus_Rubeanus": {
+    "wikidataId": "Q65521",
+    "wikipediaTitle": "Crotus_Rubeanus",
+    "canonicalTitle": "Crotus Rubeanus",
+    "appearances": [
+      {
+        "datasetId": "christian-kabbalah",
+        "datasetName": "Christian Kabbalist Network",
+        "nodeId": "person-crotus-rubeanus",
+        "nodeTitle": "Crotus Rubeanus"
+      }
+    ]
+  },
+  "Norbert_Wiener": {
+    "wikidataId": "Q178577",
+    "wikipediaTitle": "Norbert_Wiener",
+    "canonicalTitle": "Norbert Wiener",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-norbert-wiener",
+        "nodeTitle": "Norbert Wiener"
+      }
+    ]
+  },
+  "Claude_Shannon": {
+    "wikidataId": "Q92760",
+    "wikipediaTitle": "Claude_Shannon",
+    "canonicalTitle": "Claude Shannon",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-claude-shannon",
+        "nodeTitle": "Claude Shannon"
+      }
+    ]
+  },
+  "Alan_Turing": {
+    "wikidataId": "Q7251",
+    "wikipediaTitle": "Alan_Turing",
+    "canonicalTitle": "Alan Turing",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-alan-turing",
+        "nodeTitle": "Alan Turing"
+      }
+    ]
+  },
+  "John_von_Neumann": {
+    "wikidataId": "Q17455",
+    "wikipediaTitle": "John_von_Neumann",
+    "canonicalTitle": "John von Neumann",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-john-von-neumann",
+        "nodeTitle": "John von Neumann"
+      }
+    ]
+  },
+  "Gregory_Bateson": {
+    "wikidataId": "Q314252",
+    "wikipediaTitle": "Gregory_Bateson",
+    "canonicalTitle": "Gregory Bateson",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-gregory-bateson",
+        "nodeTitle": "Gregory Bateson"
+      }
+    ]
+  },
+  "W._Ross_Ashby": {
+    "wikidataId": "Q711172",
+    "wikipediaTitle": "W._Ross_Ashby",
+    "canonicalTitle": "W. Ross Ashby",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ross-ashby",
+        "nodeTitle": "W. Ross Ashby"
+      }
+    ]
+  },
+  "Stafford_Beer": {
+    "wikidataId": "Q796226",
+    "wikipediaTitle": "Stafford_Beer",
+    "canonicalTitle": "Stafford Beer",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-stafford-beer",
+        "nodeTitle": "Stafford Beer"
+      }
+    ]
+  },
+  "Warren_Weaver": {
+    "wikidataId": "Q510591",
+    "wikipediaTitle": "Warren_Weaver",
+    "canonicalTitle": "Warren Weaver",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-warren-weaver",
+        "nodeTitle": "Warren Weaver"
+      }
+    ]
+  },
+  "Richard_Hamming": {
+    "wikidataId": "Q92619",
+    "wikipediaTitle": "Richard_Hamming",
+    "canonicalTitle": "Richard Hamming",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-richard-hamming",
+        "nodeTitle": "Richard Hamming"
+      }
+    ]
+  },
+  "John_Tukey": {
+    "wikidataId": "Q382207",
+    "wikipediaTitle": "John_Tukey",
+    "canonicalTitle": "John Tukey",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-john-tukey",
+        "nodeTitle": "John Tukey"
+      }
+    ]
+  },
+  "John_R._Pierce": {
+    "wikidataId": "Q1340677",
+    "wikipediaTitle": "John_R._Pierce",
+    "canonicalTitle": "John R. Pierce",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-john-pierce",
+        "nodeTitle": "John R. Pierce"
+      }
+    ]
+  },
+  "Hendrik_Wade_Bode": {
+    "wikidataId": "Q714462",
+    "wikipediaTitle": "Hendrik_Wade_Bode",
+    "canonicalTitle": "Hendrik Bode",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-hendrik-bode",
+        "nodeTitle": "Hendrik Bode"
+      }
+    ]
+  },
+  "Harry_Nyquist": {
+    "wikidataId": "Q316022",
+    "wikipediaTitle": "Harry_Nyquist",
+    "canonicalTitle": "Harry Nyquist",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-harry-nyquist",
+        "nodeTitle": "Harry Nyquist"
+      }
+    ]
+  },
+  "Ralph_Hartley": {
+    "wikidataId": "Q529886",
+    "wikipediaTitle": "Ralph_Hartley",
+    "canonicalTitle": "Ralph Hartley",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ralph-hartley",
+        "nodeTitle": "Ralph Hartley"
+      }
+    ]
+  },
+  "David_A._Huffman": {
+    "wikidataId": "Q92784",
+    "wikipediaTitle": "David_A._Huffman",
+    "canonicalTitle": "David Huffman",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-david-huffman",
+        "nodeTitle": "David Huffman"
+      }
+    ]
+  },
+  "Robert_Fano": {
+    "wikidataId": "Q93052",
+    "wikipediaTitle": "Robert_Fano",
+    "canonicalTitle": "Robert Fano",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-robert-fano",
+        "nodeTitle": "Robert Fano"
+      }
+    ]
+  },
+  "John_Mauchly": {
+    "wikidataId": "Q522162",
+    "wikipediaTitle": "John_Mauchly",
+    "canonicalTitle": "John Mauchly",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-john-mauchly",
+        "nodeTitle": "John Mauchly"
+      }
+    ]
+  },
+  "J._Presper_Eckert": {
+    "wikidataId": "Q457906",
+    "wikipediaTitle": "J._Presper_Eckert",
+    "canonicalTitle": "J. Presper Eckert",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-presper-eckert",
+        "nodeTitle": "J. Presper Eckert"
+      }
+    ]
+  },
+  "Herman_Goldstine": {
+    "wikidataId": "Q93005",
+    "wikipediaTitle": "Herman_Goldstine",
+    "canonicalTitle": "Herman Goldstine",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-herman-goldstine",
+        "nodeTitle": "Herman Goldstine"
+      }
+    ]
+  },
+  "Maurice_Wilkes": {
+    "wikidataId": "Q62857",
+    "wikipediaTitle": "Maurice_Wilkes",
+    "canonicalTitle": "Maurice Wilkes",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-maurice-wilkes",
+        "nodeTitle": "Maurice Wilkes"
+      }
+    ]
+  },
+  "Konrad_Zuse": {
+    "wikidataId": "Q60093",
+    "wikipediaTitle": "Konrad_Zuse",
+    "canonicalTitle": "Konrad Zuse",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-konrad-zuse",
+        "nodeTitle": "Konrad Zuse"
+      }
+    ]
+  },
+  "Max_Newman": {
+    "wikidataId": "Q707155",
+    "wikipediaTitle": "Max_Newman",
+    "canonicalTitle": "Max Newman",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-max-newman",
+        "nodeTitle": "Max Newman"
+      }
+    ]
+  },
+  "Tommy_Flowers": {
+    "wikidataId": "Q954437",
+    "wikipediaTitle": "Tommy_Flowers",
+    "canonicalTitle": "Tommy Flowers",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-tommy-flowers",
+        "nodeTitle": "Tommy Flowers"
+      }
+    ]
+  },
+  "I._J._Good": {
+    "wikidataId": "Q224372",
+    "wikipediaTitle": "I._J._Good",
+    "canonicalTitle": "I.J. Good",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-i-j-good",
+        "nodeTitle": "I.J. Good"
+      }
+    ]
+  },
+  "Warren_Sturgis_McCulloch": {
+    "wikidataId": "Q962174",
+    "wikipediaTitle": "Warren_Sturgis_McCulloch",
+    "canonicalTitle": "Warren McCulloch",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-warren-mcculloch",
+        "nodeTitle": "Warren McCulloch"
+      }
+    ]
+  },
+  "Walter_Pitts": {
+    "wikidataId": "Q705010",
+    "wikipediaTitle": "Walter_Pitts",
+    "canonicalTitle": "Walter Pitts",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-walter-pitts",
+        "nodeTitle": "Walter Pitts"
+      }
+    ]
+  },
+  "Margaret_Mead": {
+    "wikidataId": "Q180099",
+    "wikipediaTitle": "Margaret_Mead",
+    "canonicalTitle": "Margaret Mead",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-margaret-mead",
+        "nodeTitle": "Margaret Mead"
+      }
+    ]
+  },
+  "Arturo_Rosenblueth": {
+    "wikidataId": "Q121729",
+    "wikipediaTitle": "Arturo_Rosenblueth",
+    "canonicalTitle": "Arturo Rosenblueth",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-arturo-rosenblueth",
+        "nodeTitle": "Arturo Rosenblueth"
+      }
+    ]
+  },
+  "Julian_Bigelow": {
+    "wikidataId": "Q328632",
+    "wikipediaTitle": "Julian_Bigelow",
+    "canonicalTitle": "Julian Bigelow",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-julian-bigelow",
+        "nodeTitle": "Julian Bigelow"
+      }
+    ]
+  },
+  "Lawrence_K._Frank": {
+    "wikidataId": "Q15430706",
+    "wikipediaTitle": "Lawrence_K._Frank",
+    "canonicalTitle": "Lawrence Frank",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-lawrence-frank",
+        "nodeTitle": "Lawrence Frank"
+      }
+    ]
+  },
+  "Frank_Fremont-Smith": {
+    "wikidataId": "Q5486704",
+    "wikipediaTitle": "Frank_Fremont-Smith",
+    "canonicalTitle": "Frank Fremont-Smith",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-frank-fremont-smith",
+        "nodeTitle": "Frank Fremont-Smith"
+      }
+    ]
+  },
+  "Ralph_Waldo_Gerard": {
+    "wikidataId": null,
+    "wikipediaTitle": "Ralph_Waldo_Gerard",
+    "canonicalTitle": "Ralph Gerard",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ralph-gerard",
+        "nodeTitle": "Ralph Gerard"
+      }
+    ]
+  },
+  "Heinrich_Klüver": {
+    "wikidataId": "Q74829",
+    "wikipediaTitle": "Heinrich_Klüver",
+    "canonicalTitle": "Heinrich Klüver",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-heinrich-kluver",
+        "nodeTitle": "Heinrich Klüver"
+      }
+    ]
+  },
+  "Kurt_Lewin": {
+    "wikidataId": "Q77106",
+    "wikipediaTitle": "Kurt_Lewin",
+    "canonicalTitle": "Kurt Lewin",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-kurt-lewin",
+        "nodeTitle": "Kurt Lewin"
+      }
+    ]
+  },
+  "Jerome_Lettvin": {
+    "wikidataId": "Q6182818",
+    "wikipediaTitle": "Jerome_Lettvin",
+    "canonicalTitle": "Jerome Lettvin",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-jerome-lettvin",
+        "nodeTitle": "Jerome Lettvin"
+      }
+    ]
+  },
+  "Donald_O._Hebb": {
+    "wikidataId": "Q683246",
+    "wikipediaTitle": "Donald_O._Hebb",
+    "canonicalTitle": "Donald Hebb",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-donald-hebb",
+        "nodeTitle": "Donald Hebb"
+      }
+    ]
+  },
+  "Frank_Rosenblatt": {
+    "wikidataId": "Q93018",
+    "wikipediaTitle": "Frank_Rosenblatt",
+    "canonicalTitle": "Frank Rosenblatt",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-frank-rosenblatt",
+        "nodeTitle": "Frank Rosenblatt"
+      }
+    ]
+  },
+  "Horace_Barlow": {
+    "wikidataId": "Q13570719",
+    "wikipediaTitle": "Horace_Barlow",
+    "canonicalTitle": "Horace Barlow",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-horace-barlow",
+        "nodeTitle": "Horace Barlow"
+      }
+    ]
+  },
+  "Albert_Uttley": {
+    "wikidataId": "Q65048378",
+    "wikipediaTitle": "Albert_Uttley",
+    "canonicalTitle": "Albert Uttley",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-albert-uttley",
+        "nodeTitle": "Albert Uttley"
+      }
+    ]
+  },
+  "William_Grey_Walter": {
+    "wikidataId": "Q1359845",
+    "wikipediaTitle": "William_Grey_Walter",
+    "canonicalTitle": "W. Grey Walter",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-grey-walter",
+        "nodeTitle": "W. Grey Walter"
+      }
+    ]
+  },
+  "Gordon_Pask": {
+    "wikidataId": "Q370461",
+    "wikipediaTitle": "Gordon_Pask",
+    "canonicalTitle": "Gordon Pask",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-gordon-pask",
+        "nodeTitle": "Gordon Pask"
+      }
+    ]
+  },
+  "Donald_MacCrimmon_MacKay": {
+    "wikidataId": "Q3036050",
+    "wikipediaTitle": "Donald_MacCrimmon_MacKay",
+    "canonicalTitle": "Donald MacKay",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-donald-mackay",
+        "nodeTitle": "Donald MacKay"
+      }
+    ]
+  },
+  "William_A._H._Rushton": {
+    "wikidataId": null,
+    "wikipediaTitle": "William_A._H._Rushton",
+    "canonicalTitle": "William Rushton",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-william-rushton",
+        "nodeTitle": "William Rushton"
+      }
+    ]
+  },
+  "Philip_M._Woodward": {
+    "wikidataId": null,
+    "wikipediaTitle": "Philip_M._Woodward",
+    "canonicalTitle": "Philip Woodward",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-philip-woodward",
+        "nodeTitle": "Philip Woodward"
+      }
+    ]
+  },
+  "Ludwig_von_Bertalanffy": {
+    "wikidataId": "Q84345",
+    "wikipediaTitle": "Ludwig_von_Bertalanffy",
+    "canonicalTitle": "Ludwig von Bertalanffy",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ludwig-von-bertalanffy",
+        "nodeTitle": "Ludwig von Bertalanffy"
+      }
+    ]
+  },
+  "Kenneth_E._Boulding": {
+    "wikidataId": "Q505520",
+    "wikipediaTitle": "Kenneth_E._Boulding",
+    "canonicalTitle": "Kenneth Boulding",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-kenneth-boulding",
+        "nodeTitle": "Kenneth Boulding"
+      }
+    ]
+  },
+  "Anatol_Rapoport": {
+    "wikidataId": "Q487453",
+    "wikipediaTitle": "Anatol_Rapoport",
+    "canonicalTitle": "Anatol Rapoport",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-anatol-rapoport",
+        "nodeTitle": "Anatol Rapoport"
+      }
+    ]
+  },
+  "Jay_Wright_Forrester": {
+    "wikidataId": "Q92763",
+    "wikipediaTitle": "Jay_Wright_Forrester",
+    "canonicalTitle": "Jay Forrester",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-jay-forrester",
+        "nodeTitle": "Jay Forrester"
+      }
+    ]
+  },
+  "Donella_Meadows": {
+    "wikidataId": "Q271226",
+    "wikipediaTitle": "Donella_Meadows",
+    "canonicalTitle": "Donella Meadows",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-donella-meadows",
+        "nodeTitle": "Donella Meadows"
+      }
+    ]
+  },
+  "Russell_L._Ackoff": {
+    "wikidataId": "Q1431186",
+    "wikipediaTitle": "Russell_L._Ackoff",
+    "canonicalTitle": "Russell Ackoff",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-russell-ackoff",
+        "nodeTitle": "Russell Ackoff"
+      }
+    ]
+  },
+  "C._West_Churchman": {
+    "wikidataId": "Q959763",
+    "wikipediaTitle": "C._West_Churchman",
+    "canonicalTitle": "C. West Churchman",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-c-west-churchman",
+        "nodeTitle": "C. West Churchman"
+      }
+    ]
+  },
+  "Peter_Checkland": {
+    "wikidataId": "Q503806",
+    "wikipediaTitle": "Peter_Checkland",
+    "canonicalTitle": "Peter Checkland",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-peter-checkland",
+        "nodeTitle": "Peter Checkland"
+      }
+    ]
+  },
+  "Raúl_Espejo": {
+    "wikidataId": null,
+    "wikipediaTitle": "Raúl_Espejo",
+    "canonicalTitle": "Raúl Espejo",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-raul-espejo",
+        "nodeTitle": "Raúl Espejo"
+      }
+    ]
+  },
+  "Heinz_von_Foerster": {
+    "wikidataId": "Q78688",
+    "wikipediaTitle": "Heinz_von_Foerster",
+    "canonicalTitle": "Heinz von Foerster",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-heinz-von-foerster",
+        "nodeTitle": "Heinz von Foerster"
+      }
+    ]
+  },
+  "Humberto_Maturana": {
+    "wikidataId": "Q376452",
+    "wikipediaTitle": "Humberto_Maturana",
+    "canonicalTitle": "Humberto Maturana",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-humberto-maturana",
+        "nodeTitle": "Humberto Maturana"
+      }
+    ]
+  },
+  "Francisco_Varela": {
+    "wikidataId": "Q923582",
+    "wikipediaTitle": "Francisco_Varela",
+    "canonicalTitle": "Francisco Varela",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-francisco-varela",
+        "nodeTitle": "Francisco Varela"
+      }
+    ]
+  },
+  "Ernst_von_Glasersfeld": {
+    "wikidataId": "Q112176",
+    "wikipediaTitle": "Ernst_von_Glasersfeld",
+    "canonicalTitle": "Ernst von Glasersfeld",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ernst-von-glasersfeld",
+        "nodeTitle": "Ernst von Glasersfeld"
+      }
+    ]
+  },
+  "Ranulph_Glanville": {
+    "wikidataId": "Q1494101",
+    "wikipediaTitle": "Ranulph_Glanville",
+    "canonicalTitle": "Ranulph Glanville",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ranulph-glanville",
+        "nodeTitle": "Ranulph Glanville"
+      }
+    ]
+  },
+  "Marvin_Minsky": {
+    "wikidataId": "Q204815",
+    "wikipediaTitle": "Marvin_Minsky",
+    "canonicalTitle": "Marvin Minsky",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-marvin-minsky",
+        "nodeTitle": "Marvin Minsky"
+      }
+    ]
+  },
+  "John_McCarthy_(computer_scientist)": {
+    "wikidataId": "Q92739",
+    "wikipediaTitle": "John_McCarthy_(computer_scientist)",
+    "canonicalTitle": "John McCarthy",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-john-mccarthy",
+        "nodeTitle": "John McCarthy"
+      }
+    ]
+  },
+  "Allen_Newell": {
+    "wikidataId": "Q439245",
+    "wikipediaTitle": "Allen_Newell",
+    "canonicalTitle": "Allen Newell",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-allen-newell",
+        "nodeTitle": "Allen Newell"
+      }
+    ]
+  },
+  "Herbert_A._Simon": {
+    "wikidataId": "Q181529",
+    "wikipediaTitle": "Herbert_A._Simon",
+    "canonicalTitle": "Herbert Simon",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-herbert-simon",
+        "nodeTitle": "Herbert Simon"
+      }
+    ]
+  },
+  "Seymour_Papert": {
+    "wikidataId": "Q335027",
+    "wikipediaTitle": "Seymour_Papert",
+    "canonicalTitle": "Seymour Papert",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-seymour-papert",
+        "nodeTitle": "Seymour Papert"
+      }
+    ]
+  },
+  "Oliver_Selfridge": {
+    "wikidataId": "Q2651957",
+    "wikipediaTitle": "Oliver_Selfridge",
+    "canonicalTitle": "Oliver Selfridge",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-oliver-selfridge",
+        "nodeTitle": "Oliver Selfridge"
+      }
+    ]
+  },
+  "Nathaniel_Rochester_(computer_scientist)": {
+    "wikidataId": "Q6969830",
+    "wikipediaTitle": "Nathaniel_Rochester_(computer_scientist)",
+    "canonicalTitle": "Nathaniel Rochester",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-nathaniel-rochester",
+        "nodeTitle": "Nathaniel Rochester"
+      }
+    ]
+  },
+  "Ray_Solomonoff": {
+    "wikidataId": "Q3123640",
+    "wikipediaTitle": "Ray_Solomonoff",
+    "canonicalTitle": "Ray Solomonoff",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ray-solomonoff",
+        "nodeTitle": "Ray Solomonoff"
+      }
+    ]
+  },
+  "Arthur_Samuel_(computer_scientist)": {
+    "wikidataId": "Q710266",
+    "wikipediaTitle": "Arthur_Samuel_(computer_scientist)",
+    "canonicalTitle": "Arthur Samuel",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-arthur-samuel",
+        "nodeTitle": "Arthur Samuel"
+      }
+    ]
+  },
+  "J._C._R._Licklider": {
+    "wikidataId": "Q92778",
+    "wikipediaTitle": "J._C._R._Licklider",
+    "canonicalTitle": "J.C.R. Licklider",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-j-c-r-licklider",
+        "nodeTitle": "J.C.R. Licklider"
+      }
+    ]
+  },
+  "Douglas_Engelbart": {
+    "wikidataId": "Q92614",
+    "wikipediaTitle": "Douglas_Engelbart",
+    "canonicalTitle": "Douglas Engelbart",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-douglas-engelbart",
+        "nodeTitle": "Douglas Engelbart"
+      }
+    ]
+  },
+  "Alfred_North_Whitehead": {
+    "wikidataId": "Q183372",
+    "wikipediaTitle": "Alfred_North_Whitehead",
+    "canonicalTitle": "Alfred North Whitehead",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-alfred-whitehead",
+        "nodeTitle": "Alfred North Whitehead"
+      }
+    ]
+  },
+  "Bertrand_Russell": {
+    "wikidataId": "Q33760",
+    "wikipediaTitle": "Bertrand_Russell",
+    "canonicalTitle": "Bertrand Russell",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-bertrand-russell",
+        "nodeTitle": "Bertrand Russell"
+      }
+    ]
+  },
+  "Alonzo_Church": {
+    "wikidataId": "Q92741",
+    "wikipediaTitle": "Alonzo_Church",
+    "canonicalTitle": "Alonzo Church",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-alonzo-church",
+        "nodeTitle": "Alonzo Church"
+      }
+    ]
+  },
+  "Kurt_Gödel": {
+    "wikidataId": "Q41390",
+    "wikipediaTitle": "Kurt_Gödel",
+    "canonicalTitle": "Kurt Gödel",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-kurt-godel",
+        "nodeTitle": "Kurt Gödel"
+      }
+    ]
+  },
+  "Walter_Bradford_Cannon": {
+    "wikidataId": "Q503192",
+    "wikipediaTitle": "Walter_Bradford_Cannon",
+    "canonicalTitle": "Walter Cannon",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-walter-cannon",
+        "nodeTitle": "Walter Cannon"
+      }
+    ]
+  },
+  "Josiah_Willard_Gibbs": {
+    "wikidataId": "Q153243",
+    "wikipediaTitle": "Josiah_Willard_Gibbs",
+    "canonicalTitle": "Josiah Willard Gibbs",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-josiah-gibbs",
+        "nodeTitle": "Josiah Willard Gibbs"
+      }
+    ]
+  },
+  "Ludwig_Boltzmann": {
+    "wikidataId": "Q84296",
+    "wikipediaTitle": "Ludwig_Boltzmann",
+    "canonicalTitle": "Ludwig Boltzmann",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-ludwig-boltzmann",
+        "nodeTitle": "Ludwig Boltzmann"
+      }
+    ]
+  },
+  "Vannevar_Bush": {
+    "wikidataId": "Q299595",
+    "wikipediaTitle": "Vannevar_Bush",
+    "canonicalTitle": "Vannevar Bush",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-vannevar-bush",
+        "nodeTitle": "Vannevar Bush"
+      }
+    ]
+  },
+  "Charles_Sanders_Peirce": {
+    "wikidataId": "Q187520",
+    "wikipediaTitle": "Charles_Sanders_Peirce",
+    "canonicalTitle": "Charles Sanders Peirce",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-charles-peirce",
+        "nodeTitle": "Charles Sanders Peirce"
+      }
+    ]
+  },
+  "Oskar_Morgenstern": {
+    "wikidataId": "Q94028",
+    "wikipediaTitle": "Oskar_Morgenstern",
+    "canonicalTitle": "Oskar Morgenstern",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-oskar-morgenstern",
+        "nodeTitle": "Oskar Morgenstern"
+      }
+    ]
+  },
+  "Jean_Piaget": {
+    "wikidataId": "Q123190",
+    "wikipediaTitle": "Jean_Piaget",
+    "canonicalTitle": "Jean Piaget",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "person-jean-piaget",
+        "nodeTitle": "Jean Piaget"
+      }
+    ]
+  },
+  "Cybernetics:_Or_Control_and_Communication_in_the_Animal_and_the_Machine": {
+    "wikidataId": "Q16953441",
+    "wikipediaTitle": "Cybernetics:_Or_Control_and_Communication_in_the_Animal_and_the_Machine",
+    "canonicalTitle": "Cybernetics: Or Control and Communication in the Animal and the Machine",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-cybernetics-wiener",
+        "nodeTitle": "Cybernetics: Or Control and Communication in the Animal and the Machine"
+      }
+    ]
+  },
+  "A_Mathematical_Theory_of_Communication": {
+    "wikidataId": "Q724029",
+    "wikipediaTitle": "A_Mathematical_Theory_of_Communication",
+    "canonicalTitle": "A Mathematical Theory of Communication",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-information-theory-shannon",
+        "nodeTitle": "A Mathematical Theory of Communication"
+      },
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-math-theory-communication-book",
+        "nodeTitle": "The Mathematical Theory of Communication (book)"
+      }
+    ]
+  },
+  "On_Computable_Numbers,_with_an_Application_to_the_Entscheidungsproblem": {
+    "wikidataId": "Q7854954",
+    "wikipediaTitle": "On_Computable_Numbers,_with_an_Application_to_the_Entscheidungsproblem",
+    "canonicalTitle": "On Computable Numbers, with an Application to the Entscheidungsproblem",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-computable-numbers-turing",
+        "nodeTitle": "On Computable Numbers, with an Application to the Entscheidungsproblem"
+      }
+    ]
+  },
+  "Computing_Machinery_and_Intelligence": {
+    "wikidataId": "Q772056",
+    "wikipediaTitle": "Computing_Machinery_and_Intelligence",
+    "canonicalTitle": "Computing Machinery and Intelligence",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-computing-machinery-turing",
+        "nodeTitle": "Computing Machinery and Intelligence"
+      }
+    ]
+  },
+  "A_Logical_Calculus_of_the_Ideas_Immanent_in_Nervous_Activity": {
+    "wikidataId": "Q22337370",
+    "wikipediaTitle": "A_Logical_Calculus_of_the_Ideas_Immanent_in_Nervous_Activity",
+    "canonicalTitle": "A Logical Calculus of the Ideas Immanent in Nervous Activity",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-logical-calculus-mcculloch-pitts",
+        "nodeTitle": "A Logical Calculus of the Ideas Immanent in Nervous Activity"
+      }
+    ]
+  },
+  "What_the_Frog's_Eye_Tells_the_Frog's_Brain": {
+    "wikidataId": null,
+    "wikipediaTitle": "What_the_Frog's_Eye_Tells_the_Frog's_Brain",
+    "canonicalTitle": "What the Frog's Eye Tells the Frog's Brain",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-frogs-eye-lettvin",
+        "nodeTitle": "What the Frog's Eye Tells the Frog's Brain"
+      }
+    ]
+  },
+  "Perceptrons_(book)": {
+    "wikidataId": "Q4359403",
+    "wikipediaTitle": "Perceptrons_(book)",
+    "canonicalTitle": "Perceptrons: An Introduction to Computational Geometry",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-perceptrons-minsky-papert",
+        "nodeTitle": "Perceptrons: An Introduction to Computational Geometry"
+      }
+    ]
+  },
+  "The_Organization_of_Behavior": {
+    "wikidataId": null,
+    "wikipediaTitle": "The_Organization_of_Behavior",
+    "canonicalTitle": "The Organization of Behavior",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-organization-behavior-hebb",
+        "nodeTitle": "The Organization of Behavior"
+      }
+    ]
+  },
+  "Design_for_a_Brain": {
+    "wikidataId": null,
+    "wikipediaTitle": "Design_for_a_Brain",
+    "canonicalTitle": "Design for a Brain",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-design-brain-ashby",
+        "nodeTitle": "Design for a Brain"
+      }
+    ]
+  },
+  "An_Introduction_to_Cybernetics": {
+    "wikidataId": "Q97359298",
+    "wikipediaTitle": "An_Introduction_to_Cybernetics",
+    "canonicalTitle": "An Introduction to Cybernetics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-intro-cybernetics-ashby",
+        "nodeTitle": "An Introduction to Cybernetics"
+      }
+    ]
+  },
+  "The_Living_Brain": {
+    "wikidataId": "Q136953442",
+    "wikipediaTitle": "The_Living_Brain",
+    "canonicalTitle": "The Living Brain",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-living-brain-walter",
+        "nodeTitle": "The Living Brain"
+      }
+    ]
+  },
+  "Behavior,_Purpose_and_Teleology": {
+    "wikidataId": null,
+    "wikipediaTitle": "Behavior,_Purpose_and_Teleology",
+    "canonicalTitle": "Behavior, Purpose and Teleology",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-behavior-purpose-teleology",
+        "nodeTitle": "Behavior, Purpose and Teleology"
+      }
+    ]
+  },
+  "The_Human_Use_of_Human_Beings": {
+    "wikidataId": "Q7740888",
+    "wikipediaTitle": "The_Human_Use_of_Human_Beings",
+    "canonicalTitle": "The Human Use of Human Beings",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-human-use-wiener",
+        "nodeTitle": "The Human Use of Human Beings"
+      }
+    ]
+  },
+  "General_System_Theory": {
+    "wikidataId": null,
+    "wikipediaTitle": "General_System_Theory",
+    "canonicalTitle": "General System Theory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-general-system-theory-bertalanffy",
+        "nodeTitle": "General System Theory"
+      }
+    ]
+  },
+  "Brain_of_the_Firm": {
+    "wikidataId": null,
+    "wikipediaTitle": "Brain_of_the_Firm",
+    "canonicalTitle": "Brain of the Firm",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-brain-firm-beer",
+        "nodeTitle": "Brain of the Firm"
+      }
+    ]
+  },
+  "Industrial_Dynamics": {
+    "wikidataId": null,
+    "wikipediaTitle": "Industrial_Dynamics",
+    "canonicalTitle": "Industrial Dynamics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-industrial-dynamics-forrester",
+        "nodeTitle": "Industrial Dynamics"
+      }
+    ]
+  },
+  "The_Limits_to_Growth": {
+    "wikidataId": "Q277111",
+    "wikipediaTitle": "The_Limits_to_Growth",
+    "canonicalTitle": "The Limits to Growth",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-limits-growth-meadows",
+        "nodeTitle": "The Limits to Growth"
+      }
+    ]
+  },
+  "Steps_to_an_Ecology_of_Mind": {
+    "wikidataId": "Q1970551",
+    "wikipediaTitle": "Steps_to_an_Ecology_of_Mind",
+    "canonicalTitle": "Steps to an Ecology of Mind",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-steps-ecology-mind-bateson",
+        "nodeTitle": "Steps to an Ecology of Mind"
+      }
+    ]
+  },
+  "Autopoiesis_and_Cognition": {
+    "wikidataId": null,
+    "wikipediaTitle": "Autopoiesis_and_Cognition",
+    "canonicalTitle": "Autopoiesis and Cognition: The Realization of the Living",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-autopoiesis-cognition",
+        "nodeTitle": "Autopoiesis and Cognition: The Realization of the Living"
+      }
+    ]
+  },
+  "The_Embodied_Mind": {
+    "wikidataId": null,
+    "wikipediaTitle": "The_Embodied_Mind",
+    "canonicalTitle": "The Embodied Mind: Cognitive Science and Human Experience",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-embodied-mind-varela",
+        "nodeTitle": "The Embodied Mind: Cognitive Science and Human Experience"
+      }
+    ]
+  },
+  "First_Draft_of_a_Report_on_the_EDVAC": {
+    "wikidataId": "Q5452926",
+    "wikipediaTitle": "First_Draft_of_a_Report_on_the_EDVAC",
+    "canonicalTitle": "First Draft of a Report on the EDVAC",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-edvac-report-neumann",
+        "nodeTitle": "First Draft of a Report on the EDVAC"
+      }
+    ]
+  },
+  "Theory_of_Games_and_Economic_Behavior": {
+    "wikidataId": "Q5226156",
+    "wikipediaTitle": "Theory_of_Games_and_Economic_Behavior",
+    "canonicalTitle": "Theory of Games and Economic Behavior",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-game-theory-neumann-morgenstern",
+        "nodeTitle": "Theory of Games and Economic Behavior"
+      }
+    ]
+  },
+  "The_Computer_and_the_Brain": {
+    "wikidataId": "Q7727248",
+    "wikipediaTitle": "The_Computer_and_the_Brain",
+    "canonicalTitle": "The Computer and the Brain",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-computer-brain-neumann",
+        "nodeTitle": "The Computer and the Brain"
+      }
+    ]
+  },
+  "Dartmouth_workshop": {
+    "wikidataId": "Q2453355",
+    "wikipediaTitle": "Dartmouth_workshop",
+    "canonicalTitle": "A Proposal for the Dartmouth Summer Research Project on Artificial Intelligence",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-dartmouth-proposal",
+        "nodeTitle": "A Proposal for the Dartmouth Summer Research Project on Artificial Intelligence"
+      },
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-dartmouth-conference",
+        "nodeTitle": "Dartmouth Conference"
+      }
+    ]
+  },
+  "Man-Computer_Symbiosis": {
+    "wikidataId": null,
+    "wikipediaTitle": "Man-Computer_Symbiosis",
+    "canonicalTitle": "Man-Computer Symbiosis",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-man-computer-symbiosis-licklider",
+        "nodeTitle": "Man-Computer Symbiosis"
+      }
+    ]
+  },
+  "The_Society_of_Mind": {
+    "wikidataId": "Q2414313",
+    "wikipediaTitle": "The_Society_of_Mind",
+    "canonicalTitle": "The Society of Mind",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-society-mind-minsky",
+        "nodeTitle": "The Society of Mind"
+      }
+    ]
+  },
+  "Unified_Theories_of_Cognition": {
+    "wikidataId": "Q7884967",
+    "wikipediaTitle": "Unified_Theories_of_Cognition",
+    "canonicalTitle": "Unified Theories of Cognition",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-unified-theories-newell",
+        "nodeTitle": "Unified Theories of Cognition"
+      }
+    ]
+  },
+  "Homeostat": {
+    "wikidataId": "Q1048881",
+    "wikipediaTitle": "Homeostat",
+    "canonicalTitle": "The Homeostat",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-homeostat-ashby",
+        "nodeTitle": "The Homeostat"
+      }
+    ]
+  },
+  "Turtle_(robot)": {
+    "wikidataId": "Q3532550",
+    "wikipediaTitle": "Turtle_(robot)",
+    "canonicalTitle": "Tortoise Robots (Elmer and Elsie)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-tortoise-robots-walter",
+        "nodeTitle": "Tortoise Robots (Elmer and Elsie)"
+      }
+    ]
+  },
+  "Perceptron": {
+    "wikidataId": "Q690207",
+    "wikipediaTitle": "Perceptron",
+    "canonicalTitle": "Mark I Perceptron",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-perceptron-hardware",
+        "nodeTitle": "Mark I Perceptron"
+      }
+    ]
+  },
+  "ENIAC": {
+    "wikidataId": "Q169399",
+    "wikipediaTitle": "ENIAC",
+    "canonicalTitle": "ENIAC",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-eniac",
+        "nodeTitle": "ENIAC"
+      }
+    ]
+  },
+  "Colossus_computer": {
+    "wikidataId": "Q770597",
+    "wikipediaTitle": "Colossus_computer",
+    "canonicalTitle": "Colossus",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-colossus",
+        "nodeTitle": "Colossus"
+      }
+    ]
+  },
+  "EDSAC": {
+    "wikidataId": "Q863565",
+    "wikipediaTitle": "EDSAC",
+    "canonicalTitle": "EDSAC",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-edsac",
+        "nodeTitle": "EDSAC"
+      }
+    ]
+  },
+  "NLS_(computer_system)": {
+    "wikidataId": "Q1050365",
+    "wikipediaTitle": "NLS_(computer_system)",
+    "canonicalTitle": "NLS/Augment System & Mouse",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "object-nls-engelbart",
+        "nodeTitle": "NLS/Augment System & Mouse"
+      }
+    ]
+  },
+  "Massachusetts_Institute_of_Technology": {
+    "wikidataId": "Q49108",
+    "wikipediaTitle": "Massachusetts_Institute_of_Technology",
+    "canonicalTitle": "Massachusetts Institute of Technology",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-mit",
+        "nodeTitle": "Massachusetts Institute of Technology"
+      }
+    ]
+  },
+  "Bell_Labs": {
+    "wikidataId": "Q217365",
+    "wikipediaTitle": "Bell_Labs",
+    "canonicalTitle": "Bell Labs",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-bell-labs",
+        "nodeTitle": "Bell Labs"
+      },
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-bell-labs-research",
+        "nodeTitle": "Bell Labs Research"
+      }
+    ]
+  },
+  "Institute_for_Advanced_Study": {
+    "wikidataId": "Q635642",
+    "wikipediaTitle": "Institute_for_Advanced_Study",
+    "canonicalTitle": "Institute for Advanced Study",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-ias-princeton",
+        "nodeTitle": "Institute for Advanced Study"
+      }
+    ]
+  },
+  "Biological_Computer_Laboratory": {
+    "wikidataId": "Q164591",
+    "wikipediaTitle": "Biological_Computer_Laboratory",
+    "canonicalTitle": "Biological Computer Laboratory (BCL)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-bcl-illinois",
+        "nodeTitle": "Biological Computer Laboratory (BCL)"
+      },
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-bcl",
+        "nodeTitle": "Biological Computer Laboratory"
+      }
+    ]
+  },
+  "SRI_International": {
+    "wikidataId": "Q604924",
+    "wikipediaTitle": "SRI_International",
+    "canonicalTitle": "Stanford Research Institute (SRI)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-sri",
+        "nodeTitle": "Stanford Research Institute (SRI)"
+      }
+    ]
+  },
+  "University_of_Cambridge": {
+    "wikidataId": "Q35794",
+    "wikipediaTitle": "University_of_Cambridge",
+    "canonicalTitle": "Cambridge University",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-cambridge",
+        "nodeTitle": "Cambridge University"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-cambridge",
+        "nodeTitle": "University of Cambridge"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-cambridge-university",
+        "nodeTitle": "University of Cambridge"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-cambridge",
+        "nodeTitle": "University of Cambridge"
+      }
+    ]
+  },
+  "University_of_Manchester": {
+    "wikidataId": "Q230899",
+    "wikipediaTitle": "University_of_Manchester",
+    "canonicalTitle": "University of Manchester",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-manchester",
+        "nodeTitle": "University of Manchester"
+      }
+    ]
+  },
+  "Bletchley_Park": {
+    "wikidataId": "Q155921",
+    "wikipediaTitle": "Bletchley_Park",
+    "canonicalTitle": "Bletchley Park",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-bletchley-park",
+        "nodeTitle": "Bletchley Park"
+      }
+    ]
+  },
+  "National_Physical_Laboratory_(United_Kingdom)": {
+    "wikidataId": "Q1967606",
+    "wikipediaTitle": "National_Physical_Laboratory_(United_Kingdom)",
+    "canonicalTitle": "National Physical Laboratory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-npl",
+        "nodeTitle": "National Physical Laboratory"
+      }
+    ]
+  },
+  "Burden_Neurological_Institute": {
+    "wikidataId": null,
+    "wikipediaTitle": "Burden_Neurological_Institute",
+    "canonicalTitle": "Burden Neurological Institute",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-burden-institute",
+        "nodeTitle": "Burden Neurological Institute"
+      }
+    ]
+  },
+  "Dartmouth_College": {
+    "wikidataId": "Q49116",
+    "wikipediaTitle": "Dartmouth_College",
+    "canonicalTitle": "Dartmouth College",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-dartmouth",
+        "nodeTitle": "Dartmouth College"
+      }
+    ]
+  },
+  "University_of_Chile": {
+    "wikidataId": "Q232141",
+    "wikipediaTitle": "University_of_Chile",
+    "canonicalTitle": "University of Chile",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-chile",
+        "nodeTitle": "University of Chile"
+      }
+    ]
+  },
+  "Project_Cybersyn": {
+    "wikidataId": "Q1147211",
+    "wikipediaTitle": "Project_Cybersyn",
+    "canonicalTitle": "OPSROOM (Cybersyn)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-opsroom-chile",
+        "nodeTitle": "OPSROOM (Cybersyn)"
+      },
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-cybersyn",
+        "nodeTitle": "Cybersyn (Project Synco)"
+      }
+    ]
+  },
+  "Vienna": {
+    "wikidataId": "Q1741",
+    "wikipediaTitle": "Vienna",
+    "canonicalTitle": "Vienna",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-vienna",
+        "nodeTitle": "Vienna"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-vienna",
+        "nodeTitle": "Vienna"
+      }
+    ]
+  },
+  "McGill_University": {
+    "wikidataId": "Q201492",
+    "wikipediaTitle": "McGill_University",
+    "canonicalTitle": "McGill University",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-mcgill",
+        "nodeTitle": "McGill University"
+      }
+    ]
+  },
+  "University_of_Michigan": {
+    "wikidataId": "Q230492",
+    "wikipediaTitle": "University_of_Michigan",
+    "canonicalTitle": "University of Michigan",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-michigan",
+        "nodeTitle": "University of Michigan"
+      }
+    ]
+  },
+  "Moore_School_of_Electrical_Engineering": {
+    "wikidataId": "Q6908229",
+    "wikipediaTitle": "Moore_School_of_Electrical_Engineering",
+    "canonicalTitle": "Moore School of Electrical Engineering",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-moore-school",
+        "nodeTitle": "Moore School of Electrical Engineering"
+      }
+    ]
+  },
+  "RAND_Corporation": {
+    "wikidataId": "Q861141",
+    "wikipediaTitle": "RAND_Corporation",
+    "canonicalTitle": "RAND Corporation",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-rand",
+        "nodeTitle": "RAND Corporation"
+      }
+    ]
+  },
+  "Cornell_Aeronautical_Laboratory": {
+    "wikidataId": null,
+    "wikipediaTitle": "Cornell_Aeronautical_Laboratory",
+    "canonicalTitle": "Cornell Aeronautical Laboratory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-cornell-aero",
+        "nodeTitle": "Cornell Aeronautical Laboratory"
+      }
+    ]
+  },
+  "Los_Alamos_National_Laboratory": {
+    "wikidataId": "Q379848",
+    "wikipediaTitle": "Los_Alamos_National_Laboratory",
+    "canonicalTitle": "Los Alamos National Laboratory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-los-alamos",
+        "nodeTitle": "Los Alamos National Laboratory"
+      }
+    ]
+  },
+  "Harvard_University": {
+    "wikidataId": "Q13371",
+    "wikipediaTitle": "Harvard_University",
+    "canonicalTitle": "Harvard University",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "location-harvard",
+        "nodeTitle": "Harvard University"
+      }
+    ]
+  },
+  "Macy_conferences": {
+    "wikidataId": "Q143363",
+    "wikipediaTitle": "Macy_conferences",
+    "canonicalTitle": "Macy Conferences on Cybernetics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-macy-conferences",
+        "nodeTitle": "Macy Conferences on Cybernetics"
+      }
+    ]
+  },
+  "Ratio_Club": {
+    "wikidataId": "Q3420069",
+    "wikipediaTitle": "Ratio_Club",
+    "canonicalTitle": "Ratio Club",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-ratio-club",
+        "nodeTitle": "Ratio Club"
+      }
+    ]
+  },
+  "International_Society_for_the_Systems_Sciences": {
+    "wikidataId": "Q4330297",
+    "wikipediaTitle": "International_Society_for_the_Systems_Sciences",
+    "canonicalTitle": "Society for General Systems Research",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-sgsr",
+        "nodeTitle": "Society for General Systems Research"
+      }
+    ]
+  },
+  "American_Society_for_Cybernetics": {
+    "wikidataId": "Q4745015",
+    "wikipediaTitle": "American_Society_for_Cybernetics",
+    "canonicalTitle": "American Society for Cybernetics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-american-cybernetics",
+        "nodeTitle": "American Society for Cybernetics"
+      }
+    ]
+  },
+  "MIT_Research_Laboratory_of_Electronics": {
+    "wikidataId": null,
+    "wikipediaTitle": "MIT_Research_Laboratory_of_Electronics",
+    "canonicalTitle": "MIT Research Laboratory of Electronics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-mit-rle",
+        "nodeTitle": "MIT Research Laboratory of Electronics"
+      }
+    ]
+  },
+  "MIT_Computer_Science_and_Artificial_Intelligence_Laboratory": {
+    "wikidataId": "Q1354917",
+    "wikipediaTitle": "MIT_Computer_Science_and_Artificial_Intelligence_Laboratory",
+    "canonicalTitle": "MIT Artificial Intelligence Laboratory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-mit-ai-lab",
+        "nodeTitle": "MIT Artificial Intelligence Laboratory"
+      }
+    ]
+  },
+  "Stanford_Artificial_Intelligence_Laboratory": {
+    "wikidataId": null,
+    "wikipediaTitle": "Stanford_Artificial_Intelligence_Laboratory",
+    "canonicalTitle": "Stanford Artificial Intelligence Laboratory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-stanford-ai-lab",
+        "nodeTitle": "Stanford Artificial Intelligence Laboratory"
+      }
+    ]
+  },
+  "Information_Processing_Techniques_Office": {
+    "wikidataId": "Q6030770",
+    "wikipediaTitle": "Information_Processing_Techniques_Office",
+    "canonicalTitle": "ARPA Information Processing Techniques Office",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-arpa-ipto",
+        "nodeTitle": "ARPA Information Processing Techniques Office"
+      }
+    ]
+  },
+  "Josiah_Macy_Jr._Foundation": {
+    "wikidataId": "Q6290556",
+    "wikipediaTitle": "Josiah_Macy_Jr._Foundation",
+    "canonicalTitle": "Josiah Macy Jr. Foundation",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-macy-foundation",
+        "nodeTitle": "Josiah Macy Jr. Foundation"
+      }
+    ]
+  },
+  "Rockefeller_Foundation": {
+    "wikidataId": "Q862034",
+    "wikipediaTitle": "Rockefeller_Foundation",
+    "canonicalTitle": "Rockefeller Foundation",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-rockefeller-foundation",
+        "nodeTitle": "Rockefeller Foundation"
+      }
+    ]
+  },
+  "Office_of_Naval_Research": {
+    "wikidataId": "Q1063818",
+    "wikipediaTitle": "Office_of_Naval_Research",
+    "canonicalTitle": "Office of Naval Research",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-onr",
+        "nodeTitle": "Office of Naval Research"
+      }
+    ]
+  },
+  "Cybernetics": {
+    "wikidataId": "Q123637",
+    "wikipediaTitle": "Cybernetics",
+    "canonicalTitle": "Cybernetics (Movement)",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-cybernetics-movement",
+        "nodeTitle": "Cybernetics (Movement)"
+      }
+    ]
+  },
+  "Information_theory": {
+    "wikidataId": "Q131222",
+    "wikipediaTitle": "Information_theory",
+    "canonicalTitle": "Information Theory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-information-theory",
+        "nodeTitle": "Information Theory"
+      }
+    ]
+  },
+  "Second-order_cybernetics": {
+    "wikidataId": "Q358532",
+    "wikipediaTitle": "Second-order_cybernetics",
+    "canonicalTitle": "Second-Order Cybernetics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-second-order-cybernetics",
+        "nodeTitle": "Second-Order Cybernetics"
+      }
+    ]
+  },
+  "Systems_theory": {
+    "wikidataId": "Q269699",
+    "wikipediaTitle": "Systems_theory",
+    "canonicalTitle": "General Systems Theory",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-general-systems-theory",
+        "nodeTitle": "General Systems Theory"
+      }
+    ]
+  },
+  "System_dynamics": {
+    "wikidataId": "Q598451",
+    "wikipediaTitle": "System_dynamics",
+    "canonicalTitle": "System Dynamics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-system-dynamics",
+        "nodeTitle": "System Dynamics"
+      }
+    ]
+  },
+  "Management_cybernetics": {
+    "wikidataId": "Q1544281",
+    "wikipediaTitle": "Management_cybernetics",
+    "canonicalTitle": "Management Cybernetics",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-management-cybernetics",
+        "nodeTitle": "Management Cybernetics"
+      }
+    ]
+  },
+  "Symbolic_artificial_intelligence": {
+    "wikidataId": "Q5514059",
+    "wikipediaTitle": "Symbolic_artificial_intelligence",
+    "canonicalTitle": "Symbolic AI / GOFAI",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-symbolic-ai",
+        "nodeTitle": "Symbolic AI / GOFAI"
+      }
+    ]
+  },
+  "Connectionism": {
+    "wikidataId": "Q203790",
+    "wikipediaTitle": "Connectionism",
+    "canonicalTitle": "Connectionism / Neural Networks",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-connectionism",
+        "nodeTitle": "Connectionism / Neural Networks"
+      }
+    ]
+  },
+  "Autopoiesis": {
+    "wikidataId": "Q599967",
+    "wikipediaTitle": "Autopoiesis",
+    "canonicalTitle": "Autopoiesis",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-autopoiesis",
+        "nodeTitle": "Autopoiesis"
+      }
+    ]
+  },
+  "Project_MAC": {
+    "wikidataId": "Q1354917",
+    "wikipediaTitle": "Project_MAC",
+    "canonicalTitle": "Project MAC",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-project-mac",
+        "nodeTitle": "Project MAC"
+      }
+    ]
+  },
+  "ARPANET": {
+    "wikidataId": "Q177524",
+    "wikipediaTitle": "ARPANET",
+    "canonicalTitle": "ARPANET",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-arpanet",
+        "nodeTitle": "ARPANET"
+      }
+    ]
+  },
+  "Whirlwind_I": {
+    "wikidataId": "Q1413683",
+    "wikipediaTitle": "Whirlwind_I",
+    "canonicalTitle": "Whirlwind / SAGE",
+    "appearances": [
+      {
+        "datasetId": "cybernetics-information-theory",
+        "datasetName": "Cybernetics & Information Theory",
+        "nodeId": "entity-whirlwind",
+        "nodeTitle": "Whirlwind / SAGE"
+      }
+    ]
+  },
+  "John_Locke": {
+    "wikidataId": "Q9353",
+    "wikipediaTitle": "John_Locke",
+    "canonicalTitle": "John Locke",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-john-locke",
+        "nodeTitle": "John Locke"
+      }
+    ]
+  },
+  "Isaac_Newton": {
+    "wikidataId": "Q935",
+    "wikipediaTitle": "Isaac_Newton",
+    "canonicalTitle": "Isaac Newton",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-isaac-newton",
+        "nodeTitle": "Isaac Newton"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-isaac-newton",
+        "nodeTitle": "Isaac Newton"
+      },
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-isaac-newton",
+        "nodeTitle": "Sir Isaac Newton"
+      }
+    ]
+  },
+  "Gottfried_Wilhelm_Leibniz": {
+    "wikidataId": "Q9047",
+    "wikipediaTitle": "Gottfried_Wilhelm_Leibniz",
+    "canonicalTitle": "Gottfried Wilhelm Leibniz",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-leibniz",
+        "nodeTitle": "Gottfried Wilhelm Leibniz"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-gottfried-leibniz",
+        "nodeTitle": "Gottfried Wilhelm Leibniz"
+      }
+    ]
+  },
+  "Voltaire": {
+    "wikidataId": "Q9068",
+    "wikipediaTitle": "Voltaire",
+    "canonicalTitle": "Voltaire",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-voltaire",
+        "nodeTitle": "Voltaire"
+      }
+    ]
+  },
+  "Denis_Diderot": {
+    "wikidataId": "Q448",
+    "wikipediaTitle": "Denis_Diderot",
+    "canonicalTitle": "Denis Diderot",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-diderot",
+        "nodeTitle": "Denis Diderot"
+      }
+    ]
+  },
+  "Jean_le_Rond_d'Alembert": {
+    "wikidataId": "Q153232",
+    "wikipediaTitle": "Jean_le_Rond_d'Alembert",
+    "canonicalTitle": "Jean le Rond d'Alembert",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-dalembert",
+        "nodeTitle": "Jean le Rond d'Alembert"
+      }
+    ]
+  },
+  "Montesquieu": {
+    "wikidataId": "Q15975",
+    "wikipediaTitle": "Montesquieu",
+    "canonicalTitle": "Montesquieu",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-montesquieu",
+        "nodeTitle": "Montesquieu"
+      }
+    ]
+  },
+  "Jean-Jacques_Rousseau": {
+    "wikidataId": "Q6527",
+    "wikipediaTitle": "Jean-Jacques_Rousseau",
+    "canonicalTitle": "Jean-Jacques Rousseau",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-rousseau",
+        "nodeTitle": "Jean-Jacques Rousseau"
+      }
+    ]
+  },
+  "Baron_d'Holbach": {
+    "wikidataId": "Q7104",
+    "wikipediaTitle": "Baron_d'Holbach",
+    "canonicalTitle": "Baron d'Holbach",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-dholbach",
+        "nodeTitle": "Baron d'Holbach"
+      }
+    ]
+  },
+  "Claude_Adrien_Helvétius": {
+    "wikidataId": "Q190302",
+    "wikipediaTitle": "Claude_Adrien_Helvétius",
+    "canonicalTitle": "Claude-Adrien Helvétius",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-helvetius",
+        "nodeTitle": "Claude-Adrien Helvétius"
+      }
+    ]
+  },
+  "Étienne_Bonnot_de_Condillac": {
+    "wikidataId": "Q272119",
+    "wikipediaTitle": "Étienne_Bonnot_de_Condillac",
+    "canonicalTitle": "Étienne Bonnot de Condillac",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-condillac",
+        "nodeTitle": "Étienne Bonnot de Condillac"
+      }
+    ]
+  },
+  "Marquis_de_Condorcet": {
+    "wikidataId": "Q201477",
+    "wikipediaTitle": "Marquis_de_Condorcet",
+    "canonicalTitle": "Nicolas de Condorcet",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-condorcet",
+        "nodeTitle": "Nicolas de Condorcet"
+      },
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-marquis-de-condorcet",
+        "nodeTitle": "Marquis de Condorcet"
+      }
+    ]
+  },
+  "Julien_Offray_de_La_Mettrie": {
+    "wikidataId": "Q7068",
+    "wikipediaTitle": "Julien_Offray_de_La_Mettrie",
+    "canonicalTitle": "Julien Offray de La Mettrie",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-la-mettrie",
+        "nodeTitle": "Julien Offray de La Mettrie"
+      }
+    ]
+  },
+  "Louis_de_Jaucourt": {
+    "wikidataId": "Q584990",
+    "wikipediaTitle": "Louis_de_Jaucourt",
+    "canonicalTitle": "Louis de Jaucourt",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-jaucourt",
+        "nodeTitle": "Louis de Jaucourt"
+      }
+    ]
+  },
+  "Étienne_Noël_Damilaville": {
+    "wikidataId": "Q3592308",
+    "wikipediaTitle": "Étienne_Noël_Damilaville",
+    "canonicalTitle": "Étienne Noël Damilaville",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-damilaville",
+        "nodeTitle": "Étienne Noël Damilaville"
+      }
+    ]
+  },
+  "André_Morellet": {
+    "wikidataId": "Q178653",
+    "wikipediaTitle": "André_Morellet",
+    "canonicalTitle": "André Morellet",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-morellet",
+        "nodeTitle": "André Morellet"
+      }
+    ]
+  },
+  "David_Hume": {
+    "wikidataId": "Q37160",
+    "wikipediaTitle": "David_Hume",
+    "canonicalTitle": "David Hume",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-david-hume",
+        "nodeTitle": "David Hume"
+      }
+    ]
+  },
+  "Adam_Smith": {
+    "wikidataId": "Q9381",
+    "wikipediaTitle": "Adam_Smith",
+    "canonicalTitle": "Adam Smith",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-adam-smith",
+        "nodeTitle": "Adam Smith"
+      }
+    ]
+  },
+  "Francis_Hutcheson_(philosopher)": {
+    "wikidataId": "Q316367",
+    "wikipediaTitle": "Francis_Hutcheson_(philosopher)",
+    "canonicalTitle": "Francis Hutcheson",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-hutcheson",
+        "nodeTitle": "Francis Hutcheson"
+      }
+    ]
+  },
+  "Thomas_Reid": {
+    "wikidataId": "Q316347",
+    "wikipediaTitle": "Thomas_Reid",
+    "canonicalTitle": "Thomas Reid",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-thomas-reid",
+        "nodeTitle": "Thomas Reid"
+      }
+    ]
+  },
+  "Adam_Ferguson": {
+    "wikidataId": "Q183094",
+    "wikipediaTitle": "Adam_Ferguson",
+    "canonicalTitle": "Adam Ferguson",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-adam-ferguson",
+        "nodeTitle": "Adam Ferguson"
+      }
+    ]
+  },
+  "William_Robertson_(historian)": {
+    "wikidataId": "Q1113461",
+    "wikipediaTitle": "William_Robertson_(historian)",
+    "canonicalTitle": "William Robertson",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-william-robertson",
+        "nodeTitle": "William Robertson"
+      }
+    ]
+  },
+  "Henry_Home,_Lord_Kames": {
+    "wikidataId": "Q1341370",
+    "wikipediaTitle": "Henry_Home,_Lord_Kames",
+    "canonicalTitle": "Henry Home, Lord Kames",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-lord-kames",
+        "nodeTitle": "Henry Home, Lord Kames"
+      }
+    ]
+  },
+  "Dugald_Stewart": {
+    "wikidataId": "Q218254",
+    "wikipediaTitle": "Dugald_Stewart",
+    "canonicalTitle": "Dugald Stewart",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-dugald-stewart",
+        "nodeTitle": "Dugald Stewart"
+      }
+    ]
+  },
+  "Immanuel_Kant": {
+    "wikidataId": "Q9312",
+    "wikipediaTitle": "Immanuel_Kant",
+    "canonicalTitle": "Immanuel Kant",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-immanuel-kant",
+        "nodeTitle": "Immanuel Kant"
+      }
+    ]
+  },
+  "Christian_Wolff_(philosopher)": {
+    "wikidataId": "Q76510",
+    "wikipediaTitle": "Christian_Wolff_(philosopher)",
+    "canonicalTitle": "Christian Wolff",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-christian-wolff",
+        "nodeTitle": "Christian Wolff"
+      }
+    ]
+  },
+  "Moses_Mendelssohn": {
+    "wikidataId": "Q76997",
+    "wikipediaTitle": "Moses_Mendelssohn",
+    "canonicalTitle": "Moses Mendelssohn",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-moses-mendelssohn",
+        "nodeTitle": "Moses Mendelssohn"
+      }
+    ]
+  },
+  "Gotthold_Ephraim_Lessing": {
+    "wikidataId": "Q34628",
+    "wikipediaTitle": "Gotthold_Ephraim_Lessing",
+    "canonicalTitle": "Gotthold Ephraim Lessing",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-gotthold-lessing",
+        "nodeTitle": "Gotthold Ephraim Lessing"
+      }
+    ]
+  },
+  "Johann_Gottfried_Herder": {
+    "wikidataId": "Q155547",
+    "wikipediaTitle": "Johann_Gottfried_Herder",
+    "canonicalTitle": "Johann Gottfried Herder",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-johann-herder",
+        "nodeTitle": "Johann Gottfried Herder"
+      }
+    ]
+  },
+  "Alexander_Gottlieb_Baumgarten": {
+    "wikidataId": "Q76517",
+    "wikipediaTitle": "Alexander_Gottlieb_Baumgarten",
+    "canonicalTitle": "Alexander Gottlieb Baumgarten",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-baumgarten",
+        "nodeTitle": "Alexander Gottlieb Baumgarten"
+      }
+    ]
+  },
+  "Johann_Wolfgang_von_Goethe": {
+    "wikidataId": "Q5879",
+    "wikipediaTitle": "Johann_Wolfgang_von_Goethe",
+    "canonicalTitle": "Johann Wolfgang von Goethe",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-goethe",
+        "nodeTitle": "Johann Wolfgang von Goethe"
+      }
+    ]
+  },
+  "George_Berkeley": {
+    "wikidataId": "Q82049",
+    "wikipediaTitle": "George_Berkeley",
+    "canonicalTitle": "George Berkeley",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-george-berkeley",
+        "nodeTitle": "George Berkeley"
+      }
+    ]
+  },
+  "Anthony_Ashley-Cooper,_3rd_Earl_of_Shaftesbury": {
+    "wikidataId": "Q335112",
+    "wikipediaTitle": "Anthony_Ashley-Cooper,_3rd_Earl_of_Shaftesbury",
+    "canonicalTitle": "Anthony Ashley Cooper, 3rd Earl of Shaftesbury",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-shaftesbury",
+        "nodeTitle": "Anthony Ashley Cooper, 3rd Earl of Shaftesbury"
+      }
+    ]
+  },
+  "Bernard_Mandeville": {
+    "wikidataId": "Q379912",
+    "wikipediaTitle": "Bernard_Mandeville",
+    "canonicalTitle": "Bernard Mandeville",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-mandeville",
+        "nodeTitle": "Bernard Mandeville"
+      }
+    ]
+  },
+  "Edmund_Burke": {
+    "wikidataId": "Q165792",
+    "wikipediaTitle": "Edmund_Burke",
+    "canonicalTitle": "Edmund Burke",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-edmund-burke",
+        "nodeTitle": "Edmund Burke"
+      }
+    ]
+  },
+  "Joseph_Priestley": {
+    "wikidataId": "Q159636",
+    "wikipediaTitle": "Joseph_Priestley",
+    "canonicalTitle": "Joseph Priestley",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-joseph-priestley",
+        "nodeTitle": "Joseph Priestley"
+      }
+    ]
+  },
+  "Jeremy_Bentham": {
+    "wikidataId": "Q60887",
+    "wikipediaTitle": "Jeremy_Bentham",
+    "canonicalTitle": "Jeremy Bentham",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-jeremy-bentham",
+        "nodeTitle": "Jeremy Bentham"
+      }
+    ]
+  },
+  "Thomas_Paine": {
+    "wikidataId": "Q126462",
+    "wikipediaTitle": "Thomas_Paine",
+    "canonicalTitle": "Thomas Paine",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-thomas-paine",
+        "nodeTitle": "Thomas Paine"
+      }
+    ]
+  },
+  "Cesare_Beccaria": {
+    "wikidataId": "Q223723",
+    "wikipediaTitle": "Cesare_Beccaria",
+    "canonicalTitle": "Cesare Beccaria",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-cesare-beccaria",
+        "nodeTitle": "Cesare Beccaria"
+      }
+    ]
+  },
+  "François_Quesnay": {
+    "wikidataId": "Q13575",
+    "wikipediaTitle": "François_Quesnay",
+    "canonicalTitle": "François Quesnay",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-francois-quesnay",
+        "nodeTitle": "François Quesnay"
+      }
+    ]
+  },
+  "Anne_Robert_Jacques_Turgot": {
+    "wikidataId": "Q221303",
+    "wikipediaTitle": "Anne_Robert_Jacques_Turgot",
+    "canonicalTitle": "Anne-Robert-Jacques Turgot",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-turgot",
+        "nodeTitle": "Anne-Robert-Jacques Turgot"
+      }
+    ]
+  },
+  "Victor_de_Riqueti,_marquis_de_Mirabeau": {
+    "wikidataId": "Q947485",
+    "wikipediaTitle": "Victor_de_Riqueti,_marquis_de_Mirabeau",
+    "canonicalTitle": "Victor de Riqueti, Marquis de Mirabeau",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-mirabeau-elder",
+        "nodeTitle": "Victor de Riqueti, Marquis de Mirabeau"
+      }
+    ]
+  },
+  "Benjamin_Franklin": {
+    "wikidataId": "Q34969",
+    "wikipediaTitle": "Benjamin_Franklin",
+    "canonicalTitle": "Benjamin Franklin",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-benjamin-franklin",
+        "nodeTitle": "Benjamin Franklin"
+      }
+    ]
+  },
+  "Thomas_Jefferson": {
+    "wikidataId": "Q11812",
+    "wikipediaTitle": "Thomas_Jefferson",
+    "canonicalTitle": "Thomas Jefferson",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-thomas-jefferson",
+        "nodeTitle": "Thomas Jefferson"
+      }
+    ]
+  },
+  "James_Madison": {
+    "wikidataId": "Q11813",
+    "wikipediaTitle": "James_Madison",
+    "canonicalTitle": "James Madison",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-james-madison",
+        "nodeTitle": "James Madison"
+      }
+    ]
+  },
+  "John_Adams": {
+    "wikidataId": "Q11806",
+    "wikipediaTitle": "John_Adams",
+    "canonicalTitle": "John Adams",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-john-adams",
+        "nodeTitle": "John Adams"
+      }
+    ]
+  },
+  "Leonhard_Euler": {
+    "wikidataId": "Q7604",
+    "wikipediaTitle": "Leonhard_Euler",
+    "canonicalTitle": "Leonhard Euler",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-leonhard-euler",
+        "nodeTitle": "Leonhard Euler"
+      }
+    ]
+  },
+  "Pierre-Simon_Laplace": {
+    "wikidataId": "Q44481",
+    "wikipediaTitle": "Pierre-Simon_Laplace",
+    "canonicalTitle": "Pierre-Simon Laplace",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-laplace",
+        "nodeTitle": "Pierre-Simon Laplace"
+      },
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-pierre-simon-laplace",
+        "nodeTitle": "Pierre-Simon Laplace"
+      }
+    ]
+  },
+  "Antoine_Lavoisier": {
+    "wikidataId": "Q39607",
+    "wikipediaTitle": "Antoine_Lavoisier",
+    "canonicalTitle": "Antoine Lavoisier",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-lavoisier",
+        "nodeTitle": "Antoine Lavoisier"
+      }
+    ]
+  },
+  "Georges-Louis_Leclerc,_Comte_de_Buffon": {
+    "wikidataId": "Q229264",
+    "wikipediaTitle": "Georges-Louis_Leclerc,_Comte_de_Buffon",
+    "canonicalTitle": "Georges-Louis Leclerc, Comte de Buffon",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-buffon",
+        "nodeTitle": "Georges-Louis Leclerc, Comte de Buffon"
+      }
+    ]
+  },
+  "Émilie_du_Châtelet": {
+    "wikidataId": "Q7286",
+    "wikipediaTitle": "Émilie_du_Châtelet",
+    "canonicalTitle": "Émilie du Châtelet",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-emilie-du-chatelet",
+        "nodeTitle": "Émilie du Châtelet"
+      }
+    ]
+  },
+  "Joseph-Louis_Lagrange": {
+    "wikidataId": "Q80222",
+    "wikipediaTitle": "Joseph-Louis_Lagrange",
+    "canonicalTitle": "Joseph-Louis Lagrange",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-lagrange",
+        "nodeTitle": "Joseph-Louis Lagrange"
+      }
+    ]
+  },
+  "Marie_Thérèse_Rodet_Geoffrin": {
+    "wikidataId": "Q269865",
+    "wikipediaTitle": "Marie_Thérèse_Rodet_Geoffrin",
+    "canonicalTitle": "Marie-Thérèse Rodet Geoffrin",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-madame-geoffrin",
+        "nodeTitle": "Marie-Thérèse Rodet Geoffrin"
+      }
+    ]
+  },
+  "Julie_de_Lespinasse": {
+    "wikidataId": "Q450354",
+    "wikipediaTitle": "Julie_de_Lespinasse",
+    "canonicalTitle": "Julie de Lespinasse",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-julie-de-lespinasse",
+        "nodeTitle": "Julie de Lespinasse"
+      }
+    ]
+  },
+  "Marie_Anne_de_Vichy-Chamrond,_marquise_du_Deffand": {
+    "wikidataId": "Q297785",
+    "wikipediaTitle": "Marie_Anne_de_Vichy-Chamrond,_marquise_du_Deffand",
+    "canonicalTitle": "Marie de Vichy-Chamrond, Marquise du Deffand",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-madame-du-deffand",
+        "nodeTitle": "Marie de Vichy-Chamrond, Marquise du Deffand"
+      }
+    ]
+  },
+  "Anne-Catherine_de_Ligniville": {
+    "wikidataId": "Q461961",
+    "wikipediaTitle": "Anne-Catherine_de_Ligniville",
+    "canonicalTitle": "Anne-Catherine de Ligniville",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-madame-helvetius",
+        "nodeTitle": "Anne-Catherine de Ligniville"
+      }
+    ]
+  },
+  "Frederick_the_Great": {
+    "wikidataId": "Q33550",
+    "wikipediaTitle": "Frederick_the_Great",
+    "canonicalTitle": "Frederick II of Prussia",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-frederick-great",
+        "nodeTitle": "Frederick II of Prussia"
+      }
+    ]
+  },
+  "Catherine_the_Great": {
+    "wikidataId": "Q36450",
+    "wikipediaTitle": "Catherine_the_Great",
+    "canonicalTitle": "Catherine II of Russia",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "person-catherine-great",
+        "nodeTitle": "Catherine II of Russia"
+      }
+    ]
+  },
+  "Philosophiæ_Naturalis_Principia_Mathematica": {
+    "wikidataId": "Q205921",
+    "wikipediaTitle": "Philosophiæ_Naturalis_Principia_Mathematica",
+    "canonicalTitle": "Philosophiæ Naturalis Principia Mathematica",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-principia-mathematica",
+        "nodeTitle": "Philosophiæ Naturalis Principia Mathematica"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-principia",
+        "nodeTitle": "Philosophiæ Naturalis Principia Mathematica"
+      }
+    ]
+  },
+  "An_Essay_Concerning_Human_Understanding": {
+    "wikidataId": "Q482438",
+    "wikipediaTitle": "An_Essay_Concerning_Human_Understanding",
+    "canonicalTitle": "Essay Concerning Human Understanding",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-essay-human-understanding",
+        "nodeTitle": "Essay Concerning Human Understanding"
+      }
+    ]
+  },
+  "Two_Treatises_of_Government": {
+    "wikidataId": "Q231949",
+    "wikipediaTitle": "Two_Treatises_of_Government",
+    "canonicalTitle": "Two Treatises of Government",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-two-treatises",
+        "nodeTitle": "Two Treatises of Government"
+      }
+    ]
+  },
+  "A_Letter_Concerning_Toleration": {
+    "wikidataId": "Q914139",
+    "wikipediaTitle": "A_Letter_Concerning_Toleration",
+    "canonicalTitle": "A Letter Concerning Toleration",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-letter-toleration",
+        "nodeTitle": "A Letter Concerning Toleration"
+      }
+    ]
+  },
+  "Opticks": {
+    "wikidataId": "Q74263",
+    "wikipediaTitle": "Opticks",
+    "canonicalTitle": "Opticks",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-opticks",
+        "nodeTitle": "Opticks"
+      }
+    ]
+  },
+  "Théodicée": {
+    "wikidataId": "Q2166858",
+    "wikipediaTitle": "Théodicée",
+    "canonicalTitle": "Theodicy",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-theodicy",
+        "nodeTitle": "Theodicy"
+      }
+    ]
+  },
+  "Characteristics_of_Men,_Manners,_Opinions,_Times": {
+    "wikidataId": "Q335112",
+    "wikipediaTitle": "Characteristics_of_Men,_Manners,_Opinions,_Times",
+    "canonicalTitle": "Characteristics of Men, Manners, Opinions, Times",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-characteristics",
+        "nodeTitle": "Characteristics of Men, Manners, Opinions, Times"
+      }
+    ]
+  },
+  "The_Fable_of_the_Bees": {
+    "wikidataId": "Q1171104",
+    "wikipediaTitle": "The_Fable_of_the_Bees",
+    "canonicalTitle": "The Fable of the Bees",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-fable-bees",
+        "nodeTitle": "The Fable of the Bees"
+      }
+    ]
+  },
+  "Monadology": {
+    "wikidataId": "Q1211539",
+    "wikipediaTitle": "Monadology",
+    "canonicalTitle": "Monadology",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-monadology",
+        "nodeTitle": "Monadology"
+      }
+    ]
+  },
+  "Persian_Letters": {
+    "wikidataId": "Q1050479",
+    "wikipediaTitle": "Persian_Letters",
+    "canonicalTitle": "Persian Letters",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-persian-letters",
+        "nodeTitle": "Persian Letters"
+      }
+    ]
+  },
+  "Letters_on_the_English": {
+    "wikidataId": "Q2551373",
+    "wikipediaTitle": "Letters_on_the_English",
+    "canonicalTitle": "Letters on the English",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-letters-english",
+        "nodeTitle": "Letters on the English"
+      }
+    ]
+  },
+  "Traité_de_Dynamique": {
+    "wikidataId": null,
+    "wikipediaTitle": "Traité_de_Dynamique",
+    "canonicalTitle": "Traité de dynamique",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-traite-dynamique",
+        "nodeTitle": "Traité de dynamique"
+      }
+    ]
+  },
+  "Essay_on_the_Origin_of_Human_Knowledge": {
+    "wikidataId": null,
+    "wikipediaTitle": "Essay_on_the_Origin_of_Human_Knowledge",
+    "canonicalTitle": "Essay on the Origin of Human Knowledge",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-essay-origin-knowledge",
+        "nodeTitle": "Essay on the Origin of Human Knowledge"
+      }
+    ]
+  },
+  "Man_a_Machine": {
+    "wikidataId": "Q3203583",
+    "wikipediaTitle": "Man_a_Machine",
+    "canonicalTitle": "Man a Machine",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-homme-machine",
+        "nodeTitle": "Man a Machine"
+      }
+    ]
+  },
+  "The_Spirit_of_the_Laws": {
+    "wikidataId": "Q514727",
+    "wikipediaTitle": "The_Spirit_of_the_Laws",
+    "canonicalTitle": "The Spirit of the Laws",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-spirit-laws",
+        "nodeTitle": "The Spirit of the Laws"
+      }
+    ]
+  },
+  "Histoire_Naturelle": {
+    "wikidataId": "Q3138032",
+    "wikipediaTitle": "Histoire_Naturelle",
+    "canonicalTitle": "Histoire naturelle",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-histoire-naturelle",
+        "nodeTitle": "Histoire naturelle"
+      }
+    ]
+  },
+  "Encyclopédie": {
+    "wikidataId": "Q447",
+    "wikipediaTitle": "Encyclopédie",
+    "canonicalTitle": "Encyclopédie",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-encyclopedie",
+        "nodeTitle": "Encyclopédie"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-encyclopedie-project",
+        "nodeTitle": "Encyclopédie Project"
+      }
+    ]
+  },
+  "Preliminary_Discourse_to_the_Encyclopedia_of_Diderot": {
+    "wikidataId": "Q3030210",
+    "wikipediaTitle": "Preliminary_Discourse_to_the_Encyclopedia_of_Diderot",
+    "canonicalTitle": "Preliminary Discourse to the Encyclopedia",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-preliminary-discourse",
+        "nodeTitle": "Preliminary Discourse to the Encyclopedia"
+      }
+    ]
+  },
+  "Treatise_on_Sensations": {
+    "wikidataId": null,
+    "wikipediaTitle": "Treatise_on_Sensations",
+    "canonicalTitle": "Treatise on Sensations",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-treatise-sensations",
+        "nodeTitle": "Treatise on Sensations"
+      }
+    ]
+  },
+  "Discourse_on_Inequality": {
+    "wikidataId": "Q135598",
+    "wikipediaTitle": "Discourse_on_Inequality",
+    "canonicalTitle": "Discourse on the Origin of Inequality",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-discourse-inequality",
+        "nodeTitle": "Discourse on the Origin of Inequality"
+      }
+    ]
+  },
+  "De_l'esprit": {
+    "wikidataId": null,
+    "wikipediaTitle": "De_l'esprit",
+    "canonicalTitle": "De l'esprit",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-de-lesprit",
+        "nodeTitle": "De l'esprit"
+      }
+    ]
+  },
+  "Tableau_économique": {
+    "wikidataId": "Q1747160",
+    "wikipediaTitle": "Tableau_économique",
+    "canonicalTitle": "Tableau économique",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-tableau-economique",
+        "nodeTitle": "Tableau économique"
+      }
+    ]
+  },
+  "Candide": {
+    "wikidataId": "Q215894",
+    "wikipediaTitle": "Candide",
+    "canonicalTitle": "Candide",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-candide",
+        "nodeTitle": "Candide"
+      }
+    ]
+  },
+  "The_Social_Contract": {
+    "wikidataId": "Q190126",
+    "wikipediaTitle": "The_Social_Contract",
+    "canonicalTitle": "The Social Contract",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-social-contract",
+        "nodeTitle": "The Social Contract"
+      }
+    ]
+  },
+  "Emile,_or_On_Education": {
+    "wikidataId": "Q913599",
+    "wikipediaTitle": "Emile,_or_On_Education",
+    "canonicalTitle": "Emile, or On Education",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-emile",
+        "nodeTitle": "Emile, or On Education"
+      }
+    ]
+  },
+  "Dictionnaire_philosophique": {
+    "wikidataId": "Q656976",
+    "wikipediaTitle": "Dictionnaire_philosophique",
+    "canonicalTitle": "Philosophical Dictionary",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-philosophical-dictionary",
+        "nodeTitle": "Philosophical Dictionary"
+      }
+    ]
+  },
+  "Reflections_on_the_Formation_and_Distribution_of_Riches": {
+    "wikidataId": null,
+    "wikipediaTitle": "Reflections_on_the_Formation_and_Distribution_of_Riches",
+    "canonicalTitle": "Reflections on the Formation and Distribution of Wealth",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-reflections-wealth",
+        "nodeTitle": "Reflections on the Formation and Distribution of Wealth"
+      }
+    ]
+  },
+  "The_System_of_Nature": {
+    "wikidataId": "Q1111930",
+    "wikipediaTitle": "The_System_of_Nature",
+    "canonicalTitle": "The System of Nature",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-system-nature",
+        "nodeTitle": "The System of Nature"
+      }
+    ]
+  },
+  "Sketch_for_a_Historical_Picture_of_the_Progress_of_the_Human_Mind": {
+    "wikidataId": "Q7534728",
+    "wikipediaTitle": "Sketch_for_a_Historical_Picture_of_the_Progress_of_the_Human_Mind",
+    "canonicalTitle": "Sketch for a Historical Picture of the Progress of the Human Mind",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-sketch-progress",
+        "nodeTitle": "Sketch for a Historical Picture of the Progress of the Human Mind"
+      }
+    ]
+  },
+  "A_Treatise_Concerning_the_Principles_of_Human_Knowledge": {
+    "wikidataId": "Q3267928",
+    "wikipediaTitle": "A_Treatise_Concerning_the_Principles_of_Human_Knowledge",
+    "canonicalTitle": "A Treatise Concerning the Principles of Human Knowledge",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-principles-human-knowledge",
+        "nodeTitle": "A Treatise Concerning the Principles of Human Knowledge"
+      }
+    ]
+  },
+  "Three_Dialogues_between_Hylas_and_Philonous": {
+    "wikidataId": null,
+    "wikipediaTitle": "Three_Dialogues_between_Hylas_and_Philonous",
+    "canonicalTitle": "Three Dialogues between Hylas and Philonous",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-three-dialogues",
+        "nodeTitle": "Three Dialogues between Hylas and Philonous"
+      }
+    ]
+  },
+  "An_Inquiry_into_the_Original_of_Our_Ideas_of_Beauty_and_Virtue": {
+    "wikidataId": null,
+    "wikipediaTitle": "An_Inquiry_into_the_Original_of_Our_Ideas_of_Beauty_and_Virtue",
+    "canonicalTitle": "Inquiry into the Original of Our Ideas of Beauty and Virtue",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-inquiry-beauty-virtue",
+        "nodeTitle": "Inquiry into the Original of Our Ideas of Beauty and Virtue"
+      }
+    ]
+  },
+  "A_Treatise_of_Human_Nature": {
+    "wikidataId": "Q2451675",
+    "wikipediaTitle": "A_Treatise_of_Human_Nature",
+    "canonicalTitle": "A Treatise of Human Nature",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-treatise-human-nature",
+        "nodeTitle": "A Treatise of Human Nature"
+      }
+    ]
+  },
+  "An_Enquiry_Concerning_Human_Understanding": {
+    "wikidataId": "Q1306656",
+    "wikipediaTitle": "An_Enquiry_Concerning_Human_Understanding",
+    "canonicalTitle": "An Enquiry Concerning Human Understanding",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-enquiry-human-understanding",
+        "nodeTitle": "An Enquiry Concerning Human Understanding"
+      }
+    ]
+  },
+  "The_History_of_England_(Hume)": {
+    "wikidataId": "Q7739783",
+    "wikipediaTitle": "The_History_of_England_(Hume)",
+    "canonicalTitle": "History of England",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-history-england",
+        "nodeTitle": "History of England"
+      }
+    ]
+  },
+  "A_Philosophical_Enquiry_into_the_Origin_of_Our_Ideas_of_the_Sublime_and_Beautiful": {
+    "wikidataId": "Q947972",
+    "wikipediaTitle": "A_Philosophical_Enquiry_into_the_Origin_of_Our_Ideas_of_the_Sublime_and_Beautiful",
+    "canonicalTitle": "A Philosophical Enquiry into the Sublime and Beautiful",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-sublime-beautiful",
+        "nodeTitle": "A Philosophical Enquiry into the Sublime and Beautiful"
+      }
+    ]
+  },
+  "The_Theory_of_Moral_Sentiments": {
+    "wikidataId": "Q1438448",
+    "wikipediaTitle": "The_Theory_of_Moral_Sentiments",
+    "canonicalTitle": "The Theory of Moral Sentiments",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-theory-moral-sentiments",
+        "nodeTitle": "The Theory of Moral Sentiments"
+      }
+    ]
+  },
+  "History_of_Scotland_(Robertson)": {
+    "wikidataId": null,
+    "wikipediaTitle": "History_of_Scotland_(Robertson)",
+    "canonicalTitle": "History of Scotland",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-history-scotland",
+        "nodeTitle": "History of Scotland"
+      }
+    ]
+  },
+  "Elements_of_Criticism": {
+    "wikidataId": null,
+    "wikipediaTitle": "Elements_of_Criticism",
+    "canonicalTitle": "Elements of Criticism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-elements-criticism",
+        "nodeTitle": "Elements of Criticism"
+      }
+    ]
+  },
+  "Inquiry_into_the_Human_Mind": {
+    "wikidataId": null,
+    "wikipediaTitle": "Inquiry_into_the_Human_Mind",
+    "canonicalTitle": "Inquiry into the Human Mind on the Principles of Common Sense",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-inquiry-common-sense",
+        "nodeTitle": "Inquiry into the Human Mind on the Principles of Common Sense"
+      }
+    ]
+  },
+  "An_Essay_on_the_History_of_Civil_Society": {
+    "wikidataId": "Q4749931",
+    "wikipediaTitle": "An_Essay_on_the_History_of_Civil_Society",
+    "canonicalTitle": "Essay on the History of Civil Society",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-essay-civil-society",
+        "nodeTitle": "Essay on the History of Civil Society"
+      }
+    ]
+  },
+  "The_Wealth_of_Nations": {
+    "wikidataId": "Q233562",
+    "wikipediaTitle": "The_Wealth_of_Nations",
+    "canonicalTitle": "An Inquiry into the Nature and Causes of the Wealth of Nations",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-wealth-nations",
+        "nodeTitle": "An Inquiry into the Nature and Causes of the Wealth of Nations"
+      }
+    ]
+  },
+  "Dialogues_Concerning_Natural_Religion": {
+    "wikidataId": "Q965564",
+    "wikipediaTitle": "Dialogues_Concerning_Natural_Religion",
+    "canonicalTitle": "Dialogues Concerning Natural Religion",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-dialogues-natural-religion",
+        "nodeTitle": "Dialogues Concerning Natural Religion"
+      }
+    ]
+  },
+  "Reflections_on_the_Revolution_in_France": {
+    "wikidataId": "Q2287584",
+    "wikipediaTitle": "Reflections_on_the_Revolution_in_France",
+    "canonicalTitle": "Reflections on the Revolution in France",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-reflections-revolution",
+        "nodeTitle": "Reflections on the Revolution in France"
+      }
+    ]
+  },
+  "An_Introduction_to_the_Principles_of_Morals_and_Legislation": {
+    "wikidataId": "Q19041209",
+    "wikipediaTitle": "An_Introduction_to_the_Principles_of_Morals_and_Legislation",
+    "canonicalTitle": "Introduction to the Principles of Morals and Legislation",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-principles-morals-legislation",
+        "nodeTitle": "Introduction to the Principles of Morals and Legislation"
+      }
+    ]
+  },
+  "Aesthetica": {
+    "wikidataId": "Q3606120",
+    "wikipediaTitle": "Aesthetica",
+    "canonicalTitle": "Aesthetica",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-aesthetica",
+        "nodeTitle": "Aesthetica"
+      }
+    ]
+  },
+  "Laocoön_(essay)": {
+    "wikidataId": null,
+    "wikipediaTitle": "Laocoön_(essay)",
+    "canonicalTitle": "Laocoon: An Essay on the Limits of Painting and Poetry",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-laocoon",
+        "nodeTitle": "Laocoon: An Essay on the Limits of Painting and Poetry"
+      }
+    ]
+  },
+  "Phädon": {
+    "wikidataId": null,
+    "wikipediaTitle": "Phädon",
+    "canonicalTitle": "Phädon",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-phadon",
+        "nodeTitle": "Phädon"
+      }
+    ]
+  },
+  "Treatise_on_the_Origin_of_Language": {
+    "wikidataId": null,
+    "wikipediaTitle": "Treatise_on_the_Origin_of_Language",
+    "canonicalTitle": "Treatise on the Origin of Language",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-treatise-origin-language",
+        "nodeTitle": "Treatise on the Origin of Language"
+      }
+    ]
+  },
+  "Nathan_the_Wise": {
+    "wikidataId": "Q286611",
+    "wikipediaTitle": "Nathan_the_Wise",
+    "canonicalTitle": "Nathan the Wise",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-nathan-wise",
+        "nodeTitle": "Nathan the Wise"
+      }
+    ]
+  },
+  "Critique_of_Pure_Reason": {
+    "wikidataId": "Q220002",
+    "wikipediaTitle": "Critique_of_Pure_Reason",
+    "canonicalTitle": "Critique of Pure Reason",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-critique-pure-reason",
+        "nodeTitle": "Critique of Pure Reason"
+      }
+    ]
+  },
+  "Jerusalem_(Mendelssohn)": {
+    "wikidataId": null,
+    "wikipediaTitle": "Jerusalem_(Mendelssohn)",
+    "canonicalTitle": "Jerusalem, or On Religious Power and Judaism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-jerusalem",
+        "nodeTitle": "Jerusalem, or On Religious Power and Judaism"
+      }
+    ]
+  },
+  "Answering_the_Question:_What_Is_Enlightenment%3F": {
+    "wikidataId": null,
+    "wikipediaTitle": "Answering_the_Question:_What_Is_Enlightenment%3F",
+    "canonicalTitle": "What is Enlightenment?",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-what-is-enlightenment",
+        "nodeTitle": "What is Enlightenment?"
+      }
+    ]
+  },
+  "Outlines_of_a_Philosophy_of_the_History_of_Man": {
+    "wikidataId": null,
+    "wikipediaTitle": "Outlines_of_a_Philosophy_of_the_History_of_Man",
+    "canonicalTitle": "Ideas for the Philosophy of History of Humanity",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-ideas-philosophy-history",
+        "nodeTitle": "Ideas for the Philosophy of History of Humanity"
+      }
+    ]
+  },
+  "Critique_of_Practical_Reason": {
+    "wikidataId": "Q870851",
+    "wikipediaTitle": "Critique_of_Practical_Reason",
+    "canonicalTitle": "Critique of Practical Reason",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-critique-practical-reason",
+        "nodeTitle": "Critique of Practical Reason"
+      }
+    ]
+  },
+  "Critique_of_Judgment": {
+    "wikidataId": "Q1056332",
+    "wikipediaTitle": "Critique_of_Judgment",
+    "canonicalTitle": "Critique of Judgment",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-critique-judgment",
+        "nodeTitle": "Critique of Judgment"
+      }
+    ]
+  },
+  "On_Crimes_and_Punishments": {
+    "wikidataId": "Q2755269",
+    "wikipediaTitle": "On_Crimes_and_Punishments",
+    "canonicalTitle": "On Crimes and Punishments",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-crimes-punishments",
+        "nodeTitle": "On Crimes and Punishments"
+      }
+    ]
+  },
+  "Experiments_and_Observations_on_Electricity": {
+    "wikidataId": "Q19108828",
+    "wikipediaTitle": "Experiments_and_Observations_on_Electricity",
+    "canonicalTitle": "Experiments and Observations on Electricity",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-experiments-electricity",
+        "nodeTitle": "Experiments and Observations on Electricity"
+      }
+    ]
+  },
+  "Common_Sense": {
+    "wikidataId": "Q843940",
+    "wikipediaTitle": "Common_Sense",
+    "canonicalTitle": "Common Sense",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-common-sense",
+        "nodeTitle": "Common Sense"
+      }
+    ]
+  },
+  "United_States_Declaration_of_Independence": {
+    "wikidataId": "Q127912",
+    "wikipediaTitle": "United_States_Declaration_of_Independence",
+    "canonicalTitle": "Declaration of Independence",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-declaration-independence",
+        "nodeTitle": "Declaration of Independence"
+      }
+    ]
+  },
+  "Virginia_Statute_for_Religious_Freedom": {
+    "wikidataId": "Q4086736",
+    "wikipediaTitle": "Virginia_Statute_for_Religious_Freedom",
+    "canonicalTitle": "Virginia Statute for Religious Freedom",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-virginia-statute",
+        "nodeTitle": "Virginia Statute for Religious Freedom"
+      }
+    ]
+  },
+  "Notes_on_the_State_of_Virginia": {
+    "wikidataId": "Q4261404",
+    "wikipediaTitle": "Notes_on_the_State_of_Virginia",
+    "canonicalTitle": "Notes on the State of Virginia",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-notes-virginia",
+        "nodeTitle": "Notes on the State of Virginia"
+      }
+    ]
+  },
+  "The_Federalist_Papers": {
+    "wikidataId": "Q858036",
+    "wikipediaTitle": "The_Federalist_Papers",
+    "canonicalTitle": "The Federalist Papers",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-federalist-papers",
+        "nodeTitle": "The Federalist Papers"
+      }
+    ]
+  },
+  "Rights_of_Man": {
+    "wikidataId": "Q979108",
+    "wikipediaTitle": "Rights_of_Man",
+    "canonicalTitle": "Rights of Man",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-rights-man",
+        "nodeTitle": "Rights of Man"
+      }
+    ]
+  },
+  "The_Age_of_Reason": {
+    "wikidataId": "Q1983019",
+    "wikipediaTitle": "The_Age_of_Reason",
+    "canonicalTitle": "The Age of Reason",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-age-reason",
+        "nodeTitle": "The Age of Reason"
+      }
+    ]
+  },
+  "Traité_Élémentaire_de_Chimie": {
+    "wikidataId": "Q2163561",
+    "wikipediaTitle": "Traité_Élémentaire_de_Chimie",
+    "canonicalTitle": "Elements of Chemistry",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "object-elements-chemistry",
+        "nodeTitle": "Elements of Chemistry"
+      }
+    ]
+  },
+  "Edinburgh": {
+    "wikidataId": "Q23436",
+    "wikipediaTitle": "Edinburgh",
+    "canonicalTitle": "Edinburgh",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-edinburgh",
+        "nodeTitle": "Edinburgh"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-edinburgh",
+        "nodeTitle": "Edinburgh"
+      },
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "loc-edinburgh",
+        "nodeTitle": "Edinburgh"
+      }
+    ]
+  },
+  "Geneva": {
+    "wikidataId": "Q71",
+    "wikipediaTitle": "Geneva",
+    "canonicalTitle": "Geneva",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-geneva",
+        "nodeTitle": "Geneva"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-geneva",
+        "nodeTitle": "Geneva"
+      }
+    ]
+  },
+  "Amsterdam": {
+    "wikidataId": "Q727",
+    "wikipediaTitle": "Amsterdam",
+    "canonicalTitle": "Amsterdam",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-amsterdam",
+        "nodeTitle": "Amsterdam"
+      },
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-amsterdam",
+        "nodeTitle": "Amsterdam"
+      }
+    ]
+  },
+  "Glasgow": {
+    "wikidataId": "Q4093",
+    "wikipediaTitle": "Glasgow",
+    "canonicalTitle": "Glasgow",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-glasgow",
+        "nodeTitle": "Glasgow"
+      }
+    ]
+  },
+  "Philadelphia": {
+    "wikidataId": "Q1345",
+    "wikipediaTitle": "Philadelphia",
+    "canonicalTitle": "Philadelphia",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-philadelphia",
+        "nodeTitle": "Philadelphia"
+      }
+    ]
+  },
+  "Königsberg": {
+    "wikidataId": "Q4120832",
+    "wikipediaTitle": "Königsberg",
+    "canonicalTitle": "Königsberg",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-konigsberg",
+        "nodeTitle": "Königsberg"
+      }
+    ]
+  },
+  "Saint_Petersburg": {
+    "wikidataId": "Q656",
+    "wikipediaTitle": "Saint_Petersburg",
+    "canonicalTitle": "St. Petersburg",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-st-petersburg",
+        "nodeTitle": "St. Petersburg"
+      }
+    ]
+  },
+  "University_of_Edinburgh": {
+    "wikidataId": "Q160302",
+    "wikipediaTitle": "University_of_Edinburgh",
+    "canonicalTitle": "University of Edinburgh",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-univ-edinburgh",
+        "nodeTitle": "University of Edinburgh"
+      }
+    ]
+  },
+  "University_of_Glasgow": {
+    "wikidataId": "Q192775",
+    "wikipediaTitle": "University_of_Glasgow",
+    "canonicalTitle": "University of Glasgow",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-univ-glasgow",
+        "nodeTitle": "University of Glasgow"
+      }
+    ]
+  },
+  "University_of_Halle": {
+    "wikidataId": null,
+    "wikipediaTitle": "University_of_Halle",
+    "canonicalTitle": "University of Halle",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-univ-halle",
+        "nodeTitle": "University of Halle"
+      }
+    ]
+  },
+  "University_of_Königsberg": {
+    "wikidataId": "Q672420",
+    "wikipediaTitle": "University_of_Königsberg",
+    "canonicalTitle": "University of Königsberg",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-univ-konigsberg",
+        "nodeTitle": "University of Königsberg"
+      }
+    ]
+  },
+  "University_of_Paris": {
+    "wikidataId": "Q209842",
+    "wikipediaTitle": "University_of_Paris",
+    "canonicalTitle": "Sorbonne / University of Paris",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-sorbonne",
+        "nodeTitle": "Sorbonne / University of Paris"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-sorbonne",
+        "nodeTitle": "University of Paris (Sorbonne)"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-paris",
+        "nodeTitle": "University of Paris"
+      }
+    ]
+  },
+  "Académie_Française": {
+    "wikidataId": "Q161806",
+    "wikipediaTitle": "Académie_Française",
+    "canonicalTitle": "Académie française",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-academie-francaise",
+        "nodeTitle": "Académie française"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-academie-francaise",
+        "nodeTitle": "Académie française (Institution)"
+      }
+    ]
+  },
+  "French_Academy_of_Sciences": {
+    "wikidataId": "Q188771",
+    "wikipediaTitle": "French_Academy_of_Sciences",
+    "canonicalTitle": "Académie des Sciences",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-academie-sciences",
+        "nodeTitle": "Académie des Sciences"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-academie-sciences",
+        "nodeTitle": "Académie des Sciences (Institution)"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-academie-des-sciences",
+        "nodeTitle": "Académie des Sciences"
+      }
+    ]
+  },
+  "Prussian_Academy_of_Sciences": {
+    "wikidataId": "Q329464",
+    "wikipediaTitle": "Prussian_Academy_of_Sciences",
+    "canonicalTitle": "Berlin Academy",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-berlin-academy",
+        "nodeTitle": "Berlin Academy"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-berlin-academy",
+        "nodeTitle": "Berlin Academy (Institution)"
+      }
+    ]
+  },
+  "Royal_Society": {
+    "wikidataId": "Q123885",
+    "wikipediaTitle": "Royal_Society",
+    "canonicalTitle": "Royal Society of London",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-royal-society",
+        "nodeTitle": "Royal Society of London"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-royal-society",
+        "nodeTitle": "Royal Society of London (Institution)"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-royal-society",
+        "nodeTitle": "Royal Society of London"
+      },
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "entity-royal-society",
+        "nodeTitle": "Royal Society"
+      }
+    ]
+  },
+  "American_Philosophical_Society": {
+    "wikidataId": "Q466089",
+    "wikipediaTitle": "American_Philosophical_Society",
+    "canonicalTitle": "American Philosophical Society",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-amer-phil-society",
+        "nodeTitle": "American Philosophical Society"
+      },
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-amer-phil-society",
+        "nodeTitle": "American Philosophical Society (Institution)"
+      }
+    ]
+  },
+  "Académie_de_Bordeaux": {
+    "wikidataId": "Q17033033",
+    "wikipediaTitle": "Académie_de_Bordeaux",
+    "canonicalTitle": "Académie de Bordeaux",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-academie-bordeaux",
+        "nodeTitle": "Académie de Bordeaux"
+      }
+    ]
+  },
+  "Sanssouci": {
+    "wikidataId": "Q151330",
+    "wikipediaTitle": "Sanssouci",
+    "canonicalTitle": "Sans-Souci Palace",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-sans-souci",
+        "nodeTitle": "Sans-Souci Palace"
+      }
+    ]
+  },
+  "Palace_of_Versailles": {
+    "wikidataId": "Q2946",
+    "wikipediaTitle": "Palace_of_Versailles",
+    "canonicalTitle": "Versailles",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-versailles",
+        "nodeTitle": "Versailles"
+      }
+    ]
+  },
+  "Ferney-Voltaire": {
+    "wikidataId": "Q233733",
+    "wikipediaTitle": "Ferney-Voltaire",
+    "canonicalTitle": "Ferney",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-ferney",
+        "nodeTitle": "Ferney"
+      }
+    ]
+  },
+  "Château_de_Cirey": {
+    "wikidataId": "Q2240551",
+    "wikipediaTitle": "Château_de_Cirey",
+    "canonicalTitle": "Cirey",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-cirey",
+        "nodeTitle": "Cirey"
+      }
+    ]
+  },
+  "Winter_Palace": {
+    "wikidataId": "Q182147",
+    "wikipediaTitle": "Winter_Palace",
+    "canonicalTitle": "Winter Palace",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-winter-palace",
+        "nodeTitle": "Winter Palace"
+      }
+    ]
+  },
+  "Select_Society": {
+    "wikidataId": null,
+    "wikipediaTitle": "Select_Society",
+    "canonicalTitle": "Select Society",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-select-society",
+        "nodeTitle": "Select Society"
+      }
+    ]
+  },
+  "The_Poker_Club": {
+    "wikidataId": "Q7757623",
+    "wikipediaTitle": "The_Poker_Club",
+    "canonicalTitle": "Poker Club",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-poker-club",
+        "nodeTitle": "Poker Club"
+      }
+    ]
+  },
+  "Rankenian_Club": {
+    "wikidataId": null,
+    "wikipediaTitle": "Rankenian_Club",
+    "canonicalTitle": "Rankenian Club",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-rankenian-club",
+        "nodeTitle": "Rankenian Club"
+      }
+    ]
+  },
+  "Café_Procope": {
+    "wikidataId": "Q751293",
+    "wikipediaTitle": "Café_Procope",
+    "canonicalTitle": "Café Procope",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "location-cafe-procope",
+        "nodeTitle": "Café Procope"
+      }
+    ]
+  },
+  "Philosophes": {
+    "wikidataId": "Q1672919",
+    "wikipediaTitle": "Philosophes",
+    "canonicalTitle": "French Philosophes",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-philosophes",
+        "nodeTitle": "French Philosophes"
+      }
+    ]
+  },
+  "Scottish_Enlightenment": {
+    "wikidataId": "Q1063038",
+    "wikipediaTitle": "Scottish_Enlightenment",
+    "canonicalTitle": "Scottish Enlightenment",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-scottish-enlightenment",
+        "nodeTitle": "Scottish Enlightenment"
+      }
+    ]
+  },
+  "Aufklärung": {
+    "wikidataId": "Q136274201",
+    "wikipediaTitle": "Aufklärung",
+    "canonicalTitle": "German Aufklärung",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-aufklarung",
+        "nodeTitle": "German Aufklärung"
+      }
+    ]
+  },
+  "Haskalah": {
+    "wikidataId": "Q472670",
+    "wikipediaTitle": "Haskalah",
+    "canonicalTitle": "Haskalah (Jewish Enlightenment)",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-haskalah",
+        "nodeTitle": "Haskalah (Jewish Enlightenment)"
+      }
+    ]
+  },
+  "Physiocracy": {
+    "wikidataId": "Q183244",
+    "wikipediaTitle": "Physiocracy",
+    "canonicalTitle": "Physiocracy",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-physiocracy",
+        "nodeTitle": "Physiocracy"
+      }
+    ]
+  },
+  "Empiricism": {
+    "wikidataId": "Q83368",
+    "wikipediaTitle": "Empiricism",
+    "canonicalTitle": "British Empiricism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-british-empiricism",
+        "nodeTitle": "British Empiricism"
+      }
+    ]
+  },
+  "Rationalism": {
+    "wikidataId": "Q483024",
+    "wikipediaTitle": "Rationalism",
+    "canonicalTitle": "Continental Rationalism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-continental-rationalism",
+        "nodeTitle": "Continental Rationalism"
+      }
+    ]
+  },
+  "Utilitarianism": {
+    "wikidataId": "Q160590",
+    "wikipediaTitle": "Utilitarianism",
+    "canonicalTitle": "Utilitarianism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-utilitarianism",
+        "nodeTitle": "Utilitarianism"
+      }
+    ]
+  },
+  "Scottish_common_sense_realism": {
+    "wikidataId": "Q1116026",
+    "wikipediaTitle": "Scottish_common_sense_realism",
+    "canonicalTitle": "Common Sense Philosophy",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-common-sense-philosophy",
+        "nodeTitle": "Common Sense Philosophy"
+      }
+    ]
+  },
+  "Radical_Enlightenment": {
+    "wikidataId": null,
+    "wikipediaTitle": "Radical_Enlightenment",
+    "canonicalTitle": "Radical Enlightenment",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-radical-enlightenment",
+        "nodeTitle": "Radical Enlightenment"
+      }
+    ]
+  },
+  "Founding_Fathers_of_the_United_States": {
+    "wikidataId": "Q186539",
+    "wikipediaTitle": "Founding_Fathers_of_the_United_States",
+    "canonicalTitle": "American Founders",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-american-founders",
+        "nodeTitle": "American Founders"
+      }
+    ]
+  },
+  "Journal_des_sçavans": {
+    "wikidataId": "Q927072",
+    "wikipediaTitle": "Journal_des_sçavans",
+    "canonicalTitle": "Journal des savants",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-journal-savants",
+        "nodeTitle": "Journal des savants"
+      }
+    ]
+  },
+  "Berlinische_Monatsschrift": {
+    "wikidataId": "Q821914",
+    "wikipediaTitle": "Berlinische_Monatsschrift",
+    "canonicalTitle": "Berlinische Monatsschrift",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-berlinische-monatsschrift",
+        "nodeTitle": "Berlinische Monatsschrift"
+      }
+    ]
+  },
+  "Religious_toleration": {
+    "wikidataId": null,
+    "wikipediaTitle": "Religious_toleration",
+    "canonicalTitle": "Religious Toleration Movement",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-religious-toleration",
+        "nodeTitle": "Religious Toleration Movement"
+      }
+    ]
+  },
+  "Enlightened_absolutism": {
+    "wikidataId": "Q219934",
+    "wikipediaTitle": "Enlightened_absolutism",
+    "canonicalTitle": "Enlightened Despotism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-enlightened-despotism",
+        "nodeTitle": "Enlightened Despotism"
+      }
+    ]
+  },
+  "Deism": {
+    "wikidataId": "Q620629",
+    "wikipediaTitle": "Deism",
+    "canonicalTitle": "Deism",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-deism",
+        "nodeTitle": "Deism"
+      }
+    ]
+  },
+  "United_States": {
+    "wikidataId": "Q30",
+    "wikipediaTitle": "United_States",
+    "canonicalTitle": "United States of America",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-united-states",
+        "nodeTitle": "United States of America"
+      }
+    ]
+  },
+  "French_Revolution": {
+    "wikidataId": "Q6534",
+    "wikipediaTitle": "French_Revolution",
+    "canonicalTitle": "French Revolution",
+    "appearances": [
+      {
+        "datasetId": "enlightenment",
+        "datasetName": "Enlightenment Intellectual Network",
+        "nodeId": "entity-french-revolution",
+        "nodeTitle": "French Revolution"
+      }
+    ]
+  },
+  "Poliziano": {
+    "wikidataId": "Q166689",
+    "wikipediaTitle": "Poliziano",
+    "canonicalTitle": "Angelo Poliziano",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-angelo-poliziano",
+        "nodeTitle": "Angelo Poliziano"
+      }
+    ]
+  },
+  "Cristoforo_Landino": {
+    "wikidataId": "Q560436",
+    "wikipediaTitle": "Cristoforo_Landino",
+    "canonicalTitle": "Cristoforo Landino",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-cristoforo-landino",
+        "nodeTitle": "Cristoforo Landino"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-cristoforo-landino",
+        "nodeTitle": "Cristoforo Landino"
+      }
+    ]
+  },
+  "Francesco_Cattani_da_Diacceto": {
+    "wikidataId": "Q1440694",
+    "wikipediaTitle": "Francesco_Cattani_da_Diacceto",
+    "canonicalTitle": "Francesco Cattani da Diacceto",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-francesco-cattani-da-diacceto",
+        "nodeTitle": "Francesco Cattani da Diacceto"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-francesco-diacceto",
+        "nodeTitle": "Francesco Cattani da Diacceto"
+      }
+    ]
+  },
+  "Girolamo_Benivieni": {
+    "wikidataId": "Q3765911",
+    "wikipediaTitle": "Girolamo_Benivieni",
+    "canonicalTitle": "Girolamo Benivieni",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-girolamo-benivieni",
+        "nodeTitle": "Girolamo Benivieni"
+      }
+    ]
+  },
+  "Piero_di_Cosimo_de'_Medici": {
+    "wikidataId": "Q313587",
+    "wikipediaTitle": "Piero_di_Cosimo_de'_Medici",
+    "canonicalTitle": "Piero di Cosimo de' Medici",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-piero-di-cosimo-de-medici",
+        "nodeTitle": "Piero di Cosimo de' Medici"
+      }
+    ]
+  },
+  "Giuliano_de'_Medici": {
+    "wikidataId": "Q316650",
+    "wikipediaTitle": "Giuliano_de'_Medici",
+    "canonicalTitle": "Giuliano de' Medici",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-giuliano-de-medici",
+        "nodeTitle": "Giuliano de' Medici"
+      }
+    ]
+  },
+  "Piero_di_Lorenzo_de'_Medici": {
+    "wikidataId": "Q310405",
+    "wikipediaTitle": "Piero_di_Lorenzo_de'_Medici",
+    "canonicalTitle": "Piero de' Medici",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-piero-de-medici-the-unfortunate",
+        "nodeTitle": "Piero de' Medici"
+      }
+    ]
+  },
+  "Gemistus_Pletho": {
+    "wikidataId": "Q310318",
+    "wikipediaTitle": "Gemistus_Pletho",
+    "canonicalTitle": "Gemistus Pletho",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-gemistus-pletho",
+        "nodeTitle": "Gemistus Pletho"
+      }
+    ]
+  },
+  "Basilios_Bessarion": {
+    "wikidataId": "Q352619",
+    "wikipediaTitle": "Basilios_Bessarion",
+    "canonicalTitle": "Cardinal Bessarion",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-bessarion",
+        "nodeTitle": "Cardinal Bessarion"
+      }
+    ]
+  },
+  "John_Argyropoulos": {
+    "wikidataId": "Q720932",
+    "wikipediaTitle": "John_Argyropoulos",
+    "canonicalTitle": "John Argyropoulos",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-john-argyropoulos",
+        "nodeTitle": "John Argyropoulos"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-johannes-argyropoulos",
+        "nodeTitle": "Johannes Argyropoulos"
+      }
+    ]
+  },
+  "Manuel_Chrysoloras": {
+    "wikidataId": "Q380417",
+    "wikipediaTitle": "Manuel_Chrysoloras",
+    "canonicalTitle": "Manuel Chrysoloras",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-manuel-chrysoloras",
+        "nodeTitle": "Manuel Chrysoloras"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-manuel-chrysoloras",
+        "nodeTitle": "Manuel Chrysoloras"
+      }
+    ]
+  },
+  "Demetrios_Chalkokondyles": {
+    "wikidataId": "Q561458",
+    "wikipediaTitle": "Demetrios_Chalkokondyles",
+    "canonicalTitle": "Demetrios Chalkokondyles",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-demetrios-chalkokondyles",
+        "nodeTitle": "Demetrios Chalkokondyles"
+      }
+    ]
+  },
+  "Hermes_Trismegistus": {
+    "wikidataId": "Q502592",
+    "wikipediaTitle": "Hermes_Trismegistus",
+    "canonicalTitle": "Hermes Trismegistus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-hermes-trismegistus",
+        "nodeTitle": "Hermes Trismegistus"
+      }
+    ]
+  },
+  "Plato": {
+    "wikidataId": "Q859",
+    "wikipediaTitle": "Plato",
+    "canonicalTitle": "Plato",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-plato",
+        "nodeTitle": "Plato"
+      }
+    ]
+  },
+  "Plotinus": {
+    "wikidataId": "Q44032",
+    "wikipediaTitle": "Plotinus",
+    "canonicalTitle": "Plotinus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-plotinus",
+        "nodeTitle": "Plotinus"
+      }
+    ]
+  },
+  "Proclus": {
+    "wikidataId": "Q188847",
+    "wikipediaTitle": "Proclus",
+    "canonicalTitle": "Proclus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-proclus",
+        "nodeTitle": "Proclus"
+      }
+    ]
+  },
+  "Iamblichus": {
+    "wikidataId": "Q42247",
+    "wikipediaTitle": "Iamblichus",
+    "canonicalTitle": "Iamblichus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-iamblichus",
+        "nodeTitle": "Iamblichus"
+      }
+    ]
+  },
+  "Pseudo-Dionysius_the_Areopagite": {
+    "wikidataId": "Q179742",
+    "wikipediaTitle": "Pseudo-Dionysius_the_Areopagite",
+    "canonicalTitle": "Pseudo-Dionysius the Areopagite",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-pseudo-dionysius",
+        "nodeTitle": "Pseudo-Dionysius the Areopagite"
+      }
+    ]
+  },
+  "Orpheus": {
+    "wikidataId": "Q43395",
+    "wikipediaTitle": "Orpheus",
+    "canonicalTitle": "Orpheus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-orpheus",
+        "nodeTitle": "Orpheus"
+      }
+    ]
+  },
+  "Zoroaster": {
+    "wikidataId": "Q4848",
+    "wikipediaTitle": "Zoroaster",
+    "canonicalTitle": "Zoroaster",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-zoroaster",
+        "nodeTitle": "Zoroaster"
+      }
+    ]
+  },
+  "Pythagoras": {
+    "wikidataId": "Q10261",
+    "wikipediaTitle": "Pythagoras",
+    "canonicalTitle": "Pythagoras",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-pythagoras",
+        "nodeTitle": "Pythagoras"
+      }
+    ]
+  },
+  "Three_Books_on_Life": {
+    "wikidataId": "Q5753247",
+    "wikipediaTitle": "Three_Books_on_Life",
+    "canonicalTitle": "De Vita Libri Tres (Three Books on Life)",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-de-vita-libri-tres",
+        "nodeTitle": "De Vita Libri Tres (Three Books on Life)"
+      }
+    ]
+  },
+  "Commentary_on_Plato%27s_Symposium_on_Love": {
+    "wikidataId": "Q5154756",
+    "wikipediaTitle": "Commentary_on_Plato%27s_Symposium_on_Love",
+    "canonicalTitle": "De Amore (Commentary on Plato's Symposium)",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-de-amore",
+        "nodeTitle": "De Amore (Commentary on Plato's Symposium)"
+      }
+    ]
+  },
+  "Heptaplus": {
+    "wikidataId": "Q5732857",
+    "wikipediaTitle": "Heptaplus",
+    "canonicalTitle": "Heptaplus",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-heptaplus",
+        "nodeTitle": "Heptaplus"
+      }
+    ]
+  },
+  "Enneads": {
+    "wikidataId": "Q606879",
+    "wikipediaTitle": "Enneads",
+    "canonicalTitle": "Enneads",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-enneads",
+        "nodeTitle": "Enneads"
+      }
+    ]
+  },
+  "Asclepius_(treatise)": {
+    "wikidataId": "Q787046",
+    "wikipediaTitle": "Asclepius_(treatise)",
+    "canonicalTitle": "Asclepius",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-asclepius",
+        "nodeTitle": "Asclepius"
+      }
+    ]
+  },
+  "Poimandres": {
+    "wikidataId": "Q921618",
+    "wikipediaTitle": "Poimandres",
+    "canonicalTitle": "Pimander",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-pimander",
+        "nodeTitle": "Pimander"
+      }
+    ]
+  },
+  "Orphic_Hymns": {
+    "wikidataId": "Q1626866",
+    "wikipediaTitle": "Orphic_Hymns",
+    "canonicalTitle": "Orphic Hymns",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "object-orphic-hymns",
+        "nodeTitle": "Orphic Hymns"
+      }
+    ]
+  },
+  "Giordano_Bruno": {
+    "wikidataId": "Q36330",
+    "wikipediaTitle": "Giordano_Bruno",
+    "canonicalTitle": "Giordano Bruno",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-giordano-bruno",
+        "nodeTitle": "Giordano Bruno"
+      }
+    ]
+  },
+  "Francesco_Patrizi_(philosopher)": {
+    "wikidataId": "Q364945",
+    "wikipediaTitle": "Francesco_Patrizi_(philosopher)",
+    "canonicalTitle": "Francesco Patrizi",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-francesco-patrizi",
+        "nodeTitle": "Francesco Patrizi"
+      }
+    ]
+  },
+  "Girolamo_Savonarola": {
+    "wikidataId": "Q45027",
+    "wikipediaTitle": "Girolamo_Savonarola",
+    "canonicalTitle": "Girolamo Savonarola",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "person-girolamo-savonarola",
+        "nodeTitle": "Girolamo Savonarola"
+      }
+    ]
+  },
+  "Villa_Medici_at_Careggi": {
+    "wikidataId": "Q579476",
+    "wikipediaTitle": "Villa_Medici_at_Careggi",
+    "canonicalTitle": "Villa Medici at Careggi",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "location-villa-careggi",
+        "nodeTitle": "Villa Medici at Careggi"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-villa-careggi",
+        "nodeTitle": "Medici Villa at Careggi"
+      }
+    ]
+  },
+  "Council_of_Florence": {
+    "wikidataId": "Q83017",
+    "wikipediaTitle": "Council_of_Florence",
+    "canonicalTitle": "Council of Florence",
+    "appearances": [
+      {
+        "datasetId": "florentine-academy",
+        "datasetName": "Florentine Academy",
+        "nodeId": "location-council-of-florence",
+        "nodeTitle": "Council of Florence"
+      }
+    ]
+  },
+  "Martin_Luther": {
+    "wikidataId": "Q9554",
+    "wikipediaTitle": "Martin_Luther",
+    "canonicalTitle": "Martin Luther",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-martin-luther",
+        "nodeTitle": "Martin Luther"
+      }
+    ]
+  },
+  "John_Calvin": {
+    "wikidataId": "Q37577",
+    "wikipediaTitle": "John_Calvin",
+    "canonicalTitle": "John Calvin",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-calvin",
+        "nodeTitle": "John Calvin"
+      }
+    ]
+  },
+  "Huldrych_Zwingli": {
+    "wikidataId": "Q123034",
+    "wikipediaTitle": "Huldrych_Zwingli",
+    "canonicalTitle": "Huldrych Zwingli",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-huldrych-zwingli",
+        "nodeTitle": "Huldrych Zwingli"
+      }
+    ]
+  },
+  "Erasmus": {
+    "wikidataId": "Q43499",
+    "wikipediaTitle": "Erasmus",
+    "canonicalTitle": "Erasmus of Rotterdam",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-erasmus-of-rotterdam",
+        "nodeTitle": "Erasmus of Rotterdam"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-desiderius-erasmus",
+        "nodeTitle": "Desiderius Erasmus of Rotterdam"
+      }
+    ]
+  },
+  "William_Tyndale": {
+    "wikidataId": "Q219639",
+    "wikipediaTitle": "William_Tyndale",
+    "canonicalTitle": "William Tyndale",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-william-tyndale",
+        "nodeTitle": "William Tyndale"
+      }
+    ]
+  },
+  "Thomas_Cranmer": {
+    "wikidataId": "Q199894",
+    "wikipediaTitle": "Thomas_Cranmer",
+    "canonicalTitle": "Thomas Cranmer",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-thomas-cranmer",
+        "nodeTitle": "Thomas Cranmer"
+      }
+    ]
+  },
+  "Philip_Melanchthon": {
+    "wikidataId": "Q76325",
+    "wikipediaTitle": "Philip_Melanchthon",
+    "canonicalTitle": "Philip Melanchthon",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-philip-melanchthon",
+        "nodeTitle": "Philip Melanchthon"
+      }
+    ]
+  },
+  "Johannes_Bugenhagen": {
+    "wikidataId": "Q77260",
+    "wikipediaTitle": "Johannes_Bugenhagen",
+    "canonicalTitle": "Johannes Bugenhagen",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-johannes-bugenhagen",
+        "nodeTitle": "Johannes Bugenhagen"
+      }
+    ]
+  },
+  "Justus_Jonas": {
+    "wikidataId": "Q38294",
+    "wikipediaTitle": "Justus_Jonas",
+    "canonicalTitle": "Justus Jonas",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-justus-jonas",
+        "nodeTitle": "Justus Jonas"
+      }
+    ]
+  },
+  "Caspar_Cruciger_the_Elder": {
+    "wikidataId": null,
+    "wikipediaTitle": "Caspar_Cruciger_the_Elder",
+    "canonicalTitle": "Caspar Cruciger the Elder",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-caspar-cruciger",
+        "nodeTitle": "Caspar Cruciger the Elder"
+      }
+    ]
+  },
+  "Georg_Spalatin": {
+    "wikidataId": null,
+    "wikipediaTitle": "Georg_Spalatin",
+    "canonicalTitle": "Georg Spalatin",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-georg-spalatin",
+        "nodeTitle": "Georg Spalatin"
+      }
+    ]
+  },
+  "Andreas_Karlstadt": {
+    "wikidataId": "Q60589",
+    "wikipediaTitle": "Andreas_Karlstadt",
+    "canonicalTitle": "Andreas Karlstadt",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-andreas-karlstadt",
+        "nodeTitle": "Andreas Karlstadt"
+      }
+    ]
+  },
+  "Katharina_von_Bora": {
+    "wikidataId": "Q77239",
+    "wikipediaTitle": "Katharina_von_Bora",
+    "canonicalTitle": "Katharina von Bora",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-katharina-von-bora",
+        "nodeTitle": "Katharina von Bora"
+      }
+    ]
+  },
+  "Lucas_Cranach_the_Elder": {
+    "wikidataId": "Q191748",
+    "wikipediaTitle": "Lucas_Cranach_the_Elder",
+    "canonicalTitle": "Lucas Cranach the Elder",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-lucas-cranach",
+        "nodeTitle": "Lucas Cranach the Elder"
+      }
+    ]
+  },
+  "Johann_Agricola": {
+    "wikidataId": null,
+    "wikipediaTitle": "Johann_Agricola",
+    "canonicalTitle": "Johann Agricola",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-johann-agricola",
+        "nodeTitle": "Johann Agricola"
+      }
+    ]
+  },
+  "Thomas_Müntzer": {
+    "wikidataId": "Q153981",
+    "wikipediaTitle": "Thomas_Müntzer",
+    "canonicalTitle": "Thomas Müntzer",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-thomas-muntzer",
+        "nodeTitle": "Thomas Müntzer"
+      }
+    ]
+  },
+  "Heinrich_Bullinger": {
+    "wikidataId": "Q123839",
+    "wikipediaTitle": "Heinrich_Bullinger",
+    "canonicalTitle": "Heinrich Bullinger",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-heinrich-bullinger",
+        "nodeTitle": "Heinrich Bullinger"
+      }
+    ]
+  },
+  "Leo_Jud": {
+    "wikidataId": "Q1345599",
+    "wikipediaTitle": "Leo_Jud",
+    "canonicalTitle": "Leo Jud",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-leo-jud",
+        "nodeTitle": "Leo Jud"
+      }
+    ]
+  },
+  "Johannes_Oecolampadius": {
+    "wikidataId": "Q123450",
+    "wikipediaTitle": "Johannes_Oecolampadius",
+    "canonicalTitle": "Johannes Oecolampadius",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-johannes-oecolampadius",
+        "nodeTitle": "Johannes Oecolampadius"
+      }
+    ]
+  },
+  "Rudolf_Gwalther": {
+    "wikidataId": "Q120138",
+    "wikipediaTitle": "Rudolf_Gwalther",
+    "canonicalTitle": "Rudolf Gwalther",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-rudolf-gwalther",
+        "nodeTitle": "Rudolf Gwalther"
+      }
+    ]
+  },
+  "Kaspar_Megander": {
+    "wikidataId": "Q1735077",
+    "wikipediaTitle": "Kaspar_Megander",
+    "canonicalTitle": "Kaspar Megander",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-kaspar-megander",
+        "nodeTitle": "Kaspar Megander"
+      }
+    ]
+  },
+  "William_Farel": {
+    "wikidataId": "Q435456",
+    "wikipediaTitle": "William_Farel",
+    "canonicalTitle": "Guillaume Farel",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-guillaume-farel",
+        "nodeTitle": "Guillaume Farel"
+      }
+    ]
+  },
+  "Pierre_Viret": {
+    "wikidataId": "Q123337",
+    "wikipediaTitle": "Pierre_Viret",
+    "canonicalTitle": "Pierre Viret",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-pierre-viret",
+        "nodeTitle": "Pierre Viret"
+      }
+    ]
+  },
+  "Theodore_Beza": {
+    "wikidataId": "Q314981",
+    "wikipediaTitle": "Theodore_Beza",
+    "canonicalTitle": "Theodore Beza",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-theodore-beza",
+        "nodeTitle": "Theodore Beza"
+      }
+    ]
+  },
+  "Olivétan": {
+    "wikidataId": null,
+    "wikipediaTitle": "Olivétan",
+    "canonicalTitle": "Pierre Robert Olivétan",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-pierre-robert-olivetan",
+        "nodeTitle": "Pierre Robert Olivétan"
+      }
+    ]
+  },
+  "Martin_Bucer": {
+    "wikidataId": "Q318622",
+    "wikipediaTitle": "Martin_Bucer",
+    "canonicalTitle": "Martin Bucer",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-martin-bucer",
+        "nodeTitle": "Martin Bucer"
+      }
+    ]
+  },
+  "Wolfgang_Capito": {
+    "wikidataId": "Q1368362",
+    "wikipediaTitle": "Wolfgang_Capito",
+    "canonicalTitle": "Wolfgang Capito",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-wolfgang-capito",
+        "nodeTitle": "Wolfgang Capito"
+      }
+    ]
+  },
+  "Katharina_Zell": {
+    "wikidataId": "Q118998",
+    "wikipediaTitle": "Katharina_Zell",
+    "canonicalTitle": "Katharina Schütz Zell",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-katharina-schutz-zell",
+        "nodeTitle": "Katharina Schütz Zell"
+      }
+    ]
+  },
+  "Matthew_Zell": {
+    "wikidataId": "Q85810",
+    "wikipediaTitle": "Matthew_Zell",
+    "canonicalTitle": "Matthew Zell",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-matthew-zell",
+        "nodeTitle": "Matthew Zell"
+      }
+    ]
+  },
+  "Thomas_Cromwell": {
+    "wikidataId": "Q294435",
+    "wikipediaTitle": "Thomas_Cromwell",
+    "canonicalTitle": "Thomas Cromwell",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-thomas-cromwell",
+        "nodeTitle": "Thomas Cromwell"
+      }
+    ]
+  },
+  "Hugh_Latimer": {
+    "wikidataId": "Q710046",
+    "wikipediaTitle": "Hugh_Latimer",
+    "canonicalTitle": "Hugh Latimer",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-hugh-latimer",
+        "nodeTitle": "Hugh Latimer"
+      }
+    ]
+  },
+  "Nicholas_Ridley_(martyr)": {
+    "wikidataId": "Q741030",
+    "wikipediaTitle": "Nicholas_Ridley_(martyr)",
+    "canonicalTitle": "Nicholas Ridley",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-nicholas-ridley",
+        "nodeTitle": "Nicholas Ridley"
+      }
+    ]
+  },
+  "Miles_Coverdale": {
+    "wikidataId": null,
+    "wikipediaTitle": "Miles_Coverdale",
+    "canonicalTitle": "Miles Coverdale",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-miles-coverdale",
+        "nodeTitle": "Miles Coverdale"
+      }
+    ]
+  },
+  "John_Foxe": {
+    "wikidataId": "Q380961",
+    "wikipediaTitle": "John_Foxe",
+    "canonicalTitle": "John Foxe",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-foxe",
+        "nodeTitle": "John Foxe"
+      }
+    ]
+  },
+  "Thomas_Bilney": {
+    "wikidataId": "Q1756294",
+    "wikipediaTitle": "Thomas_Bilney",
+    "canonicalTitle": "Thomas Bilney",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-thomas-bilney",
+        "nodeTitle": "Thomas Bilney"
+      }
+    ]
+  },
+  "Robert_Barnes_(martyr)": {
+    "wikidataId": "Q1237075",
+    "wikipediaTitle": "Robert_Barnes_(martyr)",
+    "canonicalTitle": "Robert Barnes",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-robert-barnes",
+        "nodeTitle": "Robert Barnes"
+      }
+    ]
+  },
+  "John_Frith": {
+    "wikidataId": "Q11772588",
+    "wikipediaTitle": "John_Frith",
+    "canonicalTitle": "John Frith",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-frith",
+        "nodeTitle": "John Frith"
+      }
+    ]
+  },
+  "John_Hooper_(bishop)": {
+    "wikidataId": "Q647264",
+    "wikipediaTitle": "John_Hooper_(bishop)",
+    "canonicalTitle": "John Hooper",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-hooper",
+        "nodeTitle": "John Hooper"
+      }
+    ]
+  },
+  "Matthew_Parker": {
+    "wikidataId": "Q711332",
+    "wikipediaTitle": "Matthew_Parker",
+    "canonicalTitle": "Matthew Parker",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-matthew-parker",
+        "nodeTitle": "Matthew Parker"
+      }
+    ]
+  },
+  "John_Colet": {
+    "wikidataId": "Q957527",
+    "wikipediaTitle": "John_Colet",
+    "canonicalTitle": "John Colet",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-colet",
+        "nodeTitle": "John Colet"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-john-colet",
+        "nodeTitle": "John Colet"
+      }
+    ]
+  },
+  "Thomas_More": {
+    "wikidataId": "Q42544",
+    "wikipediaTitle": "Thomas_More",
+    "canonicalTitle": "Thomas More",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-thomas-more",
+        "nodeTitle": "Thomas More"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-thomas-more",
+        "nodeTitle": "Thomas More"
+      }
+    ]
+  },
+  "Jacques_Lefèvre_d%27Étaples": {
+    "wikidataId": null,
+    "wikipediaTitle": "Jacques_Lefèvre_d%27Étaples",
+    "canonicalTitle": "Jacques Lefèvre d'Étaples",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-jacques-lefevre-detaples",
+        "nodeTitle": "Jacques Lefèvre d'Étaples"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-jacques-lefevre-detaples",
+        "nodeTitle": "Jacques Lefèvre d'Étaples"
+      }
+    ]
+  },
+  "Guillaume_Briçonnet_(cardinal)": {
+    "wikidataId": "Q967700",
+    "wikipediaTitle": "Guillaume_Briçonnet_(cardinal)",
+    "canonicalTitle": "Guillaume Briçonnet",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-guillaume-briconnet",
+        "nodeTitle": "Guillaume Briçonnet"
+      }
+    ]
+  },
+  "Conrad_Grebel": {
+    "wikidataId": "Q115638",
+    "wikipediaTitle": "Conrad_Grebel",
+    "canonicalTitle": "Conrad Grebel",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-conrad-grebel",
+        "nodeTitle": "Conrad Grebel"
+      }
+    ]
+  },
+  "Felix_Manz": {
+    "wikidataId": "Q124188",
+    "wikipediaTitle": "Felix_Manz",
+    "canonicalTitle": "Felix Manz",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-felix-manz",
+        "nodeTitle": "Felix Manz"
+      }
+    ]
+  },
+  "George_Blaurock": {
+    "wikidataId": "Q124175",
+    "wikipediaTitle": "George_Blaurock",
+    "canonicalTitle": "George Blaurock",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-george-blaurock",
+        "nodeTitle": "George Blaurock"
+      }
+    ]
+  },
+  "Balthasar_Hubmaier": {
+    "wikidataId": "Q62532",
+    "wikipediaTitle": "Balthasar_Hubmaier",
+    "canonicalTitle": "Balthasar Hubmaier",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-balthasar-hubmaier",
+        "nodeTitle": "Balthasar Hubmaier"
+      }
+    ]
+  },
+  "Menno_Simons": {
+    "wikidataId": "Q335171",
+    "wikipediaTitle": "Menno_Simons",
+    "canonicalTitle": "Menno Simons",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-menno-simons",
+        "nodeTitle": "Menno Simons"
+      }
+    ]
+  },
+  "Michael_Sattler": {
+    "wikidataId": "Q142309",
+    "wikipediaTitle": "Michael_Sattler",
+    "canonicalTitle": "Michael Sattler",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-michael-sattler",
+        "nodeTitle": "Michael Sattler"
+      }
+    ]
+  },
+  "Marguerite_de_Navarre": {
+    "wikidataId": "Q190058",
+    "wikipediaTitle": "Marguerite_de_Navarre",
+    "canonicalTitle": "Marguerite of Navarre",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-marguerite-of-navarre",
+        "nodeTitle": "Marguerite of Navarre"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-marguerite-of-navarre",
+        "nodeTitle": "Marguerite of Navarre"
+      }
+    ]
+  },
+  "Clément_Marot": {
+    "wikidataId": "Q108926",
+    "wikipediaTitle": "Clément_Marot",
+    "canonicalTitle": "Clément Marot",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-clement-marot",
+        "nodeTitle": "Clément Marot"
+      }
+    ]
+  },
+  "Antoine_Froment": {
+    "wikidataId": "Q388199",
+    "wikipediaTitle": "Antoine_Froment",
+    "canonicalTitle": "Antoine Froment",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-antoine-froment",
+        "nodeTitle": "Antoine Froment"
+      }
+    ]
+  },
+  "Marie_Dentière": {
+    "wikidataId": "Q447170",
+    "wikipediaTitle": "Marie_Dentière",
+    "canonicalTitle": "Marie Dentière",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-marie-dentiere",
+        "nodeTitle": "Marie Dentière"
+      }
+    ]
+  },
+  "Frederick_III,_Elector_of_Saxony": {
+    "wikidataId": "Q77233",
+    "wikipediaTitle": "Frederick_III,_Elector_of_Saxony",
+    "canonicalTitle": "Frederick the Wise",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-frederick-the-wise",
+        "nodeTitle": "Frederick the Wise"
+      }
+    ]
+  },
+  "John,_Elector_of_Saxony": {
+    "wikidataId": "Q61277",
+    "wikipediaTitle": "John,_Elector_of_Saxony",
+    "canonicalTitle": "John the Steadfast",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-the-steadfast",
+        "nodeTitle": "John the Steadfast"
+      }
+    ]
+  },
+  "John_Frederick_I,_Elector_of_Saxony": {
+    "wikidataId": "Q506182",
+    "wikipediaTitle": "John_Frederick_I,_Elector_of_Saxony",
+    "canonicalTitle": "John Frederick I",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-frederick-i",
+        "nodeTitle": "John Frederick I"
+      }
+    ]
+  },
+  "Philip_I,_Landgrave_of_Hesse": {
+    "wikidataId": "Q169319",
+    "wikipediaTitle": "Philip_I,_Landgrave_of_Hesse",
+    "canonicalTitle": "Philip of Hesse",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-philip-of-hesse",
+        "nodeTitle": "Philip of Hesse"
+      }
+    ]
+  },
+  "Henry_VIII": {
+    "wikidataId": "Q38370",
+    "wikipediaTitle": "Henry_VIII",
+    "canonicalTitle": "Henry VIII",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-henry-viii",
+        "nodeTitle": "Henry VIII"
+      }
+    ]
+  },
+  "Charles_V,_Holy_Roman_Emperor": {
+    "wikidataId": "Q32500",
+    "wikipediaTitle": "Charles_V,_Holy_Roman_Emperor",
+    "canonicalTitle": "Charles V",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-charles-v",
+        "nodeTitle": "Charles V"
+      }
+    ]
+  },
+  "Johann_Eck": {
+    "wikidataId": "Q60298",
+    "wikipediaTitle": "Johann_Eck",
+    "canonicalTitle": "Johann Eck",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-johann-eck",
+        "nodeTitle": "Johann Eck"
+      }
+    ]
+  },
+  "Thomas_Cajetan": {
+    "wikidataId": "Q435853",
+    "wikipediaTitle": "Thomas_Cajetan",
+    "canonicalTitle": "Cardinal Thomas Cajetan",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-cardinal-thomas-cajetan",
+        "nodeTitle": "Cardinal Thomas Cajetan"
+      }
+    ]
+  },
+  "John_Knox": {
+    "wikidataId": "Q189937",
+    "wikipediaTitle": "John_Knox",
+    "canonicalTitle": "John Knox",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-john-knox",
+        "nodeTitle": "John Knox"
+      }
+    ]
+  },
+  "George_Wishart": {
+    "wikidataId": "Q1367426",
+    "wikipediaTitle": "George_Wishart",
+    "canonicalTitle": "George Wishart",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-george-wishart",
+        "nodeTitle": "George Wishart"
+      }
+    ]
+  },
+  "Patrick_Hamilton_(martyr)": {
+    "wikidataId": "Q708980",
+    "wikipediaTitle": "Patrick_Hamilton_(martyr)",
+    "canonicalTitle": "Patrick Hamilton",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "person-patrick-hamilton",
+        "nodeTitle": "Patrick Hamilton"
+      }
+    ]
+  },
+  "Ninety-five_Theses": {
+    "wikidataId": "Q157506",
+    "wikipediaTitle": "Ninety-five_Theses",
+    "canonicalTitle": "Ninety-Five Theses",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-ninety-five-theses",
+        "nodeTitle": "Ninety-Five Theses"
+      }
+    ]
+  },
+  "To_the_Christian_Nobility_of_the_German_Nation": {
+    "wikidataId": "Q2492149",
+    "wikipediaTitle": "To_the_Christian_Nobility_of_the_German_Nation",
+    "canonicalTitle": "Address to the Christian Nobility of the German Nation",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-address-christian-nobility",
+        "nodeTitle": "Address to the Christian Nobility of the German Nation"
+      }
+    ]
+  },
+  "On_the_Babylonian_Captivity_of_the_Church": {
+    "wikidataId": "Q282497",
+    "wikipediaTitle": "On_the_Babylonian_Captivity_of_the_Church",
+    "canonicalTitle": "On the Babylonian Captivity of the Church",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-babylonian-captivity",
+        "nodeTitle": "On the Babylonian Captivity of the Church"
+      }
+    ]
+  },
+  "On_the_Freedom_of_a_Christian": {
+    "wikidataId": "Q569330",
+    "wikipediaTitle": "On_the_Freedom_of_a_Christian",
+    "canonicalTitle": "On the Freedom of a Christian",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-freedom-christian",
+        "nodeTitle": "On the Freedom of a Christian"
+      }
+    ]
+  },
+  "On_the_Bondage_of_the_Will": {
+    "wikidataId": "Q1180745",
+    "wikipediaTitle": "On_the_Bondage_of_the_Will",
+    "canonicalTitle": "The Bondage of the Will",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-bondage-of-will",
+        "nodeTitle": "The Bondage of the Will"
+      }
+    ]
+  },
+  "De_libero_arbitrio_diatribe_sive_collatio": {
+    "wikidataId": "Q846306",
+    "wikipediaTitle": "De_libero_arbitrio_diatribe_sive_collatio",
+    "canonicalTitle": "On Free Will",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-free-will-erasmus",
+        "nodeTitle": "On Free Will"
+      }
+    ]
+  },
+  "Institutes_of_the_Christian_Religion": {
+    "wikidataId": "Q371558",
+    "wikipediaTitle": "Institutes_of_the_Christian_Religion",
+    "canonicalTitle": "Institutes of the Christian Religion",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-institutes",
+        "nodeTitle": "Institutes of the Christian Religion"
+      }
+    ]
+  },
+  "Sixty-seven_Articles": {
+    "wikidataId": null,
+    "wikipediaTitle": "Sixty-seven_Articles",
+    "canonicalTitle": "Sixty-Seven Articles",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-sixty-seven-articles",
+        "nodeTitle": "Sixty-Seven Articles"
+      }
+    ]
+  },
+  "Loci_Communes": {
+    "wikidataId": null,
+    "wikipediaTitle": "Loci_Communes",
+    "canonicalTitle": "Loci Communes",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-loci-communes",
+        "nodeTitle": "Loci Communes"
+      }
+    ]
+  },
+  "The_Obedience_of_a_Christian_Man": {
+    "wikidataId": "Q7754622",
+    "wikipediaTitle": "The_Obedience_of_a_Christian_Man",
+    "canonicalTitle": "The Obedience of a Christian Man",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-obedience-christian-man",
+        "nodeTitle": "The Obedience of a Christian Man"
+      }
+    ]
+  },
+  "Luther_Bible": {
+    "wikidataId": "Q1571095",
+    "wikipediaTitle": "Luther_Bible",
+    "canonicalTitle": "Luther's German Bible",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-luther-bible",
+        "nodeTitle": "Luther's German Bible"
+      }
+    ]
+  },
+  "Novum_Instrumentum_omne": {
+    "wikidataId": "Q1526516",
+    "wikipediaTitle": "Novum_Instrumentum_omne",
+    "canonicalTitle": "Erasmus's Greek New Testament",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-novum-instrumentum",
+        "nodeTitle": "Erasmus's Greek New Testament"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-novum-instrumentum",
+        "nodeTitle": "Novum Instrumentum (Greek New Testament)"
+      }
+    ]
+  },
+  "Tyndale_Bible": {
+    "wikidataId": "Q2462802",
+    "wikipediaTitle": "Tyndale_Bible",
+    "canonicalTitle": "Tyndale's New Testament",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-tyndale-nt",
+        "nodeTitle": "Tyndale's New Testament"
+      },
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-tyndale-pentateuch",
+        "nodeTitle": "Tyndale's Pentateuch"
+      }
+    ]
+  },
+  "Coverdale_Bible": {
+    "wikidataId": "Q1138103",
+    "wikipediaTitle": "Coverdale_Bible",
+    "canonicalTitle": "Coverdale Bible",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-coverdale-bible",
+        "nodeTitle": "Coverdale Bible"
+      }
+    ]
+  },
+  "Great_Bible": {
+    "wikidataId": "Q1544227",
+    "wikipediaTitle": "Great_Bible",
+    "canonicalTitle": "Great Bible",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-great-bible",
+        "nodeTitle": "Great Bible"
+      }
+    ]
+  },
+  "Geneva_Bible": {
+    "wikidataId": "Q1502139",
+    "wikipediaTitle": "Geneva_Bible",
+    "canonicalTitle": "Geneva Bible",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-geneva-bible",
+        "nodeTitle": "Geneva Bible"
+      }
+    ]
+  },
+  "Olivétan_Bible": {
+    "wikidataId": null,
+    "wikipediaTitle": "Olivétan_Bible",
+    "canonicalTitle": "Olivétan's French Bible",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-olivetan-bible",
+        "nodeTitle": "Olivétan's French Bible"
+      }
+    ]
+  },
+  "Froschauer_Bible": {
+    "wikidataId": null,
+    "wikipediaTitle": "Froschauer_Bible",
+    "canonicalTitle": "Zurich Bible",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-zurich-bible",
+        "nodeTitle": "Zurich Bible"
+      }
+    ]
+  },
+  "Augsburg_Confession": {
+    "wikidataId": "Q154483",
+    "wikipediaTitle": "Augsburg_Confession",
+    "canonicalTitle": "Augsburg Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-augsburg-confession",
+        "nodeTitle": "Augsburg Confession"
+      }
+    ]
+  },
+  "Apology_of_the_Augsburg_Confession": {
+    "wikidataId": "Q619586",
+    "wikipediaTitle": "Apology_of_the_Augsburg_Confession",
+    "canonicalTitle": "Apology of the Augsburg Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-apology-augsburg",
+        "nodeTitle": "Apology of the Augsburg Confession"
+      }
+    ]
+  },
+  "Luther%27s_Small_Catechism": {
+    "wikidataId": null,
+    "wikipediaTitle": "Luther%27s_Small_Catechism",
+    "canonicalTitle": "Small Catechism",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-small-catechism",
+        "nodeTitle": "Small Catechism"
+      }
+    ]
+  },
+  "Luther%27s_Large_Catechism": {
+    "wikidataId": null,
+    "wikipediaTitle": "Luther%27s_Large_Catechism",
+    "canonicalTitle": "Large Catechism",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-large-catechism",
+        "nodeTitle": "Large Catechism"
+      }
+    ]
+  },
+  "Tetrapolitan_Confession": {
+    "wikidataId": "Q319300",
+    "wikipediaTitle": "Tetrapolitan_Confession",
+    "canonicalTitle": "Tetrapolitan Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-tetrapolitan-confession",
+        "nodeTitle": "Tetrapolitan Confession"
+      }
+    ]
+  },
+  "First_Helvetic_Confession": {
+    "wikidataId": null,
+    "wikipediaTitle": "First_Helvetic_Confession",
+    "canonicalTitle": "First Helvetic Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-first-helvetic-confession",
+        "nodeTitle": "First Helvetic Confession"
+      }
+    ]
+  },
+  "Second_Helvetic_Confession": {
+    "wikidataId": "Q676162",
+    "wikipediaTitle": "Second_Helvetic_Confession",
+    "canonicalTitle": "Second Helvetic Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-second-helvetic-confession",
+        "nodeTitle": "Second Helvetic Confession"
+      }
+    ]
+  },
+  "Genevan_Catechism": {
+    "wikidataId": null,
+    "wikipediaTitle": "Genevan_Catechism",
+    "canonicalTitle": "Genevan Catechism",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-genevan-catechism",
+        "nodeTitle": "Genevan Catechism"
+      }
+    ]
+  },
+  "Heidelberg_Catechism": {
+    "wikidataId": "Q327152",
+    "wikipediaTitle": "Heidelberg_Catechism",
+    "canonicalTitle": "Heidelberg Catechism",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-heidelberg-catechism",
+        "nodeTitle": "Heidelberg Catechism"
+      }
+    ]
+  },
+  "Schleitheim_Confession": {
+    "wikidataId": "Q265613",
+    "wikipediaTitle": "Schleitheim_Confession",
+    "canonicalTitle": "Schleitheim Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-schleitheim-confession",
+        "nodeTitle": "Schleitheim Confession"
+      }
+    ]
+  },
+  "Scots_Confession": {
+    "wikidataId": "Q1125192",
+    "wikipediaTitle": "Scots_Confession",
+    "canonicalTitle": "Scots Confession",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-scots-confession",
+        "nodeTitle": "Scots Confession"
+      }
+    ]
+  },
+  "Thirty-nine_Articles": {
+    "wikidataId": "Q937617",
+    "wikipediaTitle": "Thirty-nine_Articles",
+    "canonicalTitle": "Thirty-Nine Articles",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-thirty-nine-articles",
+        "nodeTitle": "Thirty-Nine Articles"
+      }
+    ]
+  },
+  "Book_of_Common_Prayer_(1549)": {
+    "wikidataId": "Q85748229",
+    "wikipediaTitle": "Book_of_Common_Prayer_(1549)",
+    "canonicalTitle": "Book of Common Prayer (1549)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-bcp-1549",
+        "nodeTitle": "Book of Common Prayer (1549)"
+      }
+    ]
+  },
+  "Book_of_Common_Prayer_(1552)": {
+    "wikidataId": "Q111955226",
+    "wikipediaTitle": "Book_of_Common_Prayer_(1552)",
+    "canonicalTitle": "Book of Common Prayer (1552)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-bcp-1552",
+        "nodeTitle": "Book of Common Prayer (1552)"
+      }
+    ]
+  },
+  "Genevan_Psalter": {
+    "wikidataId": "Q493726",
+    "wikipediaTitle": "Genevan_Psalter",
+    "canonicalTitle": "Genevan Psalter",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-genevan-psalter",
+        "nodeTitle": "Genevan Psalter"
+      }
+    ]
+  },
+  "A_Mighty_Fortress_Is_Our_God": {
+    "wikidataId": "Q855575",
+    "wikipediaTitle": "A_Mighty_Fortress_Is_Our_God",
+    "canonicalTitle": "Luther's Hymns",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-luther-hymns",
+        "nodeTitle": "Luther's Hymns"
+      }
+    ]
+  },
+  "Foxe%27s_Book_of_Martyrs": {
+    "wikidataId": null,
+    "wikipediaTitle": "Foxe%27s_Book_of_Martyrs",
+    "canonicalTitle": "Actes and Monuments (Book of Martyrs)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-book-of-martyrs",
+        "nodeTitle": "Actes and Monuments (Book of Martyrs)"
+      }
+    ]
+  },
+  "The_Praise_of_Folly": {
+    "wikidataId": null,
+    "wikipediaTitle": "The_Praise_of_Folly",
+    "canonicalTitle": "The Praise of Folly",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-praise-of-folly",
+        "nodeTitle": "The Praise of Folly"
+      }
+    ]
+  },
+  "Enchiridion_militis_Christiani": {
+    "wikidataId": null,
+    "wikipediaTitle": "Enchiridion_militis_Christiani",
+    "canonicalTitle": "Enchiridion",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-enchiridion",
+        "nodeTitle": "Enchiridion"
+      }
+    ]
+  },
+  "The_First_Blast_of_the_Trumpet_Against_the_Monstrous_Regiment_of_Women": {
+    "wikidataId": "Q7777000",
+    "wikipediaTitle": "The_First_Blast_of_the_Trumpet_Against_the_Monstrous_Regiment_of_Women",
+    "canonicalTitle": "First Blast of the Trumpet",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "object-first-blast",
+        "nodeTitle": "First Blast of the Trumpet"
+      }
+    ]
+  },
+  "Wittenberg": {
+    "wikidataId": "Q6837",
+    "wikipediaTitle": "Wittenberg",
+    "canonicalTitle": "Wittenberg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-wittenberg",
+        "nodeTitle": "Wittenberg"
+      }
+    ]
+  },
+  "University_of_Wittenberg": {
+    "wikidataId": null,
+    "wikipediaTitle": "University_of_Wittenberg",
+    "canonicalTitle": "University of Wittenberg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-wittenberg-university",
+        "nodeTitle": "University of Wittenberg"
+      }
+    ]
+  },
+  "All_Saints%27_Church,_Wittenberg": {
+    "wikidataId": null,
+    "wikipediaTitle": "All_Saints%27_Church,_Wittenberg",
+    "canonicalTitle": "Castle Church (Schlosskirche)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-castle-church-wittenberg",
+        "nodeTitle": "Castle Church (Schlosskirche)"
+      }
+    ]
+  },
+  "Worms,_Germany": {
+    "wikidataId": "Q3852",
+    "wikipediaTitle": "Worms,_Germany",
+    "canonicalTitle": "Worms",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-worms",
+        "nodeTitle": "Worms"
+      }
+    ]
+  },
+  "Augsburg": {
+    "wikidataId": "Q2749",
+    "wikipediaTitle": "Augsburg",
+    "canonicalTitle": "Augsburg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-augsburg",
+        "nodeTitle": "Augsburg"
+      },
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-augsburg",
+        "nodeTitle": "Augsburg"
+      }
+    ]
+  },
+  "Marburg": {
+    "wikidataId": "Q3869",
+    "wikipediaTitle": "Marburg",
+    "canonicalTitle": "Marburg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-marburg",
+        "nodeTitle": "Marburg"
+      },
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-marburg",
+        "nodeTitle": "Marburg"
+      }
+    ]
+  },
+  "University_of_Marburg": {
+    "wikidataId": null,
+    "wikipediaTitle": "University_of_Marburg",
+    "canonicalTitle": "University of Marburg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-marburg-university",
+        "nodeTitle": "University of Marburg"
+      },
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-university-marburg",
+        "nodeTitle": "University of Marburg"
+      }
+    ]
+  },
+  "Nuremberg": {
+    "wikidataId": "Q2090",
+    "wikipediaTitle": "Nuremberg",
+    "canonicalTitle": "Nuremberg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-nuremberg",
+        "nodeTitle": "Nuremberg"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-nuremberg",
+        "nodeTitle": "Nuremberg"
+      }
+    ]
+  },
+  "Eisleben": {
+    "wikidataId": "Q484870",
+    "wikipediaTitle": "Eisleben",
+    "canonicalTitle": "Eisleben",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-eisleben",
+        "nodeTitle": "Eisleben"
+      }
+    ]
+  },
+  "Wartburg": {
+    "wikidataId": "Q151545",
+    "wikipediaTitle": "Wartburg",
+    "canonicalTitle": "Wartburg Castle",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-wartburg",
+        "nodeTitle": "Wartburg Castle"
+      }
+    ]
+  },
+  "Erfurt": {
+    "wikidataId": "Q1729",
+    "wikipediaTitle": "Erfurt",
+    "canonicalTitle": "Erfurt",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-erfurt",
+        "nodeTitle": "Erfurt"
+      }
+    ]
+  },
+  "Mühlhausen": {
+    "wikidataId": "Q14925",
+    "wikipediaTitle": "Mühlhausen",
+    "canonicalTitle": "Mühlhausen",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-muhlhausen",
+        "nodeTitle": "Mühlhausen"
+      }
+    ]
+  },
+  "Zürich": {
+    "wikidataId": null,
+    "wikipediaTitle": "Zürich",
+    "canonicalTitle": "Zurich",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-zurich",
+        "nodeTitle": "Zurich"
+      }
+    ]
+  },
+  "Grossmünster": {
+    "wikidataId": "Q684948",
+    "wikipediaTitle": "Grossmünster",
+    "canonicalTitle": "Grossmünster",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-grossmunster",
+        "nodeTitle": "Grossmünster"
+      }
+    ]
+  },
+  "St._Pierre_Cathedral,_Geneva": {
+    "wikidataId": null,
+    "wikipediaTitle": "St._Pierre_Cathedral,_Geneva",
+    "canonicalTitle": "St. Pierre Cathedral",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-st-pierre-geneva",
+        "nodeTitle": "St. Pierre Cathedral"
+      }
+    ]
+  },
+  "University_of_Geneva": {
+    "wikidataId": "Q503473",
+    "wikipediaTitle": "University_of_Geneva",
+    "canonicalTitle": "Geneva Academy",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-geneva-academy",
+        "nodeTitle": "Geneva Academy"
+      }
+    ]
+  },
+  "Basel": {
+    "wikidataId": "Q78",
+    "wikipediaTitle": "Basel",
+    "canonicalTitle": "Basel",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-basel",
+        "nodeTitle": "Basel"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-basel",
+        "nodeTitle": "Basel"
+      },
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-basel",
+        "nodeTitle": "Basel"
+      }
+    ]
+  },
+  "University_of_Basel": {
+    "wikidataId": "Q372608",
+    "wikipediaTitle": "University_of_Basel",
+    "canonicalTitle": "University of Basel",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-basel-university",
+        "nodeTitle": "University of Basel"
+      }
+    ]
+  },
+  "Bern": {
+    "wikidataId": "Q70",
+    "wikipediaTitle": "Bern",
+    "canonicalTitle": "Bern",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-bern",
+        "nodeTitle": "Bern"
+      }
+    ]
+  },
+  "Lausanne": {
+    "wikidataId": "Q807",
+    "wikipediaTitle": "Lausanne",
+    "canonicalTitle": "Lausanne",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-lausanne",
+        "nodeTitle": "Lausanne"
+      }
+    ]
+  },
+  "Strasbourg": {
+    "wikidataId": "Q6602",
+    "wikipediaTitle": "Strasbourg",
+    "canonicalTitle": "Strasbourg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-strasbourg",
+        "nodeTitle": "Strasbourg"
+      }
+    ]
+  },
+  "Canterbury": {
+    "wikidataId": "Q29303",
+    "wikipediaTitle": "Canterbury",
+    "canonicalTitle": "Canterbury",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-canterbury",
+        "nodeTitle": "Canterbury"
+      }
+    ]
+  },
+  "Oxford": {
+    "wikidataId": "Q34217",
+    "wikipediaTitle": "Oxford",
+    "canonicalTitle": "Oxford",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-oxford",
+        "nodeTitle": "Oxford"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-oxford",
+        "nodeTitle": "Oxford"
+      }
+    ]
+  },
+  "University_of_Oxford": {
+    "wikidataId": "Q34433",
+    "wikipediaTitle": "University_of_Oxford",
+    "canonicalTitle": "University of Oxford",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-oxford-university",
+        "nodeTitle": "University of Oxford"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-oxford",
+        "nodeTitle": "University of Oxford"
+      }
+    ]
+  },
+  "Cambridge": {
+    "wikidataId": "Q350",
+    "wikipediaTitle": "Cambridge",
+    "canonicalTitle": "Cambridge",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-cambridge",
+        "nodeTitle": "Cambridge"
+      }
+    ]
+  },
+  "White_Horse_Inn,_Cambridge": {
+    "wikidataId": null,
+    "wikipediaTitle": "White_Horse_Inn,_Cambridge",
+    "canonicalTitle": "White Horse Tavern",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-white-horse-tavern",
+        "nodeTitle": "White Horse Tavern"
+      }
+    ]
+  },
+  "Antwerp": {
+    "wikidataId": "Q12892",
+    "wikipediaTitle": "Antwerp",
+    "canonicalTitle": "Antwerp",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-antwerp",
+        "nodeTitle": "Antwerp"
+      }
+    ]
+  },
+  "Vilvoorde": {
+    "wikidataId": "Q318418",
+    "wikipediaTitle": "Vilvoorde",
+    "canonicalTitle": "Vilvoorde",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-vilvoorde",
+        "nodeTitle": "Vilvoorde"
+      }
+    ]
+  },
+  "Meaux": {
+    "wikidataId": "Q207620",
+    "wikipediaTitle": "Meaux",
+    "canonicalTitle": "Meaux",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-meaux",
+        "nodeTitle": "Meaux"
+      }
+    ]
+  },
+  "Ingolstadt": {
+    "wikidataId": "Q3004",
+    "wikipediaTitle": "Ingolstadt",
+    "canonicalTitle": "Ingolstadt",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-ingolstadt",
+        "nodeTitle": "Ingolstadt"
+      }
+    ]
+  },
+  "St_Andrews": {
+    "wikidataId": "Q207736",
+    "wikipediaTitle": "St_Andrews",
+    "canonicalTitle": "St. Andrews",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-st-andrews",
+        "nodeTitle": "St. Andrews"
+      }
+    ]
+  },
+  "University_of_St_Andrews": {
+    "wikidataId": "Q216273",
+    "wikipediaTitle": "University_of_St_Andrews",
+    "canonicalTitle": "University of St. Andrews",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-st-andrews-university",
+        "nodeTitle": "University of St. Andrews"
+      }
+    ]
+  },
+  "St_Giles%27_Cathedral": {
+    "wikidataId": null,
+    "wikipediaTitle": "St_Giles%27_Cathedral",
+    "canonicalTitle": "St. Giles' Cathedral",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-st-giles-edinburgh",
+        "nodeTitle": "St. Giles' Cathedral"
+      }
+    ]
+  },
+  "Battle_of_Kappel": {
+    "wikidataId": null,
+    "wikipediaTitle": "Battle_of_Kappel",
+    "canonicalTitle": "Kappel am Albis",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-kappel",
+        "nodeTitle": "Kappel am Albis"
+      }
+    ]
+  },
+  "Schleitheim": {
+    "wikidataId": "Q69111",
+    "wikipediaTitle": "Schleitheim",
+    "canonicalTitle": "Schleitheim",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-schleitheim",
+        "nodeTitle": "Schleitheim"
+      }
+    ]
+  },
+  "Battle_of_Frankenhausen": {
+    "wikidataId": "Q703363",
+    "wikipediaTitle": "Battle_of_Frankenhausen",
+    "canonicalTitle": "Frankenhausen",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "location-frankenhausen",
+        "nodeTitle": "Frankenhausen"
+      }
+    ]
+  },
+  "Lutheranism": {
+    "wikidataId": "Q75809",
+    "wikipediaTitle": "Lutheranism",
+    "canonicalTitle": "Lutheran Territorial Churches",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-lutheran-churches",
+        "nodeTitle": "Lutheran Territorial Churches"
+      }
+    ]
+  },
+  "Church_of_England": {
+    "wikidataId": "Q82708",
+    "wikipediaTitle": "Church_of_England",
+    "canonicalTitle": "Church of England",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-church-of-england",
+        "nodeTitle": "Church of England"
+      }
+    ]
+  },
+  "Reformed_Church_in_Zürich": {
+    "wikidataId": null,
+    "wikipediaTitle": "Reformed_Church_in_Zürich",
+    "canonicalTitle": "Reformed Church of Zurich",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-zurich-church",
+        "nodeTitle": "Reformed Church of Zurich"
+      }
+    ]
+  },
+  "Venerable_Company_of_Pastors": {
+    "wikidataId": "Q16950662",
+    "wikipediaTitle": "Venerable_Company_of_Pastors",
+    "canonicalTitle": "Company of Pastors",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-company-of-pastors",
+        "nodeTitle": "Company of Pastors"
+      }
+    ]
+  },
+  "Consistory_of_Geneva": {
+    "wikidataId": null,
+    "wikipediaTitle": "Consistory_of_Geneva",
+    "canonicalTitle": "Geneva Consistory",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-geneva-consistory",
+        "nodeTitle": "Geneva Consistory"
+      }
+    ]
+  },
+  "Church_of_Scotland": {
+    "wikidataId": "Q922480",
+    "wikipediaTitle": "Church_of_Scotland",
+    "canonicalTitle": "Church of Scotland (The Kirk)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-church-of-scotland",
+        "nodeTitle": "Church of Scotland (The Kirk)"
+      }
+    ]
+  },
+  "Reformation": {
+    "wikidataId": "Q12562",
+    "wikipediaTitle": "Reformation",
+    "canonicalTitle": "Lutheran Reformation",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-lutheran-reformation",
+        "nodeTitle": "Lutheran Reformation"
+      }
+    ]
+  },
+  "Swiss_Reformed_Church": {
+    "wikidataId": null,
+    "wikipediaTitle": "Swiss_Reformed_Church",
+    "canonicalTitle": "Swiss Reformed Movement",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-swiss-reformed",
+        "nodeTitle": "Swiss Reformed Movement"
+      }
+    ]
+  },
+  "Radical_Reformation": {
+    "wikidataId": "Q1786655",
+    "wikipediaTitle": "Radical_Reformation",
+    "canonicalTitle": "Radical Reformation",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-radical-reformation",
+        "nodeTitle": "Radical Reformation"
+      }
+    ]
+  },
+  "Swiss_Brethren": {
+    "wikidataId": "Q474889",
+    "wikipediaTitle": "Swiss_Brethren",
+    "canonicalTitle": "Swiss Brethren",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-swiss-brethren",
+        "nodeTitle": "Swiss Brethren"
+      }
+    ]
+  },
+  "Mennonites": {
+    "wikidataId": "Q110223",
+    "wikipediaTitle": "Mennonites",
+    "canonicalTitle": "Mennonite Movement",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-mennonites",
+        "nodeTitle": "Mennonite Movement"
+      }
+    ]
+  },
+  "Christian_humanism": {
+    "wikidataId": "Q2327432",
+    "wikipediaTitle": "Christian_humanism",
+    "canonicalTitle": "Christian Humanism",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-christian-humanism",
+        "nodeTitle": "Christian Humanism"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-northern-humanism",
+        "nodeTitle": "Northern (Christian) Humanism"
+      }
+    ]
+  },
+  "English_Reformation": {
+    "wikidataId": "Q1645505",
+    "wikipediaTitle": "English_Reformation",
+    "canonicalTitle": "English Reformation",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-english-reformation",
+        "nodeTitle": "English Reformation"
+      }
+    ]
+  },
+  "Circle_of_Meaux": {
+    "wikidataId": null,
+    "wikipediaTitle": "Circle_of_Meaux",
+    "canonicalTitle": "Meaux Circle",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-meaux-circle",
+        "nodeTitle": "Meaux Circle"
+      }
+    ]
+  },
+  "Schmalkaldic_League": {
+    "wikidataId": "Q155024",
+    "wikipediaTitle": "Schmalkaldic_League",
+    "canonicalTitle": "Schmalkaldic League",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-schmalkaldic-league",
+        "nodeTitle": "Schmalkaldic League"
+      }
+    ]
+  },
+  "Old_Swiss_Confederacy": {
+    "wikidataId": "Q435583",
+    "wikipediaTitle": "Old_Swiss_Confederacy",
+    "canonicalTitle": "Swiss Confederacy",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-swiss-confederacy",
+        "nodeTitle": "Swiss Confederacy"
+      }
+    ]
+  },
+  "Order_of_Saint_Augustine": {
+    "wikidataId": "Q29075",
+    "wikipediaTitle": "Order_of_Saint_Augustine",
+    "canonicalTitle": "Augustinian Order",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-augustinian-order",
+        "nodeTitle": "Augustinian Order"
+      }
+    ]
+  },
+  "Diet_of_Worms": {
+    "wikidataId": "Q536822",
+    "wikipediaTitle": "Diet_of_Worms",
+    "canonicalTitle": "Diet of Worms (1521)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-diet-of-worms",
+        "nodeTitle": "Diet of Worms (1521)"
+      }
+    ]
+  },
+  "Diet_of_Augsburg": {
+    "wikidataId": "Q828750",
+    "wikipediaTitle": "Diet_of_Augsburg",
+    "canonicalTitle": "Diet of Augsburg (1530)",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-diet-of-augsburg",
+        "nodeTitle": "Diet of Augsburg (1530)"
+      }
+    ]
+  },
+  "Marburg_Colloquy": {
+    "wikidataId": "Q672138",
+    "wikipediaTitle": "Marburg_Colloquy",
+    "canonicalTitle": "Marburg Colloquy",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-marburg-colloquy",
+        "nodeTitle": "Marburg Colloquy"
+      }
+    ]
+  },
+  "First_Disputation_of_Zurich": {
+    "wikidataId": null,
+    "wikipediaTitle": "First_Disputation_of_Zurich",
+    "canonicalTitle": "First Zurich Disputation",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-zurich-disputation-1523",
+        "nodeTitle": "First Zurich Disputation"
+      }
+    ]
+  },
+  "Leipzig_Debate": {
+    "wikidataId": "Q688998",
+    "wikipediaTitle": "Leipzig_Debate",
+    "canonicalTitle": "Leipzig Debate",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-leipzig-debate",
+        "nodeTitle": "Leipzig Debate"
+      }
+    ]
+  },
+  "Peace_of_Augsburg": {
+    "wikidataId": "Q154577",
+    "wikipediaTitle": "Peace_of_Augsburg",
+    "canonicalTitle": "Peace of Augsburg",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-peace-of-augsburg",
+        "nodeTitle": "Peace of Augsburg"
+      }
+    ]
+  },
+  "Johann_Froben": {
+    "wikidataId": "Q116611",
+    "wikipediaTitle": "Johann_Froben",
+    "canonicalTitle": "Froben Press",
+    "appearances": [
+      {
+        "datasetId": "protestant-reformation",
+        "datasetName": "Protestant Reformation Network",
+        "nodeId": "entity-froben-press",
+        "nodeTitle": "Froben Press"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-johann-froben",
+        "nodeTitle": "Johann Froben"
+      }
+    ]
+  },
+  "Petrarch": {
+    "wikidataId": "Q1401",
+    "wikipediaTitle": "Petrarch",
+    "canonicalTitle": "Francesco Petrarca (Petrarch)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-francesco-petrarca",
+        "nodeTitle": "Francesco Petrarca (Petrarch)"
+      }
+    ]
+  },
+  "Giovanni_Boccaccio": {
+    "wikidataId": "Q1402",
+    "wikipediaTitle": "Giovanni_Boccaccio",
+    "canonicalTitle": "Giovanni Boccaccio",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giovanni-boccaccio",
+        "nodeTitle": "Giovanni Boccaccio"
+      }
+    ]
+  },
+  "Coluccio_Salutati": {
+    "wikidataId": "Q93113",
+    "wikipediaTitle": "Coluccio_Salutati",
+    "canonicalTitle": "Coluccio Salutati",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-coluccio-salutati",
+        "nodeTitle": "Coluccio Salutati"
+      }
+    ]
+  },
+  "Leonardo_Bruni": {
+    "wikidataId": "Q314488",
+    "wikipediaTitle": "Leonardo_Bruni",
+    "canonicalTitle": "Leonardo Bruni",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-leonardo-bruni",
+        "nodeTitle": "Leonardo Bruni"
+      }
+    ]
+  },
+  "Poggio_Bracciolini": {
+    "wikidataId": "Q318254",
+    "wikipediaTitle": "Poggio_Bracciolini",
+    "canonicalTitle": "Poggio Bracciolini",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-poggio-bracciolini",
+        "nodeTitle": "Poggio Bracciolini"
+      }
+    ]
+  },
+  "Niccolò_Niccoli": {
+    "wikidataId": "Q730505",
+    "wikipediaTitle": "Niccolò_Niccoli",
+    "canonicalTitle": "Niccolò Niccoli",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-niccolo-niccoli",
+        "nodeTitle": "Niccolò Niccoli"
+      }
+    ]
+  },
+  "Pier_Paolo_Vergerio": {
+    "wikidataId": "Q668134",
+    "wikipediaTitle": "Pier_Paolo_Vergerio",
+    "canonicalTitle": "Pier Paolo Vergerio the Elder",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-pier-paolo-vergerio",
+        "nodeTitle": "Pier Paolo Vergerio the Elder"
+      }
+    ]
+  },
+  "Gasparino_Barzizza": {
+    "wikidataId": "Q1236187",
+    "wikipediaTitle": "Gasparino_Barzizza",
+    "canonicalTitle": "Gasparino Barzizza",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-gasparino-barzizza",
+        "nodeTitle": "Gasparino Barzizza"
+      }
+    ]
+  },
+  "Giovanni_Aurispa": {
+    "wikidataId": "Q770787",
+    "wikipediaTitle": "Giovanni_Aurispa",
+    "canonicalTitle": "Giovanni Aurispa",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giovanni-aurispa",
+        "nodeTitle": "Giovanni Aurispa"
+      }
+    ]
+  },
+  "Angelo_Poliziano": {
+    "wikidataId": null,
+    "wikipediaTitle": "Angelo_Poliziano",
+    "canonicalTitle": "Angelo Poliziano (Politian)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-angelo-poliziano",
+        "nodeTitle": "Angelo Poliziano (Politian)"
+      }
+    ]
+  },
+  "Lorenzo_de%27_Medici": {
+    "wikidataId": null,
+    "wikipediaTitle": "Lorenzo_de%27_Medici",
+    "canonicalTitle": "Lorenzo de' Medici",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-lorenzo-de-medici",
+        "nodeTitle": "Lorenzo de' Medici"
+      }
+    ]
+  },
+  "Giovanni_Nesi": {
+    "wikidataId": "Q125461951",
+    "wikipediaTitle": "Giovanni_Nesi",
+    "canonicalTitle": "Giovanni Nesi",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giovanni-nesi",
+        "nodeTitle": "Giovanni Nesi"
+      }
+    ]
+  },
+  "Leon_Battista_Alberti": {
+    "wikidataId": "Q182046",
+    "wikipediaTitle": "Leon_Battista_Alberti",
+    "canonicalTitle": "Leon Battista Alberti",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-leon-battista-alberti",
+        "nodeTitle": "Leon Battista Alberti"
+      }
+    ]
+  },
+  "Niccolò_Machiavelli": {
+    "wikidataId": "Q1399",
+    "wikipediaTitle": "Niccolò_Machiavelli",
+    "canonicalTitle": "Niccolò Machiavelli",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-niccolo-machiavelli",
+        "nodeTitle": "Niccolò Machiavelli"
+      }
+    ]
+  },
+  "Francesco_Guicciardini": {
+    "wikidataId": "Q44601",
+    "wikipediaTitle": "Francesco_Guicciardini",
+    "canonicalTitle": "Francesco Guicciardini",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-francesco-guicciardini",
+        "nodeTitle": "Francesco Guicciardini"
+      }
+    ]
+  },
+  "Matteo_Palmieri": {
+    "wikidataId": "Q1229872",
+    "wikipediaTitle": "Matteo_Palmieri",
+    "canonicalTitle": "Matteo Palmieri",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-matteo-palmieri",
+        "nodeTitle": "Matteo Palmieri"
+      }
+    ]
+  },
+  "Donato_Acciaiuoli": {
+    "wikidataId": null,
+    "wikipediaTitle": "Donato_Acciaiuoli",
+    "canonicalTitle": "Donato Acciaiuoli",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-donato-acciaiuoli",
+        "nodeTitle": "Donato Acciaiuoli"
+      }
+    ]
+  },
+  "Giannozzo_Manetti": {
+    "wikidataId": "Q1234681",
+    "wikipediaTitle": "Giannozzo_Manetti",
+    "canonicalTitle": "Giannozzo Manetti",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giannozzo-manetti",
+        "nodeTitle": "Giannozzo Manetti"
+      }
+    ]
+  },
+  "Lorenzo_Valla": {
+    "wikidataId": "Q214115",
+    "wikipediaTitle": "Lorenzo_Valla",
+    "canonicalTitle": "Lorenzo Valla",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-lorenzo-valla",
+        "nodeTitle": "Lorenzo Valla"
+      }
+    ]
+  },
+  "Flavio_Biondo": {
+    "wikidataId": "Q434834",
+    "wikipediaTitle": "Flavio_Biondo",
+    "canonicalTitle": "Flavio Biondo",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-flavio-biondo",
+        "nodeTitle": "Flavio Biondo"
+      }
+    ]
+  },
+  "Giulio_Pomponio_Leto": {
+    "wikidataId": null,
+    "wikipediaTitle": "Giulio_Pomponio_Leto",
+    "canonicalTitle": "Pomponio Leto",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-pomponio-leto",
+        "nodeTitle": "Pomponio Leto"
+      }
+    ]
+  },
+  "Bartolomeo_Platina": {
+    "wikidataId": "Q455140",
+    "wikipediaTitle": "Bartolomeo_Platina",
+    "canonicalTitle": "Bartolomeo Platina",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-bartolomeo-platina",
+        "nodeTitle": "Bartolomeo Platina"
+      }
+    ]
+  },
+  "Giovanni_Pontano": {
+    "wikidataId": "Q714946",
+    "wikipediaTitle": "Giovanni_Pontano",
+    "canonicalTitle": "Giovanni Pontano",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giovanni-pontano",
+        "nodeTitle": "Giovanni Pontano"
+      }
+    ]
+  },
+  "Jacopo_Sannazaro": {
+    "wikidataId": "Q510621",
+    "wikipediaTitle": "Jacopo_Sannazaro",
+    "canonicalTitle": "Jacopo Sannazaro",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-jacopo-sannazaro",
+        "nodeTitle": "Jacopo Sannazaro"
+      }
+    ]
+  },
+  "Pope_Pius_II": {
+    "wikidataId": "Q101437",
+    "wikipediaTitle": "Pope_Pius_II",
+    "canonicalTitle": "Enea Silvio Piccolomini (Pope Pius II)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-enea-silvio-piccolomini",
+        "nodeTitle": "Enea Silvio Piccolomini (Pope Pius II)"
+      }
+    ]
+  },
+  "Pietro_Bembo": {
+    "wikidataId": "Q334188",
+    "wikipediaTitle": "Pietro_Bembo",
+    "canonicalTitle": "Pietro Bembo",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-pietro-bembo",
+        "nodeTitle": "Pietro Bembo"
+      }
+    ]
+  },
+  "Aldus_Manutius": {
+    "wikidataId": "Q213220",
+    "wikipediaTitle": "Aldus_Manutius",
+    "canonicalTitle": "Aldo Manuzio (Aldus Manutius)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-aldo-manuzio",
+        "nodeTitle": "Aldo Manuzio (Aldus Manutius)"
+      }
+    ]
+  },
+  "Ermolao_Barbaro_the_Younger": {
+    "wikidataId": null,
+    "wikipediaTitle": "Ermolao_Barbaro_the_Younger",
+    "canonicalTitle": "Ermolao Barbaro the Younger",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-ermolao-barbaro",
+        "nodeTitle": "Ermolao Barbaro the Younger"
+      }
+    ]
+  },
+  "Pietro_Pomponazzi": {
+    "wikidataId": "Q318787",
+    "wikipediaTitle": "Pietro_Pomponazzi",
+    "canonicalTitle": "Pietro Pomponazzi",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-pietro-pomponazzi",
+        "nodeTitle": "Pietro Pomponazzi"
+      }
+    ]
+  },
+  "Niccolò_Leonico_Tomeo": {
+    "wikidataId": null,
+    "wikipediaTitle": "Niccolò_Leonico_Tomeo",
+    "canonicalTitle": "Niccolò Leonico Tomeo",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-niccolo-leonico-tomeo",
+        "nodeTitle": "Niccolò Leonico Tomeo"
+      }
+    ]
+  },
+  "Giorgio_Valla": {
+    "wikidataId": "Q1525570",
+    "wikipediaTitle": "Giorgio_Valla",
+    "canonicalTitle": "Giorgio Valla",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-giorgio-valla",
+        "nodeTitle": "Giorgio Valla"
+      }
+    ]
+  },
+  "William_Grocyn": {
+    "wikidataId": "Q731879",
+    "wikipediaTitle": "William_Grocyn",
+    "canonicalTitle": "William Grocyn",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-william-grocyn",
+        "nodeTitle": "William Grocyn"
+      }
+    ]
+  },
+  "Thomas_Linacre": {
+    "wikidataId": "Q730540",
+    "wikipediaTitle": "Thomas_Linacre",
+    "canonicalTitle": "Thomas Linacre",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-thomas-linacre",
+        "nodeTitle": "Thomas Linacre"
+      }
+    ]
+  },
+  "John_Fisher_(cardinal)": {
+    "wikidataId": null,
+    "wikipediaTitle": "John_Fisher_(cardinal)",
+    "canonicalTitle": "John Fisher",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-john-fisher",
+        "nodeTitle": "John Fisher"
+      }
+    ]
+  },
+  "Cuthbert_Tunstall": {
+    "wikidataId": "Q725592",
+    "wikipediaTitle": "Cuthbert_Tunstall",
+    "canonicalTitle": "Cuthbert Tunstall",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-cuthbert-tunstall",
+        "nodeTitle": "Cuthbert Tunstall"
+      }
+    ]
+  },
+  "Juan_Luis_Vives": {
+    "wikidataId": "Q316357",
+    "wikipediaTitle": "Juan_Luis_Vives",
+    "canonicalTitle": "Juan Luis Vives",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-juan-luis-vives",
+        "nodeTitle": "Juan Luis Vives"
+      }
+    ]
+  },
+  "Guillaume_Budé": {
+    "wikidataId": "Q353668",
+    "wikipediaTitle": "Guillaume_Budé",
+    "canonicalTitle": "Guillaume Budé",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-guillaume-bude",
+        "nodeTitle": "Guillaume Budé"
+      }
+    ]
+  },
+  "Robert_Estienne": {
+    "wikidataId": "Q260921",
+    "wikipediaTitle": "Robert_Estienne",
+    "canonicalTitle": "Robert Estienne (Stephanus)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-robert-estienne",
+        "nodeTitle": "Robert Estienne (Stephanus)"
+      }
+    ]
+  },
+  "Rudolf_Agricola": {
+    "wikidataId": null,
+    "wikipediaTitle": "Rudolf_Agricola",
+    "canonicalTitle": "Rudolf Agricola",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-rudolf-agricola",
+        "nodeTitle": "Rudolf Agricola"
+      }
+    ]
+  },
+  "Johannes_Reuchlin": {
+    "wikidataId": null,
+    "wikipediaTitle": "Johannes_Reuchlin",
+    "canonicalTitle": "Johannes Reuchlin",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-johannes-reuchlin",
+        "nodeTitle": "Johannes Reuchlin"
+      }
+    ]
+  },
+  "Conrad_Celtes": {
+    "wikidataId": "Q60625",
+    "wikipediaTitle": "Conrad_Celtes",
+    "canonicalTitle": "Conrad Celtis",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-conrad-celtis",
+        "nodeTitle": "Conrad Celtis"
+      }
+    ]
+  },
+  "Willibald_Pirckheimer": {
+    "wikidataId": "Q62663",
+    "wikipediaTitle": "Willibald_Pirckheimer",
+    "canonicalTitle": "Willibald Pirckheimer",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-willibald-pirckheimer",
+        "nodeTitle": "Willibald Pirckheimer"
+      }
+    ]
+  },
+  "Jakob_Wimpfeling": {
+    "wikidataId": "Q71848",
+    "wikipediaTitle": "Jakob_Wimpfeling",
+    "canonicalTitle": "Jakob Wimpfeling",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-jakob-wimpfeling",
+        "nodeTitle": "Jakob Wimpfeling"
+      }
+    ]
+  },
+  "Beatus_Rhenanus": {
+    "wikidataId": "Q646092",
+    "wikipediaTitle": "Beatus_Rhenanus",
+    "canonicalTitle": "Beatus Rhenanus",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-beatus-rhenanus",
+        "nodeTitle": "Beatus Rhenanus"
+      }
+    ]
+  },
+  "Alexander_Hegius": {
+    "wikidataId": "Q706796",
+    "wikipediaTitle": "Alexander_Hegius",
+    "canonicalTitle": "Alexander Hegius",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-alexander-hegius",
+        "nodeTitle": "Alexander Hegius"
+      }
+    ]
+  },
+  "Antonio_de_Nebrija": {
+    "wikidataId": "Q380804",
+    "wikipediaTitle": "Antonio_de_Nebrija",
+    "canonicalTitle": "Antonio de Nebrija",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-antonio-nebrija",
+        "nodeTitle": "Antonio de Nebrija"
+      }
+    ]
+  },
+  "Francisco_Jiménez_de_Cisneros": {
+    "wikidataId": "Q342392",
+    "wikipediaTitle": "Francisco_Jiménez_de_Cisneros",
+    "canonicalTitle": "Cardinal Francisco Jiménez de Cisneros",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-cardinal-cisneros",
+        "nodeTitle": "Cardinal Francisco Jiménez de Cisneros"
+      }
+    ]
+  },
+  "Juan_de_Valdés": {
+    "wikidataId": "Q666687",
+    "wikipediaTitle": "Juan_de_Valdés",
+    "canonicalTitle": "Juan de Valdés",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-juan-de-valdes",
+        "nodeTitle": "Juan de Valdés"
+      }
+    ]
+  },
+  "Hernán_Núñez_de_Toledo": {
+    "wikidataId": null,
+    "wikipediaTitle": "Hernán_Núñez_de_Toledo",
+    "canonicalTitle": "Hernán Núñez de Toledo",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-hernan-nunez",
+        "nodeTitle": "Hernán Núñez de Toledo"
+      }
+    ]
+  },
+  "Michel_de_Montaigne": {
+    "wikidataId": "Q41568",
+    "wikipediaTitle": "Michel_de_Montaigne",
+    "canonicalTitle": "Michel de Montaigne",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-michel-de-montaigne",
+        "nodeTitle": "Michel de Montaigne"
+      }
+    ]
+  },
+  "Étienne_de_La_Boétie": {
+    "wikidataId": "Q290227",
+    "wikipediaTitle": "Étienne_de_La_Boétie",
+    "canonicalTitle": "Étienne de La Boétie",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-etienne-de-la-boetie",
+        "nodeTitle": "Étienne de La Boétie"
+      }
+    ]
+  },
+  "Jean_Dorat": {
+    "wikidataId": null,
+    "wikipediaTitle": "Jean_Dorat",
+    "canonicalTitle": "Jean Dorat",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-jean-dorat",
+        "nodeTitle": "Jean Dorat"
+      }
+    ]
+  },
+  "Guarino_da_Verona": {
+    "wikidataId": "Q539577",
+    "wikipediaTitle": "Guarino_da_Verona",
+    "canonicalTitle": "Guarino da Verona",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-guarino-da-verona",
+        "nodeTitle": "Guarino da Verona"
+      }
+    ]
+  },
+  "Vittorino_da_Feltre": {
+    "wikidataId": "Q725843",
+    "wikipediaTitle": "Vittorino_da_Feltre",
+    "canonicalTitle": "Vittorino da Feltre",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-vittorino-da-feltre",
+        "nodeTitle": "Vittorino da Feltre"
+      }
+    ]
+  },
+  "Battista_Guarino": {
+    "wikidataId": "Q810966",
+    "wikipediaTitle": "Battista_Guarino",
+    "canonicalTitle": "Battista Guarino",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-battista-guarino",
+        "nodeTitle": "Battista Guarino"
+      }
+    ]
+  },
+  "Johannes_Sturm": {
+    "wikidataId": "Q66382",
+    "wikipediaTitle": "Johannes_Sturm",
+    "canonicalTitle": "Johannes Sturm",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-johannes-sturm",
+        "nodeTitle": "Johannes Sturm"
+      }
+    ]
+  },
+  "Demetrius_Chalcondyles": {
+    "wikidataId": null,
+    "wikipediaTitle": "Demetrius_Chalcondyles",
+    "canonicalTitle": "Demetrius Chalcondyles",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-demetrius-chalcondyles",
+        "nodeTitle": "Demetrius Chalcondyles"
+      }
+    ]
+  },
+  "George_of_Trebizond": {
+    "wikidataId": "Q533514",
+    "wikipediaTitle": "George_of_Trebizond",
+    "canonicalTitle": "George of Trebizond",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-george-of-trebizond",
+        "nodeTitle": "George of Trebizond"
+      }
+    ]
+  },
+  "Bessarion": {
+    "wikidataId": "Q299446",
+    "wikipediaTitle": "Bessarion",
+    "canonicalTitle": "Cardinal Bessarion",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-cardinal-bessarion",
+        "nodeTitle": "Cardinal Bessarion"
+      }
+    ]
+  },
+  "Theodore_Gaza": {
+    "wikidataId": null,
+    "wikipediaTitle": "Theodore_Gaza",
+    "canonicalTitle": "Theodore Gaza",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-theodore-gaza",
+        "nodeTitle": "Theodore Gaza"
+      }
+    ]
+  },
+  "Francesco_Filelfo": {
+    "wikidataId": "Q4622",
+    "wikipediaTitle": "Francesco_Filelfo",
+    "canonicalTitle": "Francesco Filelfo",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-francesco-filelfo",
+        "nodeTitle": "Francesco Filelfo"
+      }
+    ]
+  },
+  "Paolo_Giovio": {
+    "wikidataId": "Q437543",
+    "wikipediaTitle": "Paolo_Giovio",
+    "canonicalTitle": "Paolo Giovio",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-paolo-giovio",
+        "nodeTitle": "Paolo Giovio"
+      }
+    ]
+  },
+  "Pietro_Aretino": {
+    "wikidataId": "Q296272",
+    "wikipediaTitle": "Pietro_Aretino",
+    "canonicalTitle": "Pietro Aretino",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-pietro-aretino",
+        "nodeTitle": "Pietro Aretino"
+      }
+    ]
+  },
+  "Baldassare_Castiglione": {
+    "wikidataId": "Q211133",
+    "wikipediaTitle": "Baldassare_Castiglione",
+    "canonicalTitle": "Baldassare Castiglione",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-baldassare-castiglione",
+        "nodeTitle": "Baldassare Castiglione"
+      }
+    ]
+  },
+  "Cosimo_de%27_Medici": {
+    "wikidataId": null,
+    "wikipediaTitle": "Cosimo_de%27_Medici",
+    "canonicalTitle": "Cosimo de' Medici",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "person-cosimo-de-medici",
+        "nodeTitle": "Cosimo de' Medici"
+      }
+    ]
+  },
+  "Epistolae_familiares": {
+    "wikidataId": "Q995950",
+    "wikipediaTitle": "Epistolae_familiares",
+    "canonicalTitle": "Epistolae familiares",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-epistolae-familiares",
+        "nodeTitle": "Epistolae familiares"
+      }
+    ]
+  },
+  "De_viris_illustribus_(Petrarch)": {
+    "wikidataId": "Q425606",
+    "wikipediaTitle": "De_viris_illustribus_(Petrarch)",
+    "canonicalTitle": "De viris illustribus",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-viris-illustribus",
+        "nodeTitle": "De viris illustribus"
+      }
+    ]
+  },
+  "The_Decameron": {
+    "wikidataId": "Q16438",
+    "wikipediaTitle": "The_Decameron",
+    "canonicalTitle": "Decameron",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-decameron",
+        "nodeTitle": "Decameron"
+      }
+    ]
+  },
+  "Genealogia_Deorum_Gentilium": {
+    "wikidataId": "Q3759459",
+    "wikipediaTitle": "Genealogia_Deorum_Gentilium",
+    "canonicalTitle": "Genealogia deorum gentilium",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-genealogia-deorum",
+        "nodeTitle": "Genealogia deorum gentilium"
+      }
+    ]
+  },
+  "Elegantiae_linguae_Latinae": {
+    "wikidataId": null,
+    "wikipediaTitle": "Elegantiae_linguae_Latinae",
+    "canonicalTitle": "Elegantiae linguae Latinae",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-elegantiae",
+        "nodeTitle": "Elegantiae linguae Latinae"
+      }
+    ]
+  },
+  "Discourse_on_the_Forgery_of_the_Alleged_Donation_of_Constantine": {
+    "wikidataId": null,
+    "wikipediaTitle": "Discourse_on_the_Forgery_of_the_Alleged_Donation_of_Constantine",
+    "canonicalTitle": "De falso credita et ementita Constantini donatione",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-donation-constantine",
+        "nodeTitle": "De falso credita et ementita Constantini donatione"
+      }
+    ]
+  },
+  "Commentarium_in_Convivium_Platonis_de_Amore": {
+    "wikidataId": null,
+    "wikipediaTitle": "Commentarium_in_Convivium_Platonis_de_Amore",
+    "canonicalTitle": "De amore",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-amore-ficino",
+        "nodeTitle": "De amore"
+      }
+    ]
+  },
+  "Hermetica": {
+    "wikidataId": "Q14941935",
+    "wikipediaTitle": "Hermetica",
+    "canonicalTitle": "Corpus Hermeticum Translation",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-corpus-hermeticum",
+        "nodeTitle": "Corpus Hermeticum Translation"
+      }
+    ]
+  },
+  "Laudatio_Florentinae_urbis": {
+    "wikidataId": null,
+    "wikipediaTitle": "Laudatio_Florentinae_urbis",
+    "canonicalTitle": "Laudatio Florentinae urbis",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-laudatio-florentinae",
+        "nodeTitle": "Laudatio Florentinae urbis"
+      }
+    ]
+  },
+  "The_Prince": {
+    "wikidataId": "Q131719",
+    "wikipediaTitle": "The_Prince",
+    "canonicalTitle": "Il Principe (The Prince)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-il-principe",
+        "nodeTitle": "Il Principe (The Prince)"
+      }
+    ]
+  },
+  "Discourses_on_Livy": {
+    "wikidataId": "Q924424",
+    "wikipediaTitle": "Discourses_on_Livy",
+    "canonicalTitle": "Discorsi sopra la prima deca di Tito Livio",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-discorsi-livy",
+        "nodeTitle": "Discorsi sopra la prima deca di Tito Livio"
+      }
+    ]
+  },
+  "Florentine_Histories": {
+    "wikidataId": "Q691766",
+    "wikipediaTitle": "Florentine_Histories",
+    "canonicalTitle": "Istorie fiorentine",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-istorie-fiorentine",
+        "nodeTitle": "Istorie fiorentine"
+      }
+    ]
+  },
+  "Storia_d%27Italia_(Guicciardini)": {
+    "wikidataId": null,
+    "wikipediaTitle": "Storia_d%27Italia_(Guicciardini)",
+    "canonicalTitle": "Storia d'Italia",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-storia-italia",
+        "nodeTitle": "Storia d'Italia"
+      }
+    ]
+  },
+  "Ricordi_(Guicciardini)": {
+    "wikidataId": null,
+    "wikipediaTitle": "Ricordi_(Guicciardini)",
+    "canonicalTitle": "Ricordi",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-ricordi",
+        "nodeTitle": "Ricordi"
+      }
+    ]
+  },
+  "The_Book_of_the_Courtier": {
+    "wikidataId": "Q1517519",
+    "wikipediaTitle": "The_Book_of_the_Courtier",
+    "canonicalTitle": "Il libro del cortegiano (The Book of the Courtier)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-book-courtier",
+        "nodeTitle": "Il libro del cortegiano (The Book of the Courtier)"
+      }
+    ]
+  },
+  "De_inventione_dialectica": {
+    "wikidataId": null,
+    "wikipediaTitle": "De_inventione_dialectica",
+    "canonicalTitle": "De inventione dialectica",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-inventione-dialectica",
+        "nodeTitle": "De inventione dialectica"
+      }
+    ]
+  },
+  "De_Copia": {
+    "wikidataId": null,
+    "wikipediaTitle": "De_Copia",
+    "canonicalTitle": "De copia",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-copia",
+        "nodeTitle": "De copia"
+      }
+    ]
+  },
+  "Handbook_of_a_Christian_Knight": {
+    "wikidataId": null,
+    "wikipediaTitle": "Handbook_of_a_Christian_Knight",
+    "canonicalTitle": "Enchiridion militis Christiani",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-enchiridion",
+        "nodeTitle": "Enchiridion militis Christiani"
+      }
+    ]
+  },
+  "Complutensian_Polyglot_Bible": {
+    "wikidataId": "Q1121746",
+    "wikipediaTitle": "Complutensian_Polyglot_Bible",
+    "canonicalTitle": "Complutensian Polyglot Bible",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-complutensian-polyglot",
+        "nodeTitle": "Complutensian Polyglot Bible"
+      }
+    ]
+  },
+  "In_Praise_of_Folly": {
+    "wikidataId": "Q569869",
+    "wikipediaTitle": "In_Praise_of_Folly",
+    "canonicalTitle": "Moriae encomium (Praise of Folly)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-praise-of-folly",
+        "nodeTitle": "Moriae encomium (Praise of Folly)"
+      }
+    ]
+  },
+  "Colloquies": {
+    "wikidataId": "Q19020085",
+    "wikipediaTitle": "Colloquies",
+    "canonicalTitle": "Colloquia familiaria",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-colloquia",
+        "nodeTitle": "Colloquia familiaria"
+      }
+    ]
+  },
+  "Utopia_(book)": {
+    "wikidataId": "Q404158",
+    "wikipediaTitle": "Utopia_(book)",
+    "canonicalTitle": "Utopia",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-utopia",
+        "nodeTitle": "Utopia"
+      }
+    ]
+  },
+  "Arcadia_(Sannazaro)": {
+    "wikidataId": null,
+    "wikipediaTitle": "Arcadia_(Sannazaro)",
+    "canonicalTitle": "Arcadia",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-arcadia",
+        "nodeTitle": "Arcadia"
+      }
+    ]
+  },
+  "Stanze_per_la_giostra": {
+    "wikidataId": null,
+    "wikipediaTitle": "Stanze_per_la_giostra",
+    "canonicalTitle": "Stanze per la giostra",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-stanze-giostra",
+        "nodeTitle": "Stanze per la giostra"
+      }
+    ]
+  },
+  "Essays_(Montaigne)": {
+    "wikidataId": "Q624852",
+    "wikipediaTitle": "Essays_(Montaigne)",
+    "canonicalTitle": "Essais",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-essais",
+        "nodeTitle": "Essais"
+      }
+    ]
+  },
+  "Discourse_on_Voluntary_Servitude": {
+    "wikidataId": "Q3030191",
+    "wikipediaTitle": "Discourse_on_Voluntary_Servitude",
+    "canonicalTitle": "Discours de la servitude volontaire",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-servitude-volontaire",
+        "nodeTitle": "Discours de la servitude volontaire"
+      }
+    ]
+  },
+  "Adagia": {
+    "wikidataId": "Q346677",
+    "wikipediaTitle": "Adagia",
+    "canonicalTitle": "Adagiorum chiliades (Adages)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-adages",
+        "nodeTitle": "Adagiorum chiliades (Adages)"
+      }
+    ]
+  },
+  "De_pictura": {
+    "wikidataId": "Q3020472",
+    "wikipediaTitle": "De_pictura",
+    "canonicalTitle": "De pictura",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-pictura",
+        "nodeTitle": "De pictura"
+      }
+    ]
+  },
+  "De_re_aedificatoria": {
+    "wikidataId": "Q1077624",
+    "wikipediaTitle": "De_re_aedificatoria",
+    "canonicalTitle": "De re aedificatoria",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-de-re-aedificatoria",
+        "nodeTitle": "De re aedificatoria"
+      }
+    ]
+  },
+  "I_Libri_della_Famiglia": {
+    "wikidataId": null,
+    "wikipediaTitle": "I_Libri_della_Famiglia",
+    "canonicalTitle": "Della famiglia",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-della-famiglia",
+        "nodeTitle": "Della famiglia"
+      }
+    ]
+  },
+  "Italia_Illustrata": {
+    "wikidataId": null,
+    "wikipediaTitle": "Italia_Illustrata",
+    "canonicalTitle": "Italia illustrata",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-italia-illustrata",
+        "nodeTitle": "Italia illustrata"
+      }
+    ]
+  },
+  "Commentaries_(Pius_II)": {
+    "wikidataId": null,
+    "wikipediaTitle": "Commentaries_(Pius_II)",
+    "canonicalTitle": "Commentarii",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "object-pius-commentarii",
+        "nodeTitle": "Commentarii"
+      }
+    ]
+  },
+  "Naples": {
+    "wikidataId": "Q2634",
+    "wikipediaTitle": "Naples",
+    "canonicalTitle": "Naples",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-naples",
+        "nodeTitle": "Naples"
+      }
+    ]
+  },
+  "Ferrara": {
+    "wikidataId": "Q13362",
+    "wikipediaTitle": "Ferrara",
+    "canonicalTitle": "Ferrara",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-ferrara",
+        "nodeTitle": "Ferrara"
+      }
+    ]
+  },
+  "Padua": {
+    "wikidataId": "Q617",
+    "wikipediaTitle": "Padua",
+    "canonicalTitle": "Padua",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-padua",
+        "nodeTitle": "Padua"
+      }
+    ]
+  },
+  "Mantua": {
+    "wikidataId": "Q6247",
+    "wikipediaTitle": "Mantua",
+    "canonicalTitle": "Mantua",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-mantua",
+        "nodeTitle": "Mantua"
+      }
+    ]
+  },
+  "Urbino": {
+    "wikidataId": "Q2759",
+    "wikipediaTitle": "Urbino",
+    "canonicalTitle": "Urbino",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-urbino",
+        "nodeTitle": "Urbino"
+      }
+    ]
+  },
+  "University_of_Florence": {
+    "wikidataId": "Q820887",
+    "wikipediaTitle": "University_of_Florence",
+    "canonicalTitle": "University of Florence (Studio Fiorentino)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-studio-fiorentino",
+        "nodeTitle": "University of Florence (Studio Fiorentino)"
+      }
+    ]
+  },
+  "University_of_Padua": {
+    "wikidataId": "Q193510",
+    "wikipediaTitle": "University_of_Padua",
+    "canonicalTitle": "University of Padua",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-padua",
+        "nodeTitle": "University of Padua"
+      }
+    ]
+  },
+  "University_of_Bologna": {
+    "wikidataId": "Q131262",
+    "wikipediaTitle": "University_of_Bologna",
+    "canonicalTitle": "University of Bologna",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-bologna",
+        "nodeTitle": "University of Bologna"
+      }
+    ]
+  },
+  "University_of_Alcalá": {
+    "wikidataId": "Q1243904",
+    "wikipediaTitle": "University_of_Alcalá",
+    "canonicalTitle": "University of Alcalá de Henares",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-alcala",
+        "nodeTitle": "University of Alcalá de Henares"
+      }
+    ]
+  },
+  "Heidelberg_University": {
+    "wikidataId": "Q151510",
+    "wikipediaTitle": "Heidelberg_University",
+    "canonicalTitle": "University of Heidelberg",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-heidelberg",
+        "nodeTitle": "University of Heidelberg"
+      }
+    ]
+  },
+  "University_of_Vienna": {
+    "wikidataId": "Q165980",
+    "wikipediaTitle": "University_of_Vienna",
+    "canonicalTitle": "University of Vienna",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-university-vienna",
+        "nodeTitle": "University of Vienna"
+      }
+    ]
+  },
+  "St_Paul%27s_School,_London": {
+    "wikidataId": null,
+    "wikipediaTitle": "St_Paul%27s_School,_London",
+    "canonicalTitle": "St. Paul's School (London)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-st-pauls-school",
+        "nodeTitle": "St. Paul's School (London)"
+      }
+    ]
+  },
+  "Aldine_Press": {
+    "wikidataId": "Q567488",
+    "wikipediaTitle": "Aldine_Press",
+    "canonicalTitle": "Aldine Press",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-aldine-press",
+        "nodeTitle": "Aldine Press"
+      },
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-aldine-press",
+        "nodeTitle": "Aldine Press"
+      }
+    ]
+  },
+  "Holy_See": {
+    "wikidataId": "Q159583",
+    "wikipediaTitle": "Holy_See",
+    "canonicalTitle": "Papal Court (Vatican)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-vatican",
+        "nodeTitle": "Papal Court (Vatican)"
+      }
+    ]
+  },
+  "Bruges": {
+    "wikidataId": "Q12994",
+    "wikipediaTitle": "Bruges",
+    "canonicalTitle": "Bruges",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-bruges",
+        "nodeTitle": "Bruges"
+      }
+    ]
+  },
+  "Rotterdam": {
+    "wikidataId": "Q34370",
+    "wikipediaTitle": "Rotterdam",
+    "canonicalTitle": "Rotterdam",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "location-rotterdam",
+        "nodeTitle": "Rotterdam"
+      }
+    ]
+  },
+  "Florentine_Academy": {
+    "wikidataId": null,
+    "wikipediaTitle": "Florentine_Academy",
+    "canonicalTitle": "Florentine Platonic Academy",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-platonic-academy",
+        "nodeTitle": "Florentine Platonic Academy"
+      }
+    ]
+  },
+  "Roman_Academy": {
+    "wikidataId": null,
+    "wikipediaTitle": "Roman_Academy",
+    "canonicalTitle": "Roman Academy (Accademia Romana)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-roman-academy",
+        "nodeTitle": "Roman Academy (Accademia Romana)"
+      }
+    ]
+  },
+  "Accademia_Pontaniana": {
+    "wikidataId": "Q143886",
+    "wikipediaTitle": "Accademia_Pontaniana",
+    "canonicalTitle": "Accademia Pontaniana",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-accademia-pontaniana",
+        "nodeTitle": "Accademia Pontaniana"
+      }
+    ]
+  },
+  "Civic_humanism": {
+    "wikidataId": "Q5128354",
+    "wikipediaTitle": "Civic_humanism",
+    "canonicalTitle": "Civic Humanism",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-civic-humanism",
+        "nodeTitle": "Civic Humanism"
+      }
+    ]
+  },
+  "Renaissance_Neoplatonism": {
+    "wikidataId": null,
+    "wikipediaTitle": "Renaissance_Neoplatonism",
+    "canonicalTitle": "Renaissance Neoplatonism",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-renaissance-neoplatonism",
+        "nodeTitle": "Renaissance Neoplatonism"
+      }
+    ]
+  },
+  "Renaissance_Aristotelianism": {
+    "wikidataId": null,
+    "wikipediaTitle": "Renaissance_Aristotelianism",
+    "canonicalTitle": "Humanist Aristotelianism",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-humanist-aristotelianism",
+        "nodeTitle": "Humanist Aristotelianism"
+      }
+    ]
+  },
+  "Christian_Kabbalah": {
+    "wikidataId": "Q1084061",
+    "wikipediaTitle": "Christian_Kabbalah",
+    "canonicalTitle": "Christian Kabbalah",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-christian-kabbalah",
+        "nodeTitle": "Christian Kabbalah"
+      }
+    ]
+  },
+  "Estienne_family": {
+    "wikidataId": null,
+    "wikipediaTitle": "Estienne_family",
+    "canonicalTitle": "Estienne Press",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-estienne-press",
+        "nodeTitle": "Estienne Press"
+      }
+    ]
+  },
+  "Medici": {
+    "wikidataId": null,
+    "wikipediaTitle": "Medici",
+    "canonicalTitle": "Medici Patronage Network",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-medici-patronage",
+        "nodeTitle": "Medici Patronage Network"
+      }
+    ]
+  },
+  "House_of_Este": {
+    "wikidataId": "Q677173",
+    "wikipediaTitle": "House_of_Este",
+    "canonicalTitle": "Este Patronage (Ferrara)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-este-patronage",
+        "nodeTitle": "Este Patronage (Ferrara)"
+      }
+    ]
+  },
+  "Kingdom_of_Naples": {
+    "wikidataId": "Q173065",
+    "wikipediaTitle": "Kingdom_of_Naples",
+    "canonicalTitle": "Aragonese Patronage (Naples)",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-aragonese-patronage",
+        "nodeTitle": "Aragonese Patronage (Naples)"
+      }
+    ]
+  },
+  "Devotio_Moderna": {
+    "wikidataId": "Q756170",
+    "wikipediaTitle": "Devotio_Moderna",
+    "canonicalTitle": "Devotio Moderna",
+    "appearances": [
+      {
+        "datasetId": "renaissance-humanism",
+        "datasetName": "Renaissance Humanism",
+        "nodeId": "entity-devotio-moderna",
+        "nodeTitle": "Devotio Moderna"
+      }
+    ]
+  },
+  "Jakob_Böhme": {
+    "wikidataId": "Q77017",
+    "wikipediaTitle": "Jakob_Böhme",
+    "canonicalTitle": "Jacob Boehme",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-jacob-boehme",
+        "nodeTitle": "Jacob Boehme"
+      }
+    ]
+  },
+  "Johann_Valentin_Andreae": {
+    "wikidataId": "Q60854",
+    "wikipediaTitle": "Johann_Valentin_Andreae",
+    "canonicalTitle": "Johann Valentin Andreae",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-jv-andreae",
+        "nodeTitle": "Johann Valentin Andreae"
+      }
+    ]
+  },
+  "Tobias_Hess": {
+    "wikidataId": "Q3530141",
+    "wikipediaTitle": "Tobias_Hess",
+    "canonicalTitle": "Tobias Hess",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-tobias-hess",
+        "nodeTitle": "Tobias Hess"
+      }
+    ]
+  },
+  "Christopher_Besoldus": {
+    "wikidataId": "Q99371",
+    "wikipediaTitle": "Christopher_Besoldus",
+    "canonicalTitle": "Christoph Besold",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-christoph-besold",
+        "nodeTitle": "Christoph Besold"
+      }
+    ]
+  },
+  "Johann_Arndt": {
+    "wikidataId": "Q61359",
+    "wikipediaTitle": "Johann_Arndt",
+    "canonicalTitle": "Johann Arndt",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-johann-arndt",
+        "nodeTitle": "Johann Arndt"
+      }
+    ]
+  },
+  "Michael_Maier": {
+    "wikidataId": "Q901303",
+    "wikipediaTitle": "Michael_Maier",
+    "canonicalTitle": "Michael Maier",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-michael-maier",
+        "nodeTitle": "Michael Maier"
+      }
+    ]
+  },
+  "Daniel_Mögling": {
+    "wikidataId": "Q55416434",
+    "wikipediaTitle": "Daniel_Mögling",
+    "canonicalTitle": "Daniel Mögling",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-daniel-mogling",
+        "nodeTitle": "Daniel Mögling"
+      }
+    ]
+  },
+  "Adam_Haslmayr": {
+    "wikidataId": "Q4679195",
+    "wikipediaTitle": "Adam_Haslmayr",
+    "canonicalTitle": "Adam Haslmayr",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-adam-haslmayr",
+        "nodeTitle": "Adam Haslmayr"
+      }
+    ]
+  },
+  "Valentin_Weigel": {
+    "wikidataId": "Q77397",
+    "wikipediaTitle": "Valentin_Weigel",
+    "canonicalTitle": "Valentin Weigel",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-valentin-weigel",
+        "nodeTitle": "Valentin Weigel"
+      }
+    ]
+  },
+  "Sebastian_Franck": {
+    "wikidataId": "Q63170",
+    "wikipediaTitle": "Sebastian_Franck",
+    "canonicalTitle": "Sebastian Franck",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-sebastian-franck",
+        "nodeTitle": "Sebastian Franck"
+      }
+    ]
+  },
+  "Caspar_Schwenckfeld": {
+    "wikidataId": "Q64137",
+    "wikipediaTitle": "Caspar_Schwenckfeld",
+    "canonicalTitle": "Caspar Schwenckfeld",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-caspar-schwenckfeld",
+        "nodeTitle": "Caspar Schwenckfeld"
+      }
+    ]
+  },
+  "Johann_Georg_Gichtel": {
+    "wikidataId": "Q75093",
+    "wikipediaTitle": "Johann_Georg_Gichtel",
+    "canonicalTitle": "Johann Georg Gichtel",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-jg-gichtel",
+        "nodeTitle": "Johann Georg Gichtel"
+      }
+    ]
+  },
+  "Adam_von_Bodenstein": {
+    "wikidataId": "Q91466",
+    "wikipediaTitle": "Adam_von_Bodenstein",
+    "canonicalTitle": "Adam von Bodenstein",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-adam-bodenstein",
+        "nodeTitle": "Adam von Bodenstein"
+      }
+    ]
+  },
+  "Heinrich_Khunrath": {
+    "wikidataId": "Q73366",
+    "wikipediaTitle": "Heinrich_Khunrath",
+    "canonicalTitle": "Heinrich Khunrath",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-heinrich-khunrath",
+        "nodeTitle": "Heinrich Khunrath"
+      }
+    ]
+  },
+  "Conrad_Khunrath": {
+    "wikidataId": "Q1126858",
+    "wikipediaTitle": "Conrad_Khunrath",
+    "canonicalTitle": "Conrad Khunrath",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-conrad-khunrath",
+        "nodeTitle": "Conrad Khunrath"
+      }
+    ]
+  },
+  "Oswald_Croll": {
+    "wikidataId": "Q899007",
+    "wikipediaTitle": "Oswald_Croll",
+    "canonicalTitle": "Oswald Croll",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-oswald-croll",
+        "nodeTitle": "Oswald Croll"
+      }
+    ]
+  },
+  "Andreas_Libavius": {
+    "wikidataId": "Q31161",
+    "wikipediaTitle": "Andreas_Libavius",
+    "canonicalTitle": "Andreas Libavius",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-andreas-libavius",
+        "nodeTitle": "Andreas Libavius"
+      }
+    ]
+  },
+  "Petrus_Severinus": {
+    "wikidataId": null,
+    "wikipediaTitle": "Petrus_Severinus",
+    "canonicalTitle": "Petrus Severinus",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-petrus-severinus",
+        "nodeTitle": "Petrus Severinus"
+      }
+    ]
+  },
+  "Daniel_Sennert": {
+    "wikidataId": "Q75164",
+    "wikipediaTitle": "Daniel_Sennert",
+    "canonicalTitle": "Daniel Sennert",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-daniel-sennert",
+        "nodeTitle": "Daniel Sennert"
+      }
+    ]
+  },
+  "Johannes_Hartmann_(chemist)": {
+    "wikidataId": null,
+    "wikipediaTitle": "Johannes_Hartmann_(chemist)",
+    "canonicalTitle": "Johannes Hartmann",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-johannes-hartmann",
+        "nodeTitle": "Johannes Hartmann"
+      }
+    ]
+  },
+  "Benedictus_Figulus": {
+    "wikidataId": "Q109400",
+    "wikipediaTitle": "Benedictus_Figulus",
+    "canonicalTitle": "Benedictus Figulus",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-benedictus-figulus",
+        "nodeTitle": "Benedictus Figulus"
+      }
+    ]
+  },
+  "Karl_Widemann": {
+    "wikidataId": "Q42378114",
+    "wikipediaTitle": "Karl_Widemann",
+    "canonicalTitle": "Karl Widemann",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-karl-widemann",
+        "nodeTitle": "Karl Widemann"
+      }
+    ]
+  },
+  "Raphael_Egli": {
+    "wikidataId": null,
+    "wikipediaTitle": "Raphael_Egli",
+    "canonicalTitle": "Raphael Eglin",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-raphael-eglin",
+        "nodeTitle": "Raphael Eglin"
+      }
+    ]
+  },
+  "Rudolf_II,_Holy_Roman_Emperor": {
+    "wikidataId": "Q150586",
+    "wikipediaTitle": "Rudolf_II,_Holy_Roman_Emperor",
+    "canonicalTitle": "Rudolf II",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-rudolf-ii",
+        "nodeTitle": "Rudolf II"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-rudolf-ii",
+        "nodeTitle": "Rudolf II"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-habsburg-court",
+        "nodeTitle": "Habsburg Court (Prague)"
+      }
+    ]
+  },
+  "John_Dee": {
+    "wikidataId": "Q201484",
+    "wikipediaTitle": "John_Dee",
+    "canonicalTitle": "John Dee",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-john-dee",
+        "nodeTitle": "John Dee"
+      }
+    ]
+  },
+  "Edward_Kelley": {
+    "wikidataId": "Q127080",
+    "wikipediaTitle": "Edward_Kelley",
+    "canonicalTitle": "Edward Kelley",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-edward-kelley",
+        "nodeTitle": "Edward Kelley"
+      }
+    ]
+  },
+  "Tycho_Brahe": {
+    "wikidataId": "Q36620",
+    "wikipediaTitle": "Tycho_Brahe",
+    "canonicalTitle": "Tycho Brahe",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-tycho-brahe",
+        "nodeTitle": "Tycho Brahe"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-tycho-brahe",
+        "nodeTitle": "Tycho Brahe"
+      }
+    ]
+  },
+  "Johannes_Kepler": {
+    "wikidataId": "Q8963",
+    "wikipediaTitle": "Johannes_Kepler",
+    "canonicalTitle": "Johannes Kepler",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-johannes-kepler",
+        "nodeTitle": "Johannes Kepler"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-johannes-kepler",
+        "nodeTitle": "Johannes Kepler"
+      }
+    ]
+  },
+  "Michael_Mästlin": {
+    "wikidataId": null,
+    "wikipediaTitle": "Michael_Mästlin",
+    "canonicalTitle": "Michael Mästlin",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-michael-mastlin",
+        "nodeTitle": "Michael Mästlin"
+      }
+    ]
+  },
+  "Vilém_of_Rosenberg": {
+    "wikidataId": null,
+    "wikipediaTitle": "Vilém_of_Rosenberg",
+    "canonicalTitle": "Vilém of Rožmberk",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-vilem-rozmberk",
+        "nodeTitle": "Vilém of Rožmberk"
+      }
+    ]
+  },
+  "Robert_Fludd": {
+    "wikidataId": "Q453697",
+    "wikipediaTitle": "Robert_Fludd",
+    "canonicalTitle": "Robert Fludd",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-robert-fludd",
+        "nodeTitle": "Robert Fludd"
+      }
+    ]
+  },
+  "Thomas_Vaughan_(philosopher)": {
+    "wikidataId": "Q3397209",
+    "wikipediaTitle": "Thomas_Vaughan_(philosopher)",
+    "canonicalTitle": "Thomas Vaughan",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-thomas-vaughan",
+        "nodeTitle": "Thomas Vaughan"
+      }
+    ]
+  },
+  "Elias_Ashmole": {
+    "wikidataId": "Q471406",
+    "wikipediaTitle": "Elias_Ashmole",
+    "canonicalTitle": "Elias Ashmole",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-elias-ashmole",
+        "nodeTitle": "Elias Ashmole"
+      },
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-elias-ashmole",
+        "nodeTitle": "Elias Ashmole"
+      }
+    ]
+  },
+  "William_Backhouse": {
+    "wikidataId": "Q8004902",
+    "wikipediaTitle": "William_Backhouse",
+    "canonicalTitle": "William Backhouse",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-william-backhouse",
+        "nodeTitle": "William Backhouse"
+      }
+    ]
+  },
+  "Francis_Bacon": {
+    "wikidataId": "Q37388",
+    "wikipediaTitle": "Francis_Bacon",
+    "canonicalTitle": "Francis Bacon",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-francis-bacon",
+        "nodeTitle": "Francis Bacon"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-francis-bacon",
+        "nodeTitle": "Francis Bacon"
+      }
+    ]
+  },
+  "Frederick_V_of_the_Palatinate": {
+    "wikidataId": "Q57195",
+    "wikipediaTitle": "Frederick_V_of_the_Palatinate",
+    "canonicalTitle": "Frederick V, Elector Palatine",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-frederick-v",
+        "nodeTitle": "Frederick V, Elector Palatine"
+      }
+    ]
+  },
+  "Elizabeth_Stuart,_Queen_of_Bohemia": {
+    "wikidataId": "Q158252",
+    "wikipediaTitle": "Elizabeth_Stuart,_Queen_of_Bohemia",
+    "canonicalTitle": "Elizabeth Stuart",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-elizabeth-stuart",
+        "nodeTitle": "Elizabeth Stuart"
+      }
+    ]
+  },
+  "Maurice,_Landgrave_of_Hesse-Kassel": {
+    "wikidataId": "Q551420",
+    "wikipediaTitle": "Maurice,_Landgrave_of_Hesse-Kassel",
+    "canonicalTitle": "Moritz of Hesse-Kassel",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-moritz-hesse-kassel",
+        "nodeTitle": "Moritz of Hesse-Kassel"
+      }
+    ]
+  },
+  "Salomon_de_Caus": {
+    "wikidataId": "Q385092",
+    "wikipediaTitle": "Salomon_de_Caus",
+    "canonicalTitle": "Salomon de Caus",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-salomon-de-caus",
+        "nodeTitle": "Salomon de Caus"
+      }
+    ]
+  },
+  "Fama_Fraternitatis": {
+    "wikidataId": "Q3643696",
+    "wikipediaTitle": "Fama_Fraternitatis",
+    "canonicalTitle": "Fama Fraternitatis",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-fama-fraternitatis",
+        "nodeTitle": "Fama Fraternitatis"
+      }
+    ]
+  },
+  "Confessio_Fraternitatis": {
+    "wikidataId": "Q3643674",
+    "wikipediaTitle": "Confessio_Fraternitatis",
+    "canonicalTitle": "Confessio Fraternitatis",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-confessio-fraternitatis",
+        "nodeTitle": "Confessio Fraternitatis"
+      }
+    ]
+  },
+  "Chymical_Wedding_of_Christian_Rosenkreutz": {
+    "wikidataId": "Q2456034",
+    "wikipediaTitle": "Chymical_Wedding_of_Christian_Rosenkreutz",
+    "canonicalTitle": "Chymical Wedding of Christian Rosenkreutz",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-chymical-wedding",
+        "nodeTitle": "Chymical Wedding of Christian Rosenkreutz"
+      }
+    ]
+  },
+  "Aurora_(Boehme)": {
+    "wikidataId": null,
+    "wikipediaTitle": "Aurora_(Boehme)",
+    "canonicalTitle": "Aurora",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-aurora",
+        "nodeTitle": "Aurora"
+      }
+    ]
+  },
+  "Mysterium_Magnum": {
+    "wikidataId": "Q6948791",
+    "wikipediaTitle": "Mysterium_Magnum",
+    "canonicalTitle": "Mysterium Magnum",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-mysterium-magnum",
+        "nodeTitle": "Mysterium Magnum"
+      }
+    ]
+  },
+  "True_Christianity_(book)": {
+    "wikidataId": null,
+    "wikipediaTitle": "True_Christianity_(book)",
+    "canonicalTitle": "True Christianity",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-true-christianity",
+        "nodeTitle": "True Christianity"
+      }
+    ]
+  },
+  "Amphitheatrum_Sapientiae_Aeternae": {
+    "wikidataId": null,
+    "wikipediaTitle": "Amphitheatrum_Sapientiae_Aeternae",
+    "canonicalTitle": "Amphitheatrum Sapientiae Aeternae",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-amphitheatrum",
+        "nodeTitle": "Amphitheatrum Sapientiae Aeternae"
+      }
+    ]
+  },
+  "Atalanta_Fugiens": {
+    "wikidataId": "Q3627850",
+    "wikipediaTitle": "Atalanta_Fugiens",
+    "canonicalTitle": "Atalanta Fugiens",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-atalanta-fugiens",
+        "nodeTitle": "Atalanta Fugiens"
+      }
+    ]
+  },
+  "Basilica_chymica": {
+    "wikidataId": null,
+    "wikipediaTitle": "Basilica_chymica",
+    "canonicalTitle": "Basilica Chymica",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-basilica-chymica",
+        "nodeTitle": "Basilica Chymica"
+      }
+    ]
+  },
+  "Utriusque_Cosmi": {
+    "wikidataId": null,
+    "wikipediaTitle": "Utriusque_Cosmi",
+    "canonicalTitle": "Utriusque Cosmi Historia",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-utriusque-cosmi",
+        "nodeTitle": "Utriusque Cosmi Historia"
+      }
+    ]
+  },
+  "Monas_Hieroglyphica": {
+    "wikidataId": "Q908061",
+    "wikipediaTitle": "Monas_Hieroglyphica",
+    "canonicalTitle": "Monas Hieroglyphica",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-monas-hieroglyphica",
+        "nodeTitle": "Monas Hieroglyphica"
+      }
+    ]
+  },
+  "Alchymia_(Libavius)": {
+    "wikidataId": null,
+    "wikipediaTitle": "Alchymia_(Libavius)",
+    "canonicalTitle": "Alchymia",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-alchymia",
+        "nodeTitle": "Alchymia"
+      }
+    ]
+  },
+  "Theatrum_Chemicum_Britannicum": {
+    "wikidataId": "Q4356652",
+    "wikipediaTitle": "Theatrum_Chemicum_Britannicum",
+    "canonicalTitle": "Theatrum Chemicum Britannicum",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-theatrum-chemicum-britannicum",
+        "nodeTitle": "Theatrum Chemicum Britannicum"
+      }
+    ]
+  },
+  "Christianopolis": {
+    "wikidataId": null,
+    "wikipediaTitle": "Christianopolis",
+    "canonicalTitle": "Christianopolis",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-christianopolis",
+        "nodeTitle": "Christianopolis"
+      }
+    ]
+  },
+  "Tübingen": {
+    "wikidataId": "Q3806",
+    "wikipediaTitle": "Tübingen",
+    "canonicalTitle": "Tübingen",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-tubingen",
+        "nodeTitle": "Tübingen"
+      }
+    ]
+  },
+  "Prague": {
+    "wikidataId": "Q1085",
+    "wikipediaTitle": "Prague",
+    "canonicalTitle": "Prague",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-prague",
+        "nodeTitle": "Prague"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "location-prague",
+        "nodeTitle": "Prague"
+      }
+    ]
+  },
+  "Heidelberg": {
+    "wikidataId": "Q2966",
+    "wikipediaTitle": "Heidelberg",
+    "canonicalTitle": "Heidelberg",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-heidelberg",
+        "nodeTitle": "Heidelberg"
+      }
+    ]
+  },
+  "Görlitz": {
+    "wikidataId": "Q4077",
+    "wikipediaTitle": "Görlitz",
+    "canonicalTitle": "Görlitz",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-gorlitz",
+        "nodeTitle": "Görlitz"
+      }
+    ]
+  },
+  "Kassel": {
+    "wikidataId": "Q2865",
+    "wikipediaTitle": "Kassel",
+    "canonicalTitle": "Kassel",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-kassel",
+        "nodeTitle": "Kassel"
+      }
+    ]
+  },
+  "The_Hague": {
+    "wikidataId": "Q36600",
+    "wikipediaTitle": "The_Hague",
+    "canonicalTitle": "The Hague",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-the-hague",
+        "nodeTitle": "The Hague"
+      }
+    ]
+  },
+  "Třeboň": {
+    "wikidataId": "Q773312",
+    "wikipediaTitle": "Třeboň",
+    "canonicalTitle": "Třeboň",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-trebon",
+        "nodeTitle": "Třeboň"
+      }
+    ]
+  },
+  "Heinrich_Petraeus": {
+    "wikidataId": "Q5700295",
+    "wikipediaTitle": "Heinrich_Petraeus",
+    "canonicalTitle": "Heinrich Petraeus",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-heinrich-petraeus",
+        "nodeTitle": "Heinrich Petraeus"
+      }
+    ]
+  },
+  "Rosicrucianism": {
+    "wikidataId": "Q194267",
+    "wikipediaTitle": "Rosicrucianism",
+    "canonicalTitle": "Rosicrucian Brotherhood",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-rosicrucian-brotherhood",
+        "nodeTitle": "Rosicrucian Brotherhood"
+      }
+    ]
+  },
+  "Christian_Rosenkreuz": {
+    "wikidataId": "Q841173",
+    "wikipediaTitle": "Christian_Rosenkreuz",
+    "canonicalTitle": "Christian Rosenkreutz",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-christian-rosenkreutz",
+        "nodeTitle": "Christian Rosenkreutz"
+      }
+    ]
+  },
+  "Paracelsianism": {
+    "wikidataId": "Q7133818",
+    "wikipediaTitle": "Paracelsianism",
+    "canonicalTitle": "Paracelsianism",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-paracelsianism",
+        "nodeTitle": "Paracelsianism"
+      }
+    ]
+  },
+  "Christian_theosophy": {
+    "wikidataId": "Q55635660",
+    "wikipediaTitle": "Christian_theosophy",
+    "canonicalTitle": "Christian Theosophy",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-christian-theosophy",
+        "nodeTitle": "Christian Theosophy"
+      }
+    ]
+  },
+  "Schwenkfelder_Church": {
+    "wikidataId": "Q672023",
+    "wikipediaTitle": "Schwenkfelder_Church",
+    "canonicalTitle": "Schwenckfelder Movement",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-schwenckfelder-movement",
+        "nodeTitle": "Schwenckfelder Movement"
+      }
+    ]
+  },
+  "Hermeticism": {
+    "wikidataId": "Q192933",
+    "wikipediaTitle": "Hermeticism",
+    "canonicalTitle": "Hermeticism (Early Modern)",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-hermeticism",
+        "nodeTitle": "Hermeticism (Early Modern)"
+      }
+    ]
+  },
+  "University_of_Tübingen": {
+    "wikidataId": "Q153978",
+    "wikipediaTitle": "University_of_Tübingen",
+    "canonicalTitle": "University of Tübingen",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-university-tubingen",
+        "nodeTitle": "University of Tübingen"
+      }
+    ]
+  },
+  "Johann_Theodor_de_Bry": {
+    "wikidataId": "Q1696381",
+    "wikipediaTitle": "Johann_Theodor_de_Bry",
+    "canonicalTitle": "Johann Theodor de Bry Publishing House",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-de-bry-publishing",
+        "nodeTitle": "Johann Theodor de Bry Publishing House"
+      }
+    ]
+  },
+  "Lucas_Jennis": {
+    "wikidataId": "Q1873081",
+    "wikipediaTitle": "Lucas_Jennis",
+    "canonicalTitle": "Lucas Jennis Publishing House",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-lucas-jennis",
+        "nodeTitle": "Lucas Jennis Publishing House"
+      }
+    ]
+  },
+  "Daniel_Cramer": {
+    "wikidataId": "Q95479",
+    "wikipediaTitle": "Daniel_Cramer",
+    "canonicalTitle": "Daniel Cramer",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-daniel-cramer",
+        "nodeTitle": "Daniel Cramer"
+      }
+    ]
+  },
+  "John_Amos_Comenius": {
+    "wikidataId": "Q12735",
+    "wikipediaTitle": "John_Amos_Comenius",
+    "canonicalTitle": "Jan Amos Comenius",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-jan-amos-comenius",
+        "nodeTitle": "Jan Amos Comenius"
+      }
+    ]
+  },
+  "Samuel_Hartlib": {
+    "wikidataId": "Q71033",
+    "wikipediaTitle": "Samuel_Hartlib",
+    "canonicalTitle": "Samuel Hartlib",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-samuel-hartlib",
+        "nodeTitle": "Samuel Hartlib"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-samuel-hartlib",
+        "nodeTitle": "Samuel Hartlib"
+      }
+    ]
+  },
+  "John_Dury": {
+    "wikidataId": "Q710665",
+    "wikipediaTitle": "John_Dury",
+    "canonicalTitle": "John Dury",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-john-dury",
+        "nodeTitle": "John Dury"
+      }
+    ]
+  },
+  "John_Heydon_(astrologer)": {
+    "wikidataId": "Q1700457",
+    "wikipediaTitle": "John_Heydon_(astrologer)",
+    "canonicalTitle": "John Heydon",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-john-heydon",
+        "nodeTitle": "John Heydon"
+      }
+    ]
+  },
+  "Thomas_Henshaw_(alchemist)": {
+    "wikidataId": "Q7790627",
+    "wikipediaTitle": "Thomas_Henshaw_(alchemist)",
+    "canonicalTitle": "Thomas Henshaw",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "person-thomas-henshaw",
+        "nodeTitle": "Thomas Henshaw"
+      }
+    ]
+  },
+  "Hartlib_Circle": {
+    "wikidataId": "Q604837",
+    "wikipediaTitle": "Hartlib_Circle",
+    "canonicalTitle": "Hartlib Circle",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "entity-hartlib-circle",
+        "nodeTitle": "Hartlib Circle"
+      },
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-hartlib-circle",
+        "nodeTitle": "Hartlib Circle"
+      }
+    ]
+  },
+  "Pansophism": {
+    "wikidataId": "Q771349",
+    "wikipediaTitle": "Pansophism",
+    "canonicalTitle": "Pansophiae Prodromus",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-pansophiae-prodromus",
+        "nodeTitle": "Pansophiae Prodromus"
+      }
+    ]
+  },
+  "Didactica_Magna": {
+    "wikidataId": null,
+    "wikipediaTitle": "Didactica_Magna",
+    "canonicalTitle": "Didactica Magna",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "object-didactica-magna",
+        "nodeTitle": "Didactica Magna"
+      }
+    ]
+  },
+  "Elbląg": {
+    "wikidataId": "Q104712",
+    "wikipediaTitle": "Elbląg",
+    "canonicalTitle": "Elbing",
+    "appearances": [
+      {
+        "datasetId": "rosicrucian-network",
+        "datasetName": "Rosicrucian-Paracelsian Network",
+        "nodeId": "loc-elbing",
+        "nodeTitle": "Elbing"
+      }
+    ]
+  },
+  "Nicolaus_Copernicus": {
+    "wikidataId": "Q619",
+    "wikipediaTitle": "Nicolaus_Copernicus",
+    "canonicalTitle": "Nicolaus Copernicus",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-nicolaus-copernicus",
+        "nodeTitle": "Nicolaus Copernicus"
+      }
+    ]
+  },
+  "Galileo_Galilei": {
+    "wikidataId": "Q307",
+    "wikipediaTitle": "Galileo_Galilei",
+    "canonicalTitle": "Galileo Galilei",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-galileo-galilei",
+        "nodeTitle": "Galileo Galilei"
+      }
+    ]
+  },
+  "Robert_Boyle": {
+    "wikidataId": "Q43393",
+    "wikipediaTitle": "Robert_Boyle",
+    "canonicalTitle": "Robert Boyle",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-robert-boyle",
+        "nodeTitle": "Robert Boyle"
+      }
+    ]
+  },
+  "Robert_Hooke": {
+    "wikidataId": "Q47081",
+    "wikipediaTitle": "Robert_Hooke",
+    "canonicalTitle": "Robert Hooke",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-robert-hooke",
+        "nodeTitle": "Robert Hooke"
+      }
+    ]
+  },
+  "Edmond_Halley": {
+    "wikidataId": "Q41790",
+    "wikipediaTitle": "Edmond_Halley",
+    "canonicalTitle": "Edmond Halley",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-edmond-halley",
+        "nodeTitle": "Edmond Halley"
+      }
+    ]
+  },
+  "Christiaan_Huygens": {
+    "wikidataId": "Q39599",
+    "wikipediaTitle": "Christiaan_Huygens",
+    "canonicalTitle": "Christiaan Huygens",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-christiaan-huygens",
+        "nodeTitle": "Christiaan Huygens"
+      }
+    ]
+  },
+  "John_Wilkins": {
+    "wikidataId": "Q557652",
+    "wikipediaTitle": "John_Wilkins",
+    "canonicalTitle": "John Wilkins",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-john-wilkins",
+        "nodeTitle": "John Wilkins"
+      }
+    ]
+  },
+  "Robert_Bellarmine": {
+    "wikidataId": "Q298908",
+    "wikipediaTitle": "Robert_Bellarmine",
+    "canonicalTitle": "Robert Bellarmine",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-robert-bellarmine",
+        "nodeTitle": "Robert Bellarmine"
+      }
+    ]
+  },
+  "Pope_Urban_VIII": {
+    "wikidataId": "Q134556",
+    "wikipediaTitle": "Pope_Urban_VIII",
+    "canonicalTitle": "Pope Urban VIII",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-urban-viii",
+        "nodeTitle": "Pope Urban VIII"
+      }
+    ]
+  },
+  "Maria_Cunitz": {
+    "wikidataId": "Q72429",
+    "wikipediaTitle": "Maria_Cunitz",
+    "canonicalTitle": "Maria Cunitz",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-maria-cunitz",
+        "nodeTitle": "Maria Cunitz"
+      }
+    ]
+  },
+  "Margaret_Cavendish,_Duchess_of_Newcastle-upon-Tyne": {
+    "wikidataId": "Q234858",
+    "wikipediaTitle": "Margaret_Cavendish,_Duchess_of_Newcastle-upon-Tyne",
+    "canonicalTitle": "Margaret Cavendish",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-margaret-cavendish",
+        "nodeTitle": "Margaret Cavendish"
+      }
+    ]
+  },
+  "De_revolutionibus_orbium_coelestium": {
+    "wikidataId": "Q211423",
+    "wikipediaTitle": "De_revolutionibus_orbium_coelestium",
+    "canonicalTitle": "De revolutionibus orbium coelestium",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-de-revolutionibus",
+        "nodeTitle": "De revolutionibus orbium coelestium"
+      }
+    ]
+  },
+  "Astronomia_nova": {
+    "wikidataId": "Q720120",
+    "wikipediaTitle": "Astronomia_nova",
+    "canonicalTitle": "Astronomia nova",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-astronomia-nova",
+        "nodeTitle": "Astronomia nova"
+      }
+    ]
+  },
+  "Sidereus_Nuncius": {
+    "wikidataId": "Q652054",
+    "wikipediaTitle": "Sidereus_Nuncius",
+    "canonicalTitle": "Sidereus Nuncius",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-sidereus-nuncius",
+        "nodeTitle": "Sidereus Nuncius"
+      }
+    ]
+  },
+  "Dialogue_Concerning_the_Two_Chief_World_Systems": {
+    "wikidataId": "Q1017439",
+    "wikipediaTitle": "Dialogue_Concerning_the_Two_Chief_World_Systems",
+    "canonicalTitle": "Dialogue Concerning the Two Chief World Systems",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-dialogo",
+        "nodeTitle": "Dialogue Concerning the Two Chief World Systems"
+      }
+    ]
+  },
+  "Novum_Organum": {
+    "wikidataId": "Q2657053",
+    "wikipediaTitle": "Novum_Organum",
+    "canonicalTitle": "Novum Organum",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-novum-organum",
+        "nodeTitle": "Novum Organum"
+      }
+    ]
+  },
+  "The_Sceptical_Chymist": {
+    "wikidataId": "Q2063476",
+    "wikipediaTitle": "The_Sceptical_Chymist",
+    "canonicalTitle": "The Sceptical Chymist",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-sceptical-chymist",
+        "nodeTitle": "The Sceptical Chymist"
+      }
+    ]
+  },
+  "Philosophical_Transactions_of_the_Royal_Society": {
+    "wikidataId": "Q2306608",
+    "wikipediaTitle": "Philosophical_Transactions_of_the_Royal_Society",
+    "canonicalTitle": "Philosophical Transactions of the Royal Society",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-philosophical-transactions",
+        "nodeTitle": "Philosophical Transactions of the Royal Society"
+      }
+    ]
+  },
+  "Urania_propitia": {
+    "wikidataId": "Q7899795",
+    "wikipediaTitle": "Urania_propitia",
+    "canonicalTitle": "Urania Propitia",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "object-urania-propitia",
+        "nodeTitle": "Urania Propitia"
+      }
+    ]
+  },
+  "Roman_Inquisition": {
+    "wikidataId": "Q1046250",
+    "wikipediaTitle": "Roman_Inquisition",
+    "canonicalTitle": "Roman Inquisition",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-roman-inquisition",
+        "nodeTitle": "Roman Inquisition"
+      }
+    ]
+  },
+  "House_of_Medici": {
+    "wikidataId": "Q37317",
+    "wikipediaTitle": "House_of_Medici",
+    "canonicalTitle": "Medici Court",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "entity-medici-court",
+        "nodeTitle": "Medici Court"
+      }
+    ]
+  },
+  "René_Descartes": {
+    "wikidataId": "Q9191",
+    "wikipediaTitle": "René_Descartes",
+    "canonicalTitle": "René Descartes",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-rene-descartes",
+        "nodeTitle": "René Descartes"
+      }
+    ]
+  },
+  "Marin_Mersenne": {
+    "wikidataId": "Q101072",
+    "wikipediaTitle": "Marin_Mersenne",
+    "canonicalTitle": "Marin Mersenne",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-marin-mersenne",
+        "nodeTitle": "Marin Mersenne"
+      }
+    ]
+  },
+  "Christopher_Wren": {
+    "wikidataId": "Q41279",
+    "wikipediaTitle": "Christopher_Wren",
+    "canonicalTitle": "Christopher Wren",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-christopher-wren",
+        "nodeTitle": "Christopher Wren"
+      }
+    ]
+  },
+  "Henry_Oldenburg": {
+    "wikidataId": "Q60017",
+    "wikipediaTitle": "Henry_Oldenburg",
+    "canonicalTitle": "Henry Oldenburg",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-henry-oldenburg",
+        "nodeTitle": "Henry Oldenburg"
+      }
+    ]
+  },
+  "Evangelista_Torricelli": {
+    "wikidataId": "Q47159",
+    "wikipediaTitle": "Evangelista_Torricelli",
+    "canonicalTitle": "Evangelista Torricelli",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-evangelista-torricelli",
+        "nodeTitle": "Evangelista Torricelli"
+      }
+    ]
+  },
+  "Blaise_Pascal": {
+    "wikidataId": "Q1290",
+    "wikipediaTitle": "Blaise_Pascal",
+    "canonicalTitle": "Blaise Pascal",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-blaise-pascal",
+        "nodeTitle": "Blaise Pascal"
+      }
+    ]
+  },
+  "Otto_von_Guericke": {
+    "wikidataId": "Q60025",
+    "wikipediaTitle": "Otto_von_Guericke",
+    "canonicalTitle": "Otto von Guericke",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-otto-von-guericke",
+        "nodeTitle": "Otto von Guericke"
+      }
+    ]
+  },
+  "William_Gilbert_(physician)": {
+    "wikidataId": "Q192330",
+    "wikipediaTitle": "William_Gilbert_(physician)",
+    "canonicalTitle": "William Gilbert",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-william-gilbert",
+        "nodeTitle": "William Gilbert"
+      }
+    ]
+  },
+  "Andreas_Vesalius": {
+    "wikidataId": "Q142862",
+    "wikipediaTitle": "Andreas_Vesalius",
+    "canonicalTitle": "Andreas Vesalius",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-andreas-vesalius",
+        "nodeTitle": "Andreas Vesalius"
+      }
+    ]
+  },
+  "Giovanni_Alfonso_Borelli": {
+    "wikidataId": "Q328441",
+    "wikipediaTitle": "Giovanni_Alfonso_Borelli",
+    "canonicalTitle": "Giovanni Alfonso Borelli",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-giovanni-borelli",
+        "nodeTitle": "Giovanni Alfonso Borelli"
+      }
+    ]
+  },
+  "Ole_Rømer": {
+    "wikidataId": "Q83371",
+    "wikipediaTitle": "Ole_Rømer",
+    "canonicalTitle": "Ole Rømer",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-ole-romer",
+        "nodeTitle": "Ole Rømer"
+      }
+    ]
+  },
+  "Marcello_Malpighi": {
+    "wikidataId": "Q185092",
+    "wikipediaTitle": "Marcello_Malpighi",
+    "canonicalTitle": "Marcello Malpighi",
+    "appearances": [
+      {
+        "datasetId": "scientific-revolution",
+        "datasetName": "Scientific Revolution",
+        "nodeId": "person-marcello-malpighi",
+        "nodeTitle": "Marcello Malpighi"
+      }
+    ]
+  },
+  "Robert_Moray": {
+    "wikidataId": "Q719623",
+    "wikipediaTitle": "Robert_Moray",
+    "canonicalTitle": "Sir Robert Moray",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-robert-moray",
+        "nodeTitle": "Sir Robert Moray"
+      }
+    ]
+  },
+  "Warrington": {
+    "wikidataId": "Q215733",
+    "wikipediaTitle": "Warrington",
+    "canonicalTitle": "Warrington",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "loc-warrington",
+        "nodeTitle": "Warrington"
+      }
+    ]
+  },
+  "Newcastle_upon_Tyne": {
+    "wikidataId": "Q1425428",
+    "wikipediaTitle": "Newcastle_upon_Tyne",
+    "canonicalTitle": "Newcastle upon Tyne",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "loc-newcastle-upon-tyne",
+        "nodeTitle": "Newcastle upon Tyne"
+      }
+    ]
+  },
+  "Premier_Grand_Lodge_of_England": {
+    "wikipediaTitle": "Premier_Grand_Lodge_of_England",
+    "canonicalTitle": "Premier Grand Lodge of England",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "entity-premier-grand-lodge-england",
+        "nodeTitle": "Premier Grand Lodge of England"
+      }
+    ]
+  },
+  "Lodge_of_Edinburgh_(Mary's_Chapel)_No._1": {
+    "wikipediaTitle": "Lodge_of_Edinburgh_(Mary's_Chapel)_No._1",
+    "canonicalTitle": "Lodge of Edinburgh (Mary's Chapel) No. 1",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "entity-lodge-edinburgh",
+        "nodeTitle": "Lodge of Edinburgh (Mary's Chapel) No. 1"
+      }
+    ]
+  },
+  "Anthony_Sayer": {
+    "wikidataId": "Q3618535",
+    "wikipediaTitle": "Anthony_Sayer",
+    "canonicalTitle": "Anthony Sayer",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-anthony-sayer",
+        "nodeTitle": "Anthony Sayer"
+      }
+    ]
+  },
+  "George_Payne_(Freemason)": {
+    "wikidataId": "Q1508044",
+    "wikipediaTitle": "George_Payne_(Freemason)",
+    "canonicalTitle": "George Payne",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-george-payne",
+        "nodeTitle": "George Payne"
+      }
+    ]
+  },
+  "John_Theophilus_Desaguliers": {
+    "wikidataId": "Q658008",
+    "wikipediaTitle": "John_Theophilus_Desaguliers",
+    "canonicalTitle": "John Theophilus Desaguliers",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-john-desaguliers",
+        "nodeTitle": "John Theophilus Desaguliers"
+      }
+    ]
+  },
+  "James_Anderson_(Freemason)": {
+    "wikidataId": "Q3160845",
+    "wikipediaTitle": "James_Anderson_(Freemason)",
+    "canonicalTitle": "Rev. James Anderson",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-james-anderson",
+        "nodeTitle": "Rev. James Anderson"
+      }
+    ]
+  },
+  "John_Montagu,_2nd_Duke_of_Montagu": {
+    "wikidataId": "Q3062451",
+    "wikipediaTitle": "John_Montagu,_2nd_Duke_of_Montagu",
+    "canonicalTitle": "John Montagu, 2nd Duke of Montagu",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-john-montagu",
+        "nodeTitle": "John Montagu, 2nd Duke of Montagu"
+      }
+    ]
+  },
+  "John_Pine": {
+    "wikidataId": "Q6252938",
+    "wikipediaTitle": "John_Pine",
+    "canonicalTitle": "John Pine",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-john-pine",
+        "nodeTitle": "John Pine"
+      }
+    ]
+  },
+  "William_Stukeley": {
+    "wikidataId": "Q1381018",
+    "wikipediaTitle": "William_Stukeley",
+    "canonicalTitle": "William Stukeley",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-william-stukeley",
+        "nodeTitle": "William Stukeley"
+      }
+    ]
+  },
+  "Philip_Wharton,_1st_Duke_of_Wharton": {
+    "wikidataId": "Q333527",
+    "wikipediaTitle": "Philip_Wharton,_1st_Duke_of_Wharton",
+    "canonicalTitle": "Philip Wharton, 1st Duke of Wharton",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "person-philip-wharton",
+        "nodeTitle": "Philip Wharton, 1st Duke of Wharton"
+      }
+    ]
+  },
+  "Society_of_Antiquaries_of_London": {
+    "wikidataId": "Q653553",
+    "wikipediaTitle": "Society_of_Antiquaries_of_London",
+    "canonicalTitle": "Society of Antiquaries of London",
+    "appearances": [
+      {
+        "datasetId": "speculative-freemasonry",
+        "datasetName": "Origins of Speculative Freemasonry",
+        "nodeId": "entity-society-antiquaries",
+        "nodeTitle": "Society of Antiquaries of London"
+      }
+    ]
+  },
+  "Adolphe_Quetelet": {
+    "wikidataId": "Q76584",
+    "wikipediaTitle": "Adolphe_Quetelet",
+    "canonicalTitle": "Adolphe Quetelet",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-adolphe-quetelet",
+        "nodeTitle": "Adolphe Quetelet"
+      }
+    ]
+  },
+  "Ronald_Fisher": {
+    "wikidataId": "Q216723",
+    "wikipediaTitle": "Ronald_Fisher",
+    "canonicalTitle": "Ronald A. Fisher",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-ronald-fisher",
+        "nodeTitle": "Ronald A. Fisher"
+      }
+    ]
+  },
+  "Carl_Friedrich_Gauss": {
+    "wikidataId": "Q6722",
+    "wikipediaTitle": "Carl_Friedrich_Gauss",
+    "canonicalTitle": "Carl Friedrich Gauss",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-carl-friedrich-gauss",
+        "nodeTitle": "Carl Friedrich Gauss"
+      }
+    ]
+  },
+  "Siméon_Denis_Poisson": {
+    "wikidataId": "Q49767",
+    "wikipediaTitle": "Siméon_Denis_Poisson",
+    "canonicalTitle": "Siméon Denis Poisson",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-simeon-denis-poisson",
+        "nodeTitle": "Siméon Denis Poisson"
+      }
+    ]
+  },
+  "Thomas_Bayes": {
+    "wikidataId": "Q318630",
+    "wikipediaTitle": "Thomas_Bayes",
+    "canonicalTitle": "Thomas Bayes",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-thomas-bayes",
+        "nodeTitle": "Thomas Bayes"
+      }
+    ]
+  },
+  "Abraham_de_Moivre": {
+    "wikidataId": "Q310551",
+    "wikipediaTitle": "Abraham_de_Moivre",
+    "canonicalTitle": "Abraham de Moivre",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-abraham-de-moivre",
+        "nodeTitle": "Abraham de Moivre"
+      }
+    ]
+  },
+  "Francis_Galton": {
+    "wikidataId": "Q131566",
+    "wikipediaTitle": "Francis_Galton",
+    "canonicalTitle": "Francis Galton",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-francis-galton",
+        "nodeTitle": "Francis Galton"
+      }
+    ]
+  },
+  "Karl_Pearson": {
+    "wikidataId": "Q180850",
+    "wikipediaTitle": "Karl_Pearson",
+    "canonicalTitle": "Karl Pearson",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-karl-pearson",
+        "nodeTitle": "Karl Pearson"
+      }
+    ]
+  },
+  "Florence_Nightingale": {
+    "wikidataId": "Q38348",
+    "wikipediaTitle": "Florence_Nightingale",
+    "canonicalTitle": "Florence Nightingale",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-florence-nightingale",
+        "nodeTitle": "Florence Nightingale"
+      }
+    ]
+  },
+  "Jerzy_Neyman": {
+    "wikidataId": "Q440568",
+    "wikipediaTitle": "Jerzy_Neyman",
+    "canonicalTitle": "Jerzy Neyman",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-jerzy-neyman",
+        "nodeTitle": "Jerzy Neyman"
+      }
+    ]
+  },
+  "Egon_Pearson": {
+    "wikidataId": "Q1302219",
+    "wikipediaTitle": "Egon_Pearson",
+    "canonicalTitle": "Egon Pearson",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-egon-pearson",
+        "nodeTitle": "Egon Pearson"
+      }
+    ]
+  },
+  "Adrien-Marie_Legendre": {
+    "wikidataId": "Q191799",
+    "wikipediaTitle": "Adrien-Marie_Legendre",
+    "canonicalTitle": "Adrien-Marie Legendre",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-adrien-marie-legendre",
+        "nodeTitle": "Adrien-Marie Legendre"
+      }
+    ]
+  },
+  "Jacob_Bernoulli": {
+    "wikidataId": "Q122420",
+    "wikipediaTitle": "Jacob_Bernoulli",
+    "canonicalTitle": "Jacob Bernoulli",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-jacob-bernoulli",
+        "nodeTitle": "Jacob Bernoulli"
+      }
+    ]
+  },
+  "William_Sealy_Gosset": {
+    "wikidataId": "Q317584",
+    "wikipediaTitle": "William_Sealy_Gosset",
+    "canonicalTitle": "William Sealy Gosset",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-william-sealy-gosset",
+        "nodeTitle": "William Sealy Gosset"
+      }
+    ]
+  },
+  "André-Michel_Guerry": {
+    "wikidataId": "Q2847710",
+    "wikipediaTitle": "André-Michel_Guerry",
+    "canonicalTitle": "André-Michel Guerry",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-andre-michel-guerry",
+        "nodeTitle": "André-Michel Guerry"
+      }
+    ]
+  },
+  "William_Farr": {
+    "wikidataId": "Q317584",
+    "wikipediaTitle": "William_Farr",
+    "canonicalTitle": "William Farr",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-william-farr",
+        "nodeTitle": "William Farr"
+      }
+    ]
+  },
+  "Charles_Darwin": {
+    "wikidataId": "Q1035",
+    "wikipediaTitle": "Charles_Darwin",
+    "canonicalTitle": "Charles Darwin",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-charles-darwin",
+        "nodeTitle": "Charles Darwin"
+      }
+    ]
+  },
+  "Andrey_Markov": {
+    "wikidataId": "Q140282",
+    "wikipediaTitle": "Andrey_Markov",
+    "canonicalTitle": "Andrey Markov",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-andrey-markov",
+        "nodeTitle": "Andrey Markov"
+      }
+    ]
+  },
+  "Émile_Durkheim": {
+    "wikidataId": "Q44279",
+    "wikipediaTitle": "Émile_Durkheim",
+    "canonicalTitle": "Émile Durkheim",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-emile-durkheim",
+        "nodeTitle": "Émile Durkheim"
+      }
+    ]
+  },
+  "Théorie_analytique_des_probabilités": {
+    "wikidataId": "Q3527157",
+    "wikipediaTitle": "Théorie_analytique_des_probabilités",
+    "canonicalTitle": "Théorie analytique des probabilités",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-theorie-analytique-des-probabilites",
+        "nodeTitle": "Théorie analytique des probabilités"
+      }
+    ]
+  },
+  "A_Philosophical_Essay_on_Probabilities": {
+    "wikidataId": "Q19169639",
+    "wikipediaTitle": "A_Philosophical_Essay_on_Probabilities",
+    "canonicalTitle": "Essai philosophique sur les probabilités",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-essai-philosophique-sur-les-probabilites",
+        "nodeTitle": "Essai philosophique sur les probabilités"
+      }
+    ]
+  },
+  "A_Treatise_on_Man_and_the_Development_of_His_Faculties": {
+    "wikidataId": null,
+    "wikipediaTitle": "A_Treatise_on_Man_and_the_Development_of_His_Faculties",
+    "canonicalTitle": "Sur l'homme et le développement de ses facultés",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-sur-l-homme",
+        "nodeTitle": "Sur l'homme et le développement de ses facultés"
+      }
+    ]
+  },
+  "Statistical_Methods_for_Research_Workers": {
+    "wikidataId": "Q25927621",
+    "wikipediaTitle": "Statistical_Methods_for_Research_Workers",
+    "canonicalTitle": "Statistical Methods for Research Workers",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-statistical-methods-for-research-workers",
+        "nodeTitle": "Statistical Methods for Research Workers"
+      }
+    ]
+  },
+  "The_Design_of_Experiments": {
+    "wikidataId": "Q7726887",
+    "wikipediaTitle": "The_Design_of_Experiments",
+    "canonicalTitle": "The Design of Experiments",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-design-of-experiments",
+        "nodeTitle": "The Design of Experiments"
+      }
+    ]
+  },
+  "An_Essay_towards_solving_a_Problem_in_the_Doctrine_of_Chances": {
+    "wikidataId": "Q4749933",
+    "wikipediaTitle": "An_Essay_towards_solving_a_Problem_in_the_Doctrine_of_Chances",
+    "canonicalTitle": "An Essay towards solving a Problem in the Doctrine of Chances",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-essay-towards-solving-a-problem",
+        "nodeTitle": "An Essay towards solving a Problem in the Doctrine of Chances"
+      }
+    ]
+  },
+  "Ars_Conjectandi": {
+    "wikidataId": "Q623586",
+    "wikipediaTitle": "Ars_Conjectandi",
+    "canonicalTitle": "Ars Conjectandi",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-ars-conjectandi",
+        "nodeTitle": "Ars Conjectandi"
+      }
+    ]
+  },
+  "The_Doctrine_of_Chances": {
+    "wikidataId": "Q1757843",
+    "wikipediaTitle": "The_Doctrine_of_Chances",
+    "canonicalTitle": "The Doctrine of Chances",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-doctrine-of-chances",
+        "nodeTitle": "The Doctrine of Chances"
+      }
+    ]
+  },
+  "Hereditary_Genius": {
+    "wikidataId": "Q5734888",
+    "wikipediaTitle": "Hereditary_Genius",
+    "canonicalTitle": "Hereditary Genius",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-hereditary-genius",
+        "nodeTitle": "Hereditary Genius"
+      }
+    ]
+  },
+  "Natural_Inheritance": {
+    "wikidataId": "Q51508521",
+    "wikipediaTitle": "Natural_Inheritance",
+    "canonicalTitle": "Natural Inheritance",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-natural-inheritance",
+        "nodeTitle": "Natural Inheritance"
+      }
+    ]
+  },
+  "The_Grammar_of_Science": {
+    "wikidataId": "Q7734628",
+    "wikipediaTitle": "The_Grammar_of_Science",
+    "canonicalTitle": "The Grammar of Science",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-grammar-of-science",
+        "nodeTitle": "The Grammar of Science"
+      }
+    ]
+  },
+  "Suicide_(Durkheim_book)": {
+    "wikidataId": "Q2088170",
+    "wikipediaTitle": "Suicide_(Durkheim_book)",
+    "canonicalTitle": "Le Suicide",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-le-suicide",
+        "nodeTitle": "Le Suicide"
+      }
+    ]
+  },
+  "École_Polytechnique": {
+    "wikidataId": "Q273626",
+    "wikipediaTitle": "École_Polytechnique",
+    "canonicalTitle": "École Polytechnique",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "location-ecole-polytechnique",
+        "nodeTitle": "École Polytechnique"
+      }
+    ]
+  },
+  "University_College_London": {
+    "wikidataId": "Q193196",
+    "wikipediaTitle": "University_College_London",
+    "canonicalTitle": "University College London",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "location-university-college-london",
+        "nodeTitle": "University College London"
+      }
+    ]
+  },
+  "Rothamsted_Research": {
+    "wikidataId": "Q2157227",
+    "wikipediaTitle": "Rothamsted_Research",
+    "canonicalTitle": "Rothamsted Experimental Station",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "location-rothamsted-experimental-station",
+        "nodeTitle": "Rothamsted Experimental Station"
+      }
+    ]
+  },
+  "Biometrika": {
+    "wikidataId": "Q673175",
+    "wikipediaTitle": "Biometrika",
+    "canonicalTitle": "Biometrika",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "entity-biometrika",
+        "nodeTitle": "Biometrika"
+      }
+    ]
+  },
+  "Royal_Statistical_Society": {
+    "wikidataId": "Q1423882",
+    "wikipediaTitle": "Royal_Statistical_Society",
+    "canonicalTitle": "Royal Statistical Society",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "entity-royal-statistical-society",
+        "nodeTitle": "Royal Statistical Society"
+      }
+    ]
+  },
+  "Eugenics_Society": {
+    "wikidataId": "Q5407573",
+    "wikipediaTitle": "Eugenics_Society",
+    "canonicalTitle": "Eugenics Education Society",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "entity-eugenics-education-society",
+        "nodeTitle": "Eugenics Education Society"
+      }
+    ]
+  },
+  "Johann_Heinrich_Lambert": {
+    "wikidataId": "Q76610",
+    "wikipediaTitle": "Johann_Heinrich_Lambert",
+    "canonicalTitle": "Johann Heinrich Lambert",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-johann-heinrich-lambert",
+        "nodeTitle": "Johann Heinrich Lambert"
+      }
+    ]
+  },
+  "Friedrich_Bessel": {
+    "wikidataId": "Q78247",
+    "wikipediaTitle": "Friedrich_Bessel",
+    "canonicalTitle": "Friedrich Wilhelm Bessel",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-friedrich-bessel",
+        "nodeTitle": "Friedrich Wilhelm Bessel"
+      }
+    ]
+  },
+  "Johann_Franz_Encke": {
+    "wikidataId": "Q57330",
+    "wikipediaTitle": "Johann_Franz_Encke",
+    "canonicalTitle": "Johann Franz Encke",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-johann-franz-encke",
+        "nodeTitle": "Johann Franz Encke"
+      }
+    ]
+  },
+  "Tobias_Mayer": {
+    "wikidataId": "Q61071",
+    "wikipediaTitle": "Tobias_Mayer",
+    "canonicalTitle": "Tobias Mayer",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-tobias-mayer",
+        "nodeTitle": "Tobias Mayer"
+      }
+    ]
+  },
+  "Theoria_motus_corporum_coelestium_in_sectionibus_conicis_solem_ambientium": {
+    "wikidataId": "Q15989807",
+    "wikipediaTitle": "Theoria_motus_corporum_coelestium_in_sectionibus_conicis_solem_ambientium",
+    "canonicalTitle": "Theoria motus corporum coelestium",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "object-theoria-motus",
+        "nodeTitle": "Theoria motus corporum coelestium"
+      }
+    ]
+  },
+  "Göttingen_Observatory": {
+    "wikidataId": "Q896313",
+    "wikipediaTitle": "Göttingen_Observatory",
+    "canonicalTitle": "Göttingen Observatory",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "location-gottingen-observatory",
+        "nodeTitle": "Göttingen Observatory"
+      }
+    ]
+  },
+  "Königsberg_Observatory": {
+    "wikidataId": "Q1796310",
+    "wikipediaTitle": "Königsberg_Observatory",
+    "canonicalTitle": "Königsberg Observatory",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "location-konigsberg-observatory",
+        "nodeTitle": "Königsberg Observatory"
+      }
+    ]
+  },
+  "Pafnuty_Chebyshev": {
+    "wikidataId": "Q206012",
+    "wikipediaTitle": "Pafnuty_Chebyshev",
+    "canonicalTitle": "Pafnuty Chebyshev",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-pafnuty-chebyshev",
+        "nodeTitle": "Pafnuty Chebyshev"
+      }
+    ]
+  },
+  "W._F._R._Weldon": {
+    "wikidataId": "Q1573240",
+    "wikipediaTitle": "W._F._R._Weldon",
+    "canonicalTitle": "W.F.R. Weldon",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-walter-frank-raphael-weldon",
+        "nodeTitle": "W.F.R. Weldon"
+      }
+    ]
+  },
+  "Udny_Yule": {
+    "wikidataId": "Q991476",
+    "wikipediaTitle": "Udny_Yule",
+    "canonicalTitle": "George Udny Yule",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-george-udny-yule",
+        "nodeTitle": "George Udny Yule"
+      }
+    ]
+  },
+  "Francis_Ysidro_Edgeworth": {
+    "wikidataId": "Q355607",
+    "wikipediaTitle": "Francis_Ysidro_Edgeworth",
+    "canonicalTitle": "Francis Ysidro Edgeworth",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-francis-ysidro-edgeworth",
+        "nodeTitle": "Francis Ysidro Edgeworth"
+      }
+    ]
+  },
+  "Wilhelm_Lexis": {
+    "wikidataId": "Q64383",
+    "wikipediaTitle": "Wilhelm_Lexis",
+    "canonicalTitle": "Wilhelm Lexis",
+    "appearances": [
+      {
+        "datasetId": "statistics-social-physics",
+        "datasetName": "Measurement, Statistics & the Calculus of Society",
+        "nodeId": "person-wilhelm-lexis",
+        "nodeTitle": "Wilhelm Lexis"
+      }
+    ]
+  }
+}

--- a/public/cross-scene-index/manifest.json
+++ b/public/cross-scene-index/manifest.json
@@ -1,0 +1,66 @@
+{
+  "generatedAt": "2026-01-30T13:24:55.867Z",
+  "datasetCount": 12,
+  "datasets": [
+    {
+      "id": "ai-llm-research",
+      "name": "AI & LLM Research Network"
+    },
+    {
+      "id": "ambient-music",
+      "name": "Ambient Music Network"
+    },
+    {
+      "id": "christian-kabbalah",
+      "name": "Christian Kabbalist Network"
+    },
+    {
+      "id": "cybernetics-information-theory",
+      "name": "Cybernetics & Information Theory"
+    },
+    {
+      "id": "enlightenment",
+      "name": "Enlightenment Intellectual Network"
+    },
+    {
+      "id": "florentine-academy",
+      "name": "Florentine Academy"
+    },
+    {
+      "id": "protestant-reformation",
+      "name": "Protestant Reformation Network"
+    },
+    {
+      "id": "renaissance-humanism",
+      "name": "Renaissance Humanism"
+    },
+    {
+      "id": "rosicrucian-network",
+      "name": "Rosicrucian-Paracelsian Network"
+    },
+    {
+      "id": "scientific-revolution",
+      "name": "Scientific Revolution"
+    },
+    {
+      "id": "speculative-freemasonry",
+      "name": "Origins of Speculative Freemasonry"
+    },
+    {
+      "id": "statistics-social-physics",
+      "name": "Measurement, Statistics & the Calculus of Society"
+    }
+  ],
+  "indexes": {
+    "wikidata": {
+      "totalEntities": 1088,
+      "shardCount": 167
+    },
+    "wikipedia": {
+      "totalEntities": 1200
+    },
+    "nodeid": {
+      "totalEntities": 1434
+    }
+  }
+}

--- a/scripts/build-cross-scene-index/index.ts
+++ b/scripts/build-cross-scene-index/index.ts
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+/**
+ * Cross-Scene Index Builder
+ *
+ * Scans all datasets in public/datasets/ and builds lookup indexes
+ * for cross-dataset entity discovery.
+ *
+ * Outputs three parallel indexes:
+ * - by-wikidata/: Sharded by QID numeric range
+ * - by-wikipedia/: Keyed by normalized Wikipedia title
+ * - by-nodeid/: Keyed by exact node ID
+ *
+ * Usage: npm run build:cross-scene-index
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+interface Node {
+  id: string;
+  type: string;
+  title: string;
+  wikidataId?: string;
+  wikipediaTitle?: string;
+}
+
+interface Manifest {
+  id: string;
+  name: string;
+  description: string;
+}
+
+interface EntityAppearance {
+  datasetId: string;
+  datasetName: string;
+  nodeId: string;
+  nodeTitle: string;
+}
+
+interface EntityRecord {
+  wikidataId?: string;
+  wikipediaTitle?: string;
+  canonicalTitle: string;
+  appearances: EntityAppearance[];
+}
+
+type EntityIndex = Map<string, EntityRecord>;
+
+// Define QID ranges for sharding (100k per shard)
+const QID_SHARD_SIZE = 100000;
+
+/**
+ * Get all dataset directories
+ */
+function getDatasetDirs(datasetsPath: string): string[] {
+  const entries = fs.readdirSync(datasetsPath, { withFileTypes: true });
+  return entries
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .filter(name => !name.startsWith('.'));
+}
+
+/**
+ * Load a dataset's manifest
+ */
+function loadManifest(datasetPath: string): Manifest | null {
+  const manifestPath = path.join(datasetPath, 'manifest.json');
+  if (!fs.existsSync(manifestPath)) {
+    return null;
+  }
+
+  try {
+    const content = fs.readFileSync(manifestPath, 'utf-8');
+    return JSON.parse(content);
+  } catch (error) {
+    console.warn(`Failed to load manifest for ${datasetPath}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Load a dataset's nodes
+ */
+function loadNodes(datasetPath: string): Node[] {
+  const nodesPath = path.join(datasetPath, 'nodes.json');
+  if (!fs.existsSync(nodesPath)) {
+    return [];
+  }
+
+  try {
+    const content = fs.readFileSync(nodesPath, 'utf-8');
+    return JSON.parse(content);
+  } catch (error) {
+    console.warn(`Failed to load nodes for ${datasetPath}:`, error);
+    return [];
+  }
+}
+
+/**
+ * Build entity indexes from all datasets
+ */
+function buildIndexes(datasetsPath: string): {
+  byWikidata: EntityIndex;
+  byWikipedia: EntityIndex;
+  byNodeId: EntityIndex;
+  datasetList: Array<{ id: string; name: string }>;
+} {
+  const byWikidata: EntityIndex = new Map();
+  const byWikipedia: EntityIndex = new Map();
+  const byNodeId: EntityIndex = new Map();
+  const datasetList: Array<{ id: string; name: string }> = [];
+
+  const datasetDirs = getDatasetDirs(datasetsPath);
+
+  console.log(`Found ${datasetDirs.length} datasets`);
+
+  for (const datasetDir of datasetDirs) {
+    const datasetPath = path.join(datasetsPath, datasetDir);
+    const manifest = loadManifest(datasetPath);
+
+    if (!manifest) {
+      console.warn(`Skipping ${datasetDir}: no valid manifest`);
+      continue;
+    }
+
+    datasetList.push({ id: manifest.id, name: manifest.name });
+    console.log(`Processing ${manifest.name} (${manifest.id})...`);
+
+    const nodes = loadNodes(datasetPath);
+    let processedCount = 0;
+    let skippedCount = 0;
+
+    for (const node of nodes) {
+      // Skip nodes without any identifiers
+      if (!node.wikidataId && !node.wikipediaTitle && !node.id) {
+        skippedCount++;
+        continue;
+      }
+
+      const appearance: EntityAppearance = {
+        datasetId: manifest.id,
+        datasetName: manifest.name,
+        nodeId: node.id,
+        nodeTitle: node.title,
+      };
+
+      // Index by wikidataId
+      if (node.wikidataId) {
+        if (!byWikidata.has(node.wikidataId)) {
+          byWikidata.set(node.wikidataId, {
+            wikidataId: node.wikidataId,
+            wikipediaTitle: node.wikipediaTitle,
+            canonicalTitle: node.title,
+            appearances: [],
+          });
+        }
+        byWikidata.get(node.wikidataId)!.appearances.push(appearance);
+      }
+
+      // Index by wikipediaTitle
+      if (node.wikipediaTitle) {
+        if (!byWikipedia.has(node.wikipediaTitle)) {
+          byWikipedia.set(node.wikipediaTitle, {
+            wikidataId: node.wikidataId,
+            wikipediaTitle: node.wikipediaTitle,
+            canonicalTitle: node.title,
+            appearances: [],
+          });
+        }
+        byWikipedia.get(node.wikipediaTitle)!.appearances.push(appearance);
+      }
+
+      // Index by nodeId
+      if (node.id) {
+        if (!byNodeId.has(node.id)) {
+          byNodeId.set(node.id, {
+            wikidataId: node.wikidataId,
+            wikipediaTitle: node.wikipediaTitle,
+            canonicalTitle: node.title,
+            appearances: [],
+          });
+        }
+        byNodeId.get(node.id)!.appearances.push(appearance);
+      }
+
+      processedCount++;
+    }
+
+    console.log(`  ✓ Processed ${processedCount} nodes, skipped ${skippedCount}`);
+  }
+
+  console.log(`\nIndex summary:`);
+  console.log(`  - Wikidata IDs: ${byWikidata.size}`);
+  console.log(`  - Wikipedia titles: ${byWikipedia.size}`);
+  console.log(`  - Node IDs: ${byNodeId.size}`);
+
+  return { byWikidata, byWikipedia, byNodeId, datasetList };
+}
+
+/**
+ * Get shard filename for a wikidata QID
+ */
+function getWikidataShardFilename(qid: string): string {
+  const match = qid.match(/^Q(\d+)$/);
+  if (!match) {
+    return 'other.json';
+  }
+
+  const num = parseInt(match[1], 10);
+  const shardStart = Math.floor(num / QID_SHARD_SIZE) * QID_SHARD_SIZE;
+  const shardEnd = shardStart + QID_SHARD_SIZE - 1;
+
+  return `Q${shardStart}-Q${shardEnd}.json`;
+}
+
+/**
+ * Write indexes to disk
+ */
+function writeIndexes(
+  outputPath: string,
+  indexes: {
+    byWikidata: EntityIndex;
+    byWikipedia: EntityIndex;
+    byNodeId: EntityIndex;
+    datasetList: Array<{ id: string; name: string }>;
+  }
+): void {
+  // Create output directory structure
+  const dirs = [
+    outputPath,
+    path.join(outputPath, 'by-wikidata'),
+    path.join(outputPath, 'by-wikipedia'),
+    path.join(outputPath, 'by-nodeid'),
+  ];
+
+  for (const dir of dirs) {
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+  }
+
+  // Write manifest
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    datasetCount: indexes.datasetList.length,
+    datasets: indexes.datasetList,
+    indexes: {
+      wikidata: {
+        totalEntities: indexes.byWikidata.size,
+        shardCount: 0, // Will update after writing shards
+      },
+      wikipedia: {
+        totalEntities: indexes.byWikipedia.size,
+      },
+      nodeid: {
+        totalEntities: indexes.byNodeId.size,
+      },
+    },
+  };
+
+  // Write sharded wikidata index
+  const wikidataShards = new Map<string, Record<string, EntityRecord>>();
+
+  for (const [qid, record] of indexes.byWikidata.entries()) {
+    const shardName = getWikidataShardFilename(qid);
+    if (!wikidataShards.has(shardName)) {
+      wikidataShards.set(shardName, {});
+    }
+    wikidataShards.get(shardName)![qid] = record;
+  }
+
+  console.log(`\nWriting ${wikidataShards.size} wikidata shards...`);
+  for (const [shardName, shard] of wikidataShards.entries()) {
+    const shardPath = path.join(outputPath, 'by-wikidata', shardName);
+    fs.writeFileSync(shardPath, JSON.stringify(shard, null, 2));
+    console.log(`  ✓ ${shardName}: ${Object.keys(shard).length} entries`);
+  }
+
+  manifest.indexes.wikidata.shardCount = wikidataShards.size;
+
+  // Write wikipedia index
+  const wikipediaIndex: Record<string, EntityRecord> = {};
+  for (const [title, record] of indexes.byWikipedia.entries()) {
+    wikipediaIndex[title] = record;
+  }
+  const wikipediaPath = path.join(outputPath, 'by-wikipedia', 'titles.json');
+  fs.writeFileSync(wikipediaPath, JSON.stringify(wikipediaIndex, null, 2));
+  console.log(`\nWrote wikipedia index: ${Object.keys(wikipediaIndex).length} entries`);
+
+  // Write nodeid index
+  const nodeidIndex: Record<string, EntityRecord> = {};
+  for (const [nodeId, record] of indexes.byNodeId.entries()) {
+    nodeidIndex[nodeId] = record;
+  }
+  const nodeidPath = path.join(outputPath, 'by-nodeid', 'nodeids.json');
+  fs.writeFileSync(nodeidPath, JSON.stringify(nodeidIndex, null, 2));
+  console.log(`Wrote nodeid index: ${Object.keys(nodeidIndex).length} entries`);
+
+  // Write manifest
+  const manifestPath = path.join(outputPath, 'manifest.json');
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+  console.log(`\nWrote manifest: ${manifestPath}`);
+
+  console.log(`\n✅ Cross-scene index built successfully!`);
+}
+
+/**
+ * Main entry point
+ */
+function main() {
+  console.log('🔨 Building cross-scene index...\n');
+
+  const projectRoot = path.resolve(__dirname, '../..');
+  const datasetsPath = path.join(projectRoot, 'public', 'datasets');
+  const outputPath = path.join(projectRoot, 'public', 'cross-scene-index');
+
+  if (!fs.existsSync(datasetsPath)) {
+    console.error(`❌ Datasets directory not found: ${datasetsPath}`);
+    process.exit(1);
+  }
+
+  const indexes = buildIndexes(datasetsPath);
+  writeIndexes(outputPath, indexes);
+}
+
+main();

--- a/scripts/test-node-scenes-api.sh
+++ b/scripts/test-node-scenes-api.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Test script for /api/node-scenes endpoint
+
+API_URL="http://localhost:3000/api/node-scenes"
+
+echo "Testing /api/node-scenes API endpoint..."
+echo ""
+
+# Test 1: London (Q84) - should have 8 appearances
+echo "Test 1: London (Q84) - expecting 8 appearances"
+curl -s "${API_URL}?wikidataId=Q84" | jq -r '.totalAppearances'
+echo ""
+
+# Test 2: Paris (Q90) - should have 7 appearances
+echo "Test 2: Paris (Q90) - expecting 7 appearances"
+curl -s "${API_URL}?wikidataId=Q90" | jq -r '.totalAppearances'
+echo ""
+
+# Test 3: Isaac Newton (Q935) - should have 3 appearances
+echo "Test 3: Isaac Newton (Q935) - expecting 3 appearances"
+curl -s "${API_URL}?wikidataId=Q935" | jq -r '.totalAppearances'
+echo ""
+
+# Test 4: Batch lookup
+echo "Test 4: Batch lookup - Q84,Q90,Q935"
+curl -s "${API_URL}?wikidataIds=Q84,Q90,Q935" | jq '{
+  "Q84": .results.Q84.totalAppearances,
+  "Q90": .results.Q90.totalAppearances,
+  "Q935": .results.Q935.totalAppearances,
+  "notFound": .notFound
+}'
+echo ""
+
+# Test 5: Not found
+echo "Test 5: Not found entity"
+curl -s "${API_URL}?wikidataId=Q999999999" | jq -r '.totalAppearances'
+echo ""
+
+# Test 6: Wikipedia title lookup
+echo "Test 6: Wikipedia title lookup - Isaac_Newton"
+curl -s "${API_URL}?wikipediaTitle=Isaac_Newton" | jq -r '.totalAppearances'
+echo ""
+
+echo "✅ Tests complete!"

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
-  "buildCommand": "npm run build",
+  "buildCommand": "npm run build:cross-scene-index && npm run build",
   "outputDirectory": "dist",
   "rewrites": [
     { "source": "/api/:path*", "destination": "/api/:path*" },


### PR DESCRIPTION
## Summary

Implements M29 Cross-Scene Node Index API - the backend infrastructure for cross-dataset entity discovery. This enables users to discover when entities (people, locations, objects) appear across multiple datasets and navigate between them.

**User Value**: "I'm viewing Galileo in Scientific Revolution → discover he's also in Florentine Academy → click to see him in that context"

## What's Included

### 1. Index Build Script
- **Location**: `scripts/build-cross-scene-index/index.ts`
- Scans all 12 datasets in `public/datasets/`
- Builds three parallel lookup indexes (wikidataId, wikipediaTitle, nodeId)
- Generates 167 sharded files for efficient loading
- **Run**: `npm run build:cross-scene-index`

### 2. Static Index Files
- **Location**: `public/cross-scene-index/`
- `by-wikidata/` - 167 sharded JSON files (Q0-Q99999.json, Q100000-Q199999.json, etc.)
- `by-wikipedia/titles.json` - 1,200 entries
- `by-nodeid/nodeids.json` - 1,434 entries
- `manifest.json` - Index metadata and dataset list

### 3. Serverless API Endpoint
- **Location**: `api/node-scenes.ts`
- **Endpoint**: `GET /api/node-scenes`

**Single Lookup**:
```
/api/node-scenes?wikidataId=Q84
/api/node-scenes?wikipediaTitle=Isaac_Newton
/api/node-scenes?nodeId=person-ficino
```

**Batch Lookup**:
```
/api/node-scenes?wikidataIds=Q84,Q90,Q935
```

**Response**:
```json
{
  "identity": {
    "wikidataId": "Q84",
    "wikipediaTitle": "London",
    "canonicalTitle": "London, United Kingdom"
  },
  "appearances": [
    {
      "datasetId": "ai-llm-research",
      "datasetName": "AI & LLM Research Network",
      "nodeId": "location-london",
      "nodeTitle": "London, United Kingdom"
    }
  ],
  "totalAppearances": 8
}
```

### 4. CI Integration
- Updated `vercel.json` build command to generate index before build
- Updated `.github/workflows/e2e.yml` to generate index in CI
- Index files automatically included in deployment

## Validation Results ✅

### Test Entities Verified
- **London (Q84)**: 8 datasets ✅
- **Paris (Q90)**: 7 datasets ✅
- **Isaac Newton (Q935)**: 3 datasets ✅

### API Features Tested
- ✅ Single lookup by wikidataId
- ✅ Single lookup by wikipediaTitle
- ✅ Single lookup by nodeId
- ✅ Batch lookup (multiple entities in one request)
- ✅ Not found handling (returns empty appearances)
- ✅ Build process includes index generation
- ✅ Index files included in dist/

### Coverage Stats
- **1,088** unique Wikidata IDs indexed
- **1,200** unique Wikipedia titles indexed
- **1,434** unique node IDs indexed
- **79%** of nodes have wikidataId
- **44** entities appear in multiple datasets

## Testing Instructions

### Local Testing

1. **Generate the index**:
```bash
npm run build:cross-scene-index
```

2. **Start dev server**:
```bash
npm start
```

3. **Test the API**:
```bash
# Run test script
./scripts/test-node-scenes-api.sh

# Or manually test
curl "http://localhost:3000/api/node-scenes?wikidataId=Q84"
curl "http://localhost:3000/api/node-scenes?wikidataIds=Q84,Q90,Q935"
```

### Expected Results
- London (Q84) should return 8 appearances
- Paris (Q90) should return 7 appearances
- Isaac Newton (Q935) should return 3 appearances

## Dependencies

**Blocks**: M30 (Cross-Scene UI)
- M30 requires this API endpoint to be deployed
- Do not start M30 until this PR is merged and deployed

## Notes

- ~21% of nodes lack both wikidataId and wikipediaTitle - this is expected and acceptable
- Index files are committed to git and deployed with the site
- Performance in production will be better than local dev (Vercel CDN + edge caching)
- Sharding keeps individual files small for fast loading

## Checklist

- [x] Index generation script works
- [x] All three index types generated correctly
- [x] API endpoint returns correct data
- [x] Test entities validated (London, Paris, Newton)
- [x] Batch API works
- [x] CI integration added
- [x] Build includes index generation
- [x] Code follows existing patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)
