### PR TITLE
Enrich datasets from Wikidata (2A) + enrich hardening; flag ai-llm-research ID corruption

### DIFF
--- a/public/datasets/ambient-music/enrich-ambiguous.json
+++ b/public/datasets/ambient-music/enrich-ambiguous.json
@@ -1,0 +1,246 @@
+[
+  {
+    "nodeId": "person-david-cockerell",
+    "title": "David Cockerell",
+    "type": "person",
+    "reason": "not-found",
+    "note": "Wikipedia page \"David_Cockerell_(engineer)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "person-peter-baumann",
+    "title": "Peter Baumann",
+    "type": "person",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Peter_Baumann_(musician)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-schaeffer-etude-chemins-de-fer",
+    "title": "Étude aux chemins de fer",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Études_de_bruits\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-young-dream-house",
+    "title": "Dream House",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Dream_House_(art_installation)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-bryars-titanic",
+    "title": "The Sinking of the Titanic",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"The_Sinking_of_the_Titanic_(album)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-tubby-dub-roots",
+    "title": "Dub from the Roots",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Dub from the Roots\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-eno-ambient-manifesto",
+    "title": "Music for Airports Liner Notes",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Music for Airports Liner Notes\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-schaeffer-traite",
+    "title": "Traité des objets musicaux",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Traité_des_objets_musicaux\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-nyman-experimental-music",
+    "title": "Experimental Music: Cage and Beyond",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Experimental_Music:_Cage_and_Beyond\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-buchla-easel",
+    "title": "Buchla Music Easel",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Buchla_Music_Easel\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "loc-forst",
+    "title": "Forst",
+    "type": "location",
+    "reason": "multiple-candidates",
+    "note": "5 Wikidata candidates for \"Forst\"",
+    "candidates": [
+      {
+        "wikidataId": "Q572545",
+        "label": "Forst (Lausitz)",
+        "description": "town in Spree-Neiße District, Brandenburg, Germany"
+      },
+      {
+        "wikidataId": "Q677078",
+        "label": "Forst",
+        "description": "place in Rhineland-Palatinate, Germany"
+      },
+      {
+        "wikidataId": "Q648840",
+        "label": "Forst",
+        "description": "municipality of Germany"
+      },
+      {
+        "wikidataId": "Q83947567",
+        "label": "Forst",
+        "description": "human settlement in Wiener Neustadt District"
+      },
+      {
+        "wikidataId": "Q17521245",
+        "label": "Forster",
+        "description": "family name"
+      }
+    ]
+  },
+  {
+    "nodeId": "loc-king-tubby-studio",
+    "title": "King Tubby's Studio",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"King Tubby's Studio\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "loc-ems-studio",
+    "title": "EMS Studio",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"EMS Studio\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "loc-british-art-schools",
+    "title": "Ipswich/Winchester Art Schools",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Ipswich/Winchester Art Schools\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "loc-dream-house-install",
+    "title": "Dream House Installation",
+    "type": "location",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Dream_House_(art_installation)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "loc-young-loft",
+    "title": "La Monte Young's Loft",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"La Monte Young's Loft\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-brain",
+    "title": "Brain Records",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Brain_(record_label)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-grm-editions",
+    "title": "GRM Editions",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"GRM Editions\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-berlin-school",
+    "title": "Berlin School",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Berlin_School_(electronic_music)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-kankyo-ongaku",
+    "title": "Kankyō Ongaku",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Kankyō_ongaku\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-czukay-canaxis",
+    "title": "Canaxis 5",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Canaxis\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-takada-looking-glass",
+    "title": "Through the Looking Glass",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Through_the_Looking_Glass_(Midori_Takada_album)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-ashikawa-still-way",
+    "title": "Still Way (Wave Notation 2)",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Still Way (Wave Notation 2)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-sound-process",
+    "title": "Sound Process",
+    "type": "entity",
+    "reason": "multiple-candidates",
+    "note": "5 Wikidata candidates for \"Sound Process\"",
+    "candidates": [
+      {
+        "wikidataId": "Q119498452",
+        "label": "Sound processing apparatus and sound processing system",
+        "description": "US patent 11146904"
+      },
+      {
+        "wikidataId": "Q119345023",
+        "label": "Sound processing device, sound processing method, and program",
+        "description": "US patent 11336999"
+      },
+      {
+        "wikidataId": "Q119352188",
+        "label": "Sound processing device, sound processing method, and program",
+        "description": "US patent 11297428"
+      },
+      {
+        "wikidataId": "Q123046424",
+        "label": "Sound processing method, remote conversation method, sound processing device, remote conversation device, headset, and remote conversation system",
+        "description": "US patent 11259116"
+      },
+      {
+        "wikidataId": "Q119362720",
+        "label": "Sound processing device, method and program",
+        "description": "US patent 11265647"
+      }
+    ]
+  }
+]

--- a/public/datasets/ambient-music/nodes.json
+++ b/public/datasets/ambient-music/nodes.json
@@ -1519,7 +1519,9 @@
       "person-michael-nyman"
     ],
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q5248828",
+    "wikipediaTitle": "Decay_Music"
   },
   {
     "id": "object-yoshimura-postcards",
@@ -1558,7 +1560,8 @@
       "person-haruomi-hosono"
     ],
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q11614996"
   },
   {
     "id": "object-sakamoto-async",
@@ -1831,7 +1834,8 @@
     "shortDescription": "Capital of Berlin School electronic music",
     "country": "Germany",
     "wikipediaTitle": "Berlin",
-    "wikidataId": "Q64"
+    "wikidataId": "Q64",
+    "dateStart": "1244"
   },
   {
     "id": "loc-dusseldorf",
@@ -1871,7 +1875,8 @@
     "shortDescription": "Birthplace of musique concrète and furniture music",
     "country": "France",
     "wikipediaTitle": "Paris",
-    "wikidataId": "Q90"
+    "wikidataId": "Q90",
+    "dateStart": "-300"
   },
   {
     "id": "loc-london",
@@ -1881,7 +1886,8 @@
     "shortDescription": "Home of BBC Radiophonic Workshop and British experimental scene",
     "country": "United Kingdom",
     "wikipediaTitle": "London",
-    "wikidataId": "Q84"
+    "wikidataId": "Q84",
+    "dateStart": "47"
   },
   {
     "id": "loc-new-york",
@@ -1891,7 +1897,8 @@
     "shortDescription": "Center of American avant-garde and minimalism",
     "country": "United States",
     "wikipediaTitle": "New_York_City",
-    "wikidataId": "Q60"
+    "wikidataId": "Q60",
+    "dateStart": "1624"
   },
   {
     "id": "loc-san-francisco",
@@ -1911,7 +1918,8 @@
     "shortDescription": "Birthplace of dub music",
     "country": "Jamaica",
     "wikipediaTitle": "Kingston,_Jamaica",
-    "wikidataId": "Q34692"
+    "wikidataId": "Q34692",
+    "dateStart": "1692"
   },
   {
     "id": "loc-tokyo",
@@ -1921,7 +1929,8 @@
     "shortDescription": "Center of Japanese electronic and environmental music",
     "country": "Japan",
     "wikipediaTitle": "Tokyo",
-    "wikidataId": "Q1490"
+    "wikidataId": "Q1490",
+    "dateStart": "1868"
   },
   {
     "id": "loc-milan",
@@ -1931,7 +1940,8 @@
     "shortDescription": "Base of Italian Futurism",
     "country": "Italy",
     "wikipediaTitle": "Milan",
-    "wikidataId": "Q490"
+    "wikidataId": "Q490",
+    "dateStart": "-600"
   },
   {
     "id": "loc-hamilton",
@@ -1941,7 +1951,8 @@
     "shortDescription": "Location of Daniel Lanois's Grant Avenue Studio",
     "country": "Canada",
     "wikipediaTitle": "Hamilton,_Ontario",
-    "wikidataId": "Q133116"
+    "wikidataId": "Q133116",
+    "dateStart": "1846"
   },
   {
     "id": "loc-conny-studio",
@@ -1963,7 +1974,9 @@
     "country": "France",
     "parentLocation": "loc-paris",
     "wikipediaTitle": "Groupe_de_recherches_musicales",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q823560",
+    "dateStart": "1948"
   },
   {
     "id": "loc-wdr-studio",
@@ -1974,7 +1987,8 @@
     "country": "Germany",
     "parentLocation": "loc-cologne",
     "wikipediaTitle": "Studio_for_Electronic_Music_(WDR)",
-    "wikidataId": "Q2358704"
+    "wikidataId": "Q2358704",
+    "dateStart": "1951"
   },
   {
     "id": "loc-bbc-radiophonic",
@@ -2011,7 +2025,8 @@
     "dateStart": "1973",
     "dateEnd": "1979",
     "wikipediaTitle": "Black_Ark",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q2331306"
   },
   {
     "id": "loc-kling-klang",
@@ -2033,7 +2048,8 @@
     "country": "Canada",
     "parentLocation": "loc-hamilton",
     "wikipediaTitle": "Grant_Avenue_Studio",
-    "wikidataId": "Q118898952"
+    "wikidataId": "Q118898952",
+    "dateStart": "1976"
   },
   {
     "id": "loc-ems-studio",
@@ -2055,7 +2071,8 @@
     "country": "Germany",
     "parentLocation": "loc-berlin",
     "wikipediaTitle": "Hansa_Tonstudio",
-    "wikidataId": "Q667023"
+    "wikidataId": "Q667023",
+    "dateStart": "1974"
   },
   {
     "id": "loc-sftmc",
@@ -2079,7 +2096,8 @@
     "country": "United States",
     "parentLocation": "loc-san-francisco",
     "wikipediaTitle": "Mills_College",
-    "wikidataId": "Q638859"
+    "wikidataId": "Q638859",
+    "dateStart": "1852"
   },
   {
     "id": "loc-darmstadt",
@@ -2089,7 +2107,9 @@
     "shortDescription": "International summer courses where avant-garde traditions met",
     "country": "Germany",
     "wikipediaTitle": "Darmstadt_International_Summer_Courses_for_New_Music",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q694704",
+    "dateStart": "1946"
   },
   {
     "id": "loc-zodiak",
@@ -2123,7 +2143,8 @@
     "country": "Germany",
     "parentLocation": "loc-dusseldorf",
     "wikipediaTitle": "Kunstakademie_Düsseldorf",
-    "wikidataId": "Q662355"
+    "wikidataId": "Q662355",
+    "dateStart": "1773"
   },
   {
     "id": "loc-kitchen",
@@ -2135,7 +2156,8 @@
     "parentLocation": "loc-new-york",
     "dateStart": "1971",
     "wikipediaTitle": "The_Kitchen",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q1743849"
   },
   {
     "id": "loc-washington-square",
@@ -2146,7 +2168,8 @@
     "country": "United States",
     "parentLocation": "loc-new-york",
     "wikipediaTitle": "Washington_Square_Park",
-    "wikidataId": "Q909592"
+    "wikidataId": "Q909592",
+    "dateStart": "1827"
   },
   {
     "id": "loc-dream-house-install",
@@ -2326,7 +2349,8 @@
     "dateStart": "1950",
     "headquarters": "loc-new-york",
     "wikipediaTitle": "New_York_School_(art)",
-    "wikidataId": "Q1972942"
+    "wikidataId": "Q1972942",
+    "dateEnd": "1960"
   },
   {
     "id": "entity-deep-listening-band",
@@ -2434,7 +2458,8 @@
     "dateStart": "1973",
     "headquarters": "loc-london",
     "wikipediaTitle": "E.G._Records",
-    "wikidataId": "Q1611073"
+    "wikidataId": "Q1611073",
+    "dateEnd": "1996"
   },
   {
     "id": "entity-editions-eg",
@@ -2445,7 +2470,8 @@
     "dateStart": "1981",
     "headquarters": "loc-london",
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q118256298"
   },
   {
     "id": "entity-grm-editions",
@@ -2615,7 +2641,8 @@
     ],
     "headquarters": "loc-paris",
     "wikipediaTitle": "Groupe_de_recherches_musicales",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q823560"
   },
   {
     "id": "entity-sftmc-org",
@@ -2716,7 +2743,9 @@
     "birthPlace": "Japan",
     "nationality": "Japanese",
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q96187424",
+    "wikipediaTitle": "Satoshi_Ashikawa"
   },
   {
     "id": "person-richard-d-james",

--- a/public/datasets/christian-kabbalah/enrich-ambiguous.json
+++ b/public/datasets/christian-kabbalah/enrich-ambiguous.json
@@ -1,0 +1,59 @@
+[
+  {
+    "nodeId": "object-in-scripturam-sacram-problemata",
+    "title": "In Scripturam Sacram Problemata",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"In Scripturam Sacram Problemata\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-de-originibus",
+    "title": "De originibus seu de Hebraicae linguae et gentis antiquitate",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"De originibus seu de Hebraicae linguae et gentis antiquitate\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-absconditorum-clavis",
+    "title": "Absconditorum clavis",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Absconditorum clavis\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-augenspiegel",
+    "title": "Augenspiegel",
+    "type": "object",
+    "reason": "multiple-candidates",
+    "note": "5 Wikidata candidates for \"Augenspiegel\"",
+    "candidates": [
+      {
+        "wikidataId": "Q837188",
+        "label": "ophthalmoscopy",
+        "description": "test that allows a health professional to see inside the fundus of the eye and other structures using an ophthalmoscope, crucial in determining the health of the retina, optic disc, and vitreous humor"
+      },
+      {
+        "wikidataId": "Q16583733",
+        "label": "ophthalmoscope",
+        "description": "instrument for examining the interior of the eye"
+      },
+      {
+        "wikidataId": "Q5689325",
+        "label": "head mirror",
+        "description": "simple diagnostic device"
+      },
+      {
+        "wikidataId": "Q29019832",
+        "label": "Augenspiegel"
+      },
+      {
+        "wikidataId": "Q28957634",
+        "label": "Augenspiegel",
+        "description": "Wikimedia disambiguation page"
+      }
+    ]
+  }
+]

--- a/public/datasets/christian-kabbalah/nodes.json
+++ b/public/datasets/christian-kabbalah/nodes.json
@@ -329,7 +329,8 @@
     "language": "Latin/Hebrew",
     "subject": "Hebrew language",
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q42188609"
   },
   {
     "id": "object-de-occulta-philosophia",
@@ -404,7 +405,8 @@
     "language": "Latin",
     "subject": "angel magic, philosophy of history",
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q121991644"
   },
   {
     "id": "object-de-harmonia-mundi",
@@ -606,7 +608,8 @@
     "locationType": "city",
     "country": "Italy",
     "wikipediaTitle": "Venice",
-    "wikidataId": "Q641"
+    "wikidataId": "Q641",
+    "dateStart": "421"
   },
   {
     "id": "location-cologne",
@@ -626,7 +629,8 @@
     "locationType": "city",
     "country": "Italy",
     "wikipediaTitle": "Rome",
-    "wikidataId": "Q220"
+    "wikidataId": "Q220",
+    "dateStart": "-753"
   },
   {
     "id": "location-sponheim-abbey",
@@ -658,7 +662,8 @@
     "locationType": "city",
     "country": "France",
     "wikipediaTitle": "Paris",
-    "wikidataId": "Q90"
+    "wikidataId": "Q90",
+    "dateStart": "-300"
   },
   {
     "id": "entity-platonic-academy-florence",
@@ -704,7 +709,8 @@
     "shortDescription": "Mendicant order whose Cologne members led opposition to Reuchlin",
     "entityType": "religious order",
     "wikipediaTitle": "Dominican_Order",
-    "wikidataId": "Q192632"
+    "wikidataId": "Q192632",
+    "dateStart": "1952"
   },
   {
     "id": "person-lorenzo-de-medici",

--- a/public/datasets/cybernetics-information-theory/enrich-ambiguous.json
+++ b/public/datasets/cybernetics-information-theory/enrich-ambiguous.json
@@ -1,0 +1,198 @@
+[
+  {
+    "nodeId": "person-john-bates",
+    "title": "John Bates",
+    "type": "person",
+    "reason": "multiple-candidates",
+    "note": "5 Wikidata candidates for \"John Bates\"",
+    "candidates": [
+      {
+        "wikidataId": "Q106677495",
+        "label": "John Bates",
+        "description": "American football player"
+      },
+      {
+        "wikidataId": "Q110606569",
+        "label": "John Bates",
+        "description": "Abt 1753 - 16 Feb 1816"
+      },
+      {
+        "wikidataId": "Q115537304",
+        "label": "John Bates",
+        "description": "1521 - before 13 May 1580"
+      },
+      {
+        "wikidataId": "Q107310635",
+        "label": "John Bates",
+        "description": "(1722-1775)"
+      },
+      {
+        "wikidataId": "Q110606570",
+        "label": "John Bates"
+      }
+    ]
+  },
+  {
+    "nodeId": "person-william-rushton",
+    "title": "William Rushton",
+    "type": "person",
+    "reason": "not-found",
+    "note": "Wikipedia page \"William_A._H._Rushton\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "person-philip-woodward",
+    "title": "Philip Woodward",
+    "type": "person",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Philip_M._Woodward\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "person-raul-espejo",
+    "title": "Raúl Espejo",
+    "type": "person",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Raúl_Espejo\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-frogs-eye-lettvin",
+    "title": "What the Frog's Eye Tells the Frog's Brain",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"What_the_Frog's_Eye_Tells_the_Frog's_Brain\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-neurodynamics-rosenblatt",
+    "title": "Principles of Neurodynamics",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Principles of Neurodynamics\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-design-brain-ashby",
+    "title": "Design for a Brain",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Design_for_a_Brain\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-behavior-purpose-teleology",
+    "title": "Behavior, Purpose and Teleology",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Behavior,_Purpose_and_Teleology\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-cybernetics-management-beer",
+    "title": "Cybernetics and Management",
+    "type": "object",
+    "reason": "multiple-candidates",
+    "note": "2 Wikidata candidates for \"Cybernetics and Management\"",
+    "candidates": [
+      {
+        "wikidataId": "Q114785463",
+        "label": "Cybernetics and Management",
+        "description": "Anthony Stafford Beer's book where he addresses the connections between systems, ubiquity and feedback, as well as logical theory, biophysical theory and analogous theory of cybernetics on which the viable system model (VSM) is based"
+      },
+      {
+        "wikidataId": "Q58961875",
+        "label": "Cybernetics and Management",
+        "description": "Review published in Nature among the book \"Cybernetics and Management\" of Stafford Beer"
+      }
+    ]
+  },
+  {
+    "nodeId": "object-industrial-dynamics-forrester",
+    "title": "Industrial Dynamics",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Industrial_Dynamics\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-autopoiesis-cognition",
+    "title": "Autopoiesis and Cognition: The Realization of the Living",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Autopoiesis_and_Cognition\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-observing-systems-foerster",
+    "title": "Observing Systems",
+    "type": "object",
+    "reason": "multiple-candidates",
+    "note": "3 Wikidata candidates for \"Observing Systems\"",
+    "candidates": [
+      {
+        "wikidataId": "Q7075490",
+        "label": "Observing Systems",
+        "description": "album by Tied & Tickled Trio"
+      },
+      {
+        "wikidataId": "Q63489290",
+        "label": "Observing Systems for Atmospheric Composition",
+        "description": "article"
+      },
+      {
+        "wikidataId": "Q114639604",
+        "label": "Observing systems and data sets related to the cryosphere in Canada: A contribution to planning for the global climate observing system",
+        "description": "scientific article published in 1995"
+      }
+    ]
+  },
+  {
+    "nodeId": "object-programs-common-sense-mccarthy",
+    "title": "Programs with Common Sense",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Programs with Common Sense\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-macy-proceedings",
+    "title": "Cybernetics: Circular Causal and Feedback Mechanisms (Macy Proceedings)",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Cybernetics: Circular Causal and Feedback Mechanisms (Macy Proceedings)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-beekman-hotel",
+    "title": "Beekman Hotel (Macy Conferences)",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Beekman Hotel (Macy Conferences)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-ratio-club-london",
+    "title": "Ratio Club Meeting Venues",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Ratio Club Meeting Venues\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-uk-cybernetics",
+    "title": "Cybernetics Society (UK)",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Cybernetics Society (UK)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-mit-rle",
+    "title": "MIT Research Laboratory of Electronics",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "Wikipedia page \"MIT_Research_Laboratory_of_Electronics\" has no linked Wikidata item",
+    "candidates": []
+  }
+]

--- a/public/datasets/cybernetics-information-theory/nodes.json
+++ b/public/datasets/cybernetics-information-theory/nodes.json
@@ -144,7 +144,8 @@
     ],
     "nationality": "American",
     "subgroup": "Information Theory",
-    "wikidataId": "Q510591"
+    "wikidataId": "Q510591",
+    "birthPlace": "Reedsburg"
   },
   {
     "id": "person-richard-hamming",
@@ -160,7 +161,8 @@
     ],
     "nationality": "American",
     "subgroup": "Information Theory",
-    "wikidataId": "Q92619"
+    "wikidataId": "Q92619",
+    "birthPlace": "Chicago"
   },
   {
     "id": "person-john-tukey",
@@ -177,7 +179,8 @@
     ],
     "nationality": "American",
     "subgroup": "Information Theory",
-    "wikidataId": "Q382207"
+    "wikidataId": "Q382207",
+    "birthPlace": "New Bedford"
   },
   {
     "id": "person-john-pierce",
@@ -194,7 +197,8 @@
     ],
     "nationality": "American",
     "subgroup": "Information Theory",
-    "wikidataId": "Q1340677"
+    "wikidataId": "Q1340677",
+    "birthPlace": "Des Moines"
   },
   {
     "id": "person-hendrik-bode",
@@ -211,7 +215,8 @@
     ],
     "nationality": "American",
     "subgroup": "Information Theory",
-    "wikidataId": "Q714462"
+    "wikidataId": "Q714462",
+    "birthPlace": "Madison"
   },
   {
     "id": "person-harry-nyquist",
@@ -243,7 +248,8 @@
     ],
     "nationality": "American",
     "subgroup": "Information Theory",
-    "wikidataId": "Q529886"
+    "wikidataId": "Q529886",
+    "birthPlace": "Sprucemont"
   },
   {
     "id": "person-david-huffman",
@@ -259,7 +265,8 @@
     ],
     "nationality": "American",
     "subgroup": "Information Theory",
-    "wikidataId": "Q92784"
+    "wikidataId": "Q92784",
+    "birthPlace": "Alliance"
   },
   {
     "id": "person-robert-fano",
@@ -276,7 +283,8 @@
     ],
     "nationality": "Italian-American",
     "subgroup": "Information Theory",
-    "wikidataId": "Q93052"
+    "wikidataId": "Q93052",
+    "birthPlace": "Turin"
   },
   {
     "id": "person-john-mauchly",
@@ -293,7 +301,8 @@
     ],
     "nationality": "American",
     "subgroup": "Computing Pioneers",
-    "wikidataId": "Q522162"
+    "wikidataId": "Q522162",
+    "birthPlace": "Cincinnati"
   },
   {
     "id": "person-presper-eckert",
@@ -309,7 +318,8 @@
     ],
     "nationality": "American",
     "subgroup": "Computing Pioneers",
-    "wikidataId": "Q457906"
+    "wikidataId": "Q457906",
+    "birthPlace": "Philadelphia"
   },
   {
     "id": "person-herman-goldstine",
@@ -326,7 +336,8 @@
     ],
     "nationality": "American",
     "subgroup": "Computing Pioneers",
-    "wikidataId": "Q93005"
+    "wikidataId": "Q93005",
+    "birthPlace": "Chicago"
   },
   {
     "id": "person-maurice-wilkes",
@@ -342,7 +353,8 @@
     ],
     "nationality": "British",
     "subgroup": "Computing Pioneers",
-    "wikidataId": "Q62857"
+    "wikidataId": "Q62857",
+    "birthPlace": "Dudley"
   },
   {
     "id": "person-konrad-zuse",
@@ -359,7 +371,8 @@
     ],
     "nationality": "German",
     "subgroup": "Computing Pioneers",
-    "wikidataId": "Q60093"
+    "wikidataId": "Q60093",
+    "birthPlace": "Wilmersdorf"
   },
   {
     "id": "person-max-newman",
@@ -375,7 +388,8 @@
     ],
     "nationality": "British",
     "subgroup": "Computing Pioneers",
-    "wikidataId": "Q707155"
+    "wikidataId": "Q707155",
+    "birthPlace": "London"
   },
   {
     "id": "person-tommy-flowers",
@@ -391,7 +405,8 @@
     ],
     "nationality": "British",
     "subgroup": "Computing Pioneers",
-    "wikidataId": "Q954437"
+    "wikidataId": "Q954437",
+    "birthPlace": "Poplar"
   },
   {
     "id": "person-i-j-good",
@@ -408,7 +423,8 @@
     ],
     "nationality": "British",
     "subgroup": "Computing Pioneers",
-    "wikidataId": "Q224372"
+    "wikidataId": "Q224372",
+    "birthPlace": "London"
   },
   {
     "id": "person-warren-mcculloch",
@@ -425,7 +441,8 @@
     ],
     "nationality": "American",
     "subgroup": "Macy Conference Core",
-    "wikidataId": "Q962174"
+    "wikidataId": "Q962174",
+    "birthPlace": "Orange"
   },
   {
     "id": "person-walter-pitts",
@@ -442,7 +459,8 @@
     ],
     "nationality": "American",
     "subgroup": "Macy Conference Core",
-    "wikidataId": "Q705010"
+    "wikidataId": "Q705010",
+    "birthPlace": "Detroit"
   },
   {
     "id": "person-margaret-mead",
@@ -458,7 +476,8 @@
     ],
     "nationality": "American",
     "subgroup": "Macy Conference Core",
-    "wikidataId": "Q180099"
+    "wikidataId": "Q180099",
+    "birthPlace": "Philadelphia"
   },
   {
     "id": "person-arturo-rosenblueth",
@@ -474,7 +493,8 @@
     ],
     "nationality": "Mexican",
     "subgroup": "Macy Conference Core",
-    "wikidataId": "Q121729"
+    "wikidataId": "Q121729",
+    "birthPlace": "Chihuahua City"
   },
   {
     "id": "person-julian-bigelow",
@@ -490,7 +510,8 @@
     ],
     "nationality": "American",
     "subgroup": "Macy Conference Core",
-    "wikidataId": "Q328632"
+    "wikidataId": "Q328632",
+    "birthPlace": "Nutley"
   },
   {
     "id": "person-lawrence-frank",
@@ -507,7 +528,8 @@
     ],
     "nationality": "American",
     "subgroup": "Macy Conference Core",
-    "wikidataId": "Q15430706"
+    "wikidataId": "Q15430706",
+    "birthPlace": "Cincinnati"
   },
   {
     "id": "person-frank-fremont-smith",
@@ -540,7 +562,9 @@
     ],
     "nationality": "American",
     "subgroup": "Macy Conference Core",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q2406358",
+    "birthPlace": "Harvey"
   },
   {
     "id": "person-heinrich-kluver",
@@ -556,7 +580,8 @@
     ],
     "nationality": "German-American",
     "subgroup": "Macy Conference Core",
-    "wikidataId": "Q74829"
+    "wikidataId": "Q74829",
+    "birthPlace": "Holstein"
   },
   {
     "id": "person-kurt-lewin",
@@ -572,7 +597,8 @@
     ],
     "nationality": "German-American",
     "subgroup": "Macy Conference Core",
-    "wikidataId": "Q77106"
+    "wikidataId": "Q77106",
+    "birthPlace": "Mogilno"
   },
   {
     "id": "person-jerome-lettvin",
@@ -588,7 +614,8 @@
     ],
     "nationality": "American",
     "subgroup": "Neurophysiology",
-    "wikidataId": "Q6182818"
+    "wikidataId": "Q6182818",
+    "birthPlace": "Chicago"
   },
   {
     "id": "person-donald-hebb",
@@ -605,7 +632,8 @@
     ],
     "nationality": "Canadian",
     "subgroup": "Neurophysiology",
-    "wikidataId": "Q683246"
+    "wikidataId": "Q683246",
+    "birthPlace": "Chester"
   },
   {
     "id": "person-frank-rosenblatt",
@@ -622,7 +650,8 @@
     ],
     "nationality": "American",
     "subgroup": "Neurophysiology",
-    "wikidataId": "Q93018"
+    "wikidataId": "Q93018",
+    "birthPlace": "New Rochelle"
   },
   {
     "id": "person-horace-barlow",
@@ -672,7 +701,8 @@
     ],
     "nationality": "British",
     "subgroup": "British Cybernetics",
-    "wikidataId": "Q1359845"
+    "wikidataId": "Q1359845",
+    "birthPlace": "Kansas City"
   },
   {
     "id": "person-gordon-pask",
@@ -689,7 +719,8 @@
     ],
     "nationality": "British",
     "subgroup": "British Cybernetics",
-    "wikidataId": "Q370461"
+    "wikidataId": "Q370461",
+    "birthPlace": "Derby"
   },
   {
     "id": "person-donald-mackay",
@@ -771,7 +802,8 @@
     ],
     "nationality": "Austrian-American",
     "subgroup": "Systems Theory",
-    "wikidataId": "Q84345"
+    "wikidataId": "Q84345",
+    "birthPlace": "Atzgersdorf"
   },
   {
     "id": "person-kenneth-boulding",
@@ -788,7 +820,8 @@
     ],
     "nationality": "British-American",
     "subgroup": "Systems Theory",
-    "wikidataId": "Q505520"
+    "wikidataId": "Q505520",
+    "birthPlace": "Liverpool"
   },
   {
     "id": "person-anatol-rapoport",
@@ -805,7 +838,8 @@
     ],
     "nationality": "Russian-American",
     "subgroup": "Systems Theory",
-    "wikidataId": "Q487453"
+    "wikidataId": "Q487453",
+    "birthPlace": "Lozova"
   },
   {
     "id": "person-jay-forrester",
@@ -822,7 +856,8 @@
     ],
     "nationality": "American",
     "subgroup": "Systems Theory",
-    "wikidataId": "Q92763"
+    "wikidataId": "Q92763",
+    "birthPlace": "Anselmo"
   },
   {
     "id": "person-donella-meadows",
@@ -839,7 +874,8 @@
     ],
     "nationality": "American",
     "subgroup": "Systems Theory",
-    "wikidataId": "Q271226"
+    "wikidataId": "Q271226",
+    "birthPlace": "Elgin"
   },
   {
     "id": "person-russell-ackoff",
@@ -856,7 +892,8 @@
     ],
     "nationality": "American",
     "subgroup": "Systems Theory",
-    "wikidataId": "Q1431186"
+    "wikidataId": "Q1431186",
+    "birthPlace": "Philadelphia"
   },
   {
     "id": "person-c-west-churchman",
@@ -873,7 +910,8 @@
     ],
     "nationality": "American",
     "subgroup": "Systems Theory",
-    "wikidataId": "Q959763"
+    "wikidataId": "Q959763",
+    "birthPlace": "Philadelphia"
   },
   {
     "id": "person-peter-checkland",
@@ -889,7 +927,8 @@
     ],
     "nationality": "British",
     "subgroup": "Systems Theory",
-    "wikidataId": "Q503806"
+    "wikidataId": "Q503806",
+    "birthPlace": "Birmingham"
   },
   {
     "id": "person-raul-espejo",
@@ -922,7 +961,8 @@
     ],
     "nationality": "Austrian-American",
     "subgroup": "Second-Order Cybernetics",
-    "wikidataId": "Q78688"
+    "wikidataId": "Q78688",
+    "birthPlace": "Vienna"
   },
   {
     "id": "person-humberto-maturana",
@@ -939,7 +979,8 @@
     ],
     "nationality": "Chilean",
     "subgroup": "Second-Order Cybernetics",
-    "wikidataId": "Q376452"
+    "wikidataId": "Q376452",
+    "birthPlace": "Santiago"
   },
   {
     "id": "person-francisco-varela",
@@ -957,7 +998,8 @@
     ],
     "nationality": "Chilean-French",
     "subgroup": "Second-Order Cybernetics",
-    "wikidataId": "Q923582"
+    "wikidataId": "Q923582",
+    "birthPlace": "Talcahuano"
   },
   {
     "id": "person-ernst-von-glasersfeld",
@@ -974,7 +1016,8 @@
     ],
     "nationality": "Austrian-American",
     "subgroup": "Second-Order Cybernetics",
-    "wikidataId": "Q112176"
+    "wikidataId": "Q112176",
+    "birthPlace": "Munich"
   },
   {
     "id": "person-ranulph-glanville",
@@ -991,7 +1034,8 @@
     ],
     "nationality": "British",
     "subgroup": "Second-Order Cybernetics",
-    "wikidataId": "Q1494101"
+    "wikidataId": "Q1494101",
+    "birthPlace": "Greater London"
   },
   {
     "id": "person-marvin-minsky",
@@ -1008,7 +1052,8 @@
     ],
     "nationality": "American",
     "subgroup": "AI & Cognitive Science",
-    "wikidataId": "Q204815"
+    "wikidataId": "Q204815",
+    "birthPlace": "New York City"
   },
   {
     "id": "person-john-mccarthy",
@@ -1024,7 +1069,8 @@
     ],
     "nationality": "American",
     "subgroup": "AI & Cognitive Science",
-    "wikidataId": "Q92739"
+    "wikidataId": "Q92739",
+    "birthPlace": "Boston"
   },
   {
     "id": "person-allen-newell",
@@ -1041,7 +1087,8 @@
     ],
     "nationality": "American",
     "subgroup": "AI & Cognitive Science",
-    "wikidataId": "Q439245"
+    "wikidataId": "Q439245",
+    "birthPlace": "San Francisco"
   },
   {
     "id": "person-herbert-simon",
@@ -1059,7 +1106,8 @@
     ],
     "nationality": "American",
     "subgroup": "AI & Cognitive Science",
-    "wikidataId": "Q181529"
+    "wikidataId": "Q181529",
+    "birthPlace": "Milwaukee"
   },
   {
     "id": "person-seymour-papert",
@@ -1077,7 +1125,8 @@
     ],
     "nationality": "South African-American",
     "subgroup": "AI & Cognitive Science",
-    "wikidataId": "Q335027"
+    "wikidataId": "Q335027",
+    "birthPlace": "Pretoria"
   },
   {
     "id": "person-oliver-selfridge",
@@ -1093,7 +1142,8 @@
     ],
     "nationality": "American",
     "subgroup": "AI & Cognitive Science",
-    "wikidataId": "Q2651957"
+    "wikidataId": "Q2651957",
+    "birthPlace": "London"
   },
   {
     "id": "person-nathaniel-rochester",
@@ -1109,7 +1159,8 @@
     ],
     "nationality": "American",
     "subgroup": "AI & Cognitive Science",
-    "wikidataId": "Q6969830"
+    "wikidataId": "Q6969830",
+    "birthPlace": "Buffalo"
   },
   {
     "id": "person-ray-solomonoff",
@@ -1125,7 +1176,8 @@
     ],
     "nationality": "American",
     "subgroup": "AI & Cognitive Science",
-    "wikidataId": "Q3123640"
+    "wikidataId": "Q3123640",
+    "birthPlace": "Cleveland"
   },
   {
     "id": "person-arthur-samuel",
@@ -1141,7 +1193,8 @@
     ],
     "nationality": "American",
     "subgroup": "AI & Cognitive Science",
-    "wikidataId": "Q710266"
+    "wikidataId": "Q710266",
+    "birthPlace": "Emporia"
   },
   {
     "id": "person-j-c-r-licklider",
@@ -1158,7 +1211,8 @@
     ],
     "nationality": "American",
     "subgroup": "AI & Cognitive Science",
-    "wikidataId": "Q92778"
+    "wikidataId": "Q92778",
+    "birthPlace": "St. Louis"
   },
   {
     "id": "person-douglas-engelbart",
@@ -1175,7 +1229,8 @@
     ],
     "nationality": "American",
     "subgroup": "AI & Cognitive Science",
-    "wikidataId": "Q92614"
+    "wikidataId": "Q92614",
+    "birthPlace": "Portland"
   },
   {
     "id": "person-alfred-whitehead",
@@ -1192,7 +1247,8 @@
     ],
     "nationality": "British-American",
     "subgroup": "Precursors",
-    "wikidataId": "Q183372"
+    "wikidataId": "Q183372",
+    "birthPlace": "Ramsgate"
   },
   {
     "id": "person-bertrand-russell",
@@ -1210,7 +1266,8 @@
     ],
     "nationality": "British",
     "subgroup": "Precursors",
-    "wikidataId": "Q33760"
+    "wikidataId": "Q33760",
+    "birthPlace": "Trellech"
   },
   {
     "id": "person-alonzo-church",
@@ -1227,7 +1284,8 @@
     ],
     "nationality": "American",
     "subgroup": "Precursors",
-    "wikidataId": "Q92741"
+    "wikidataId": "Q92741",
+    "birthPlace": "Washington, D.C."
   },
   {
     "id": "person-kurt-godel",
@@ -1244,7 +1302,8 @@
     ],
     "nationality": "Austrian-American",
     "subgroup": "Precursors",
-    "wikidataId": "Q41390"
+    "wikidataId": "Q41390",
+    "birthPlace": "Brno"
   },
   {
     "id": "person-walter-cannon",
@@ -1260,7 +1319,8 @@
     ],
     "nationality": "American",
     "subgroup": "Precursors",
-    "wikidataId": "Q503192"
+    "wikidataId": "Q503192",
+    "birthPlace": "Wisconsin"
   },
   {
     "id": "person-josiah-gibbs",
@@ -1278,7 +1338,8 @@
     ],
     "nationality": "American",
     "subgroup": "Precursors",
-    "wikidataId": "Q153243"
+    "wikidataId": "Q153243",
+    "birthPlace": "New Haven"
   },
   {
     "id": "person-ludwig-boltzmann",
@@ -1294,7 +1355,8 @@
     ],
     "nationality": "Austrian",
     "subgroup": "Precursors",
-    "wikidataId": "Q84296"
+    "wikidataId": "Q84296",
+    "birthPlace": "Vienna"
   },
   {
     "id": "person-vannevar-bush",
@@ -1311,7 +1373,8 @@
     ],
     "nationality": "American",
     "subgroup": "Precursors",
-    "wikidataId": "Q299595"
+    "wikidataId": "Q299595",
+    "birthPlace": "Everett"
   },
   {
     "id": "person-charles-peirce",
@@ -1328,7 +1391,8 @@
     ],
     "nationality": "American",
     "subgroup": "Precursors",
-    "wikidataId": "Q187520"
+    "wikidataId": "Q187520",
+    "birthPlace": "Cambridge"
   },
   {
     "id": "person-oskar-morgenstern",
@@ -1344,7 +1408,8 @@
     ],
     "nationality": "Austrian-American",
     "subgroup": "Precursors",
-    "wikidataId": "Q94028"
+    "wikidataId": "Q94028",
+    "birthPlace": "Görlitz"
   },
   {
     "id": "person-jean-piaget",
@@ -1361,7 +1426,8 @@
     ],
     "nationality": "Swiss",
     "subgroup": "Precursors",
-    "wikidataId": "Q123190"
+    "wikidataId": "Q123190",
+    "birthPlace": "Neuchâtel"
   },
   {
     "id": "object-cybernetics-wiener",
@@ -1557,7 +1623,8 @@
     "language": "English",
     "shortDescription": "Proposed Hebbian learning: 'neurons that fire together wire together'",
     "wikipediaTitle": "The_Organization_of_Behavior",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q7755339"
   },
   {
     "id": "object-design-brain-ashby",
@@ -1653,7 +1720,8 @@
     "language": "English",
     "shortDescription": "Foundational text for systems theory",
     "wikipediaTitle": "General_System_Theory",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q269699"
   },
   {
     "id": "object-cybernetics-management-beer",
@@ -1681,7 +1749,8 @@
     "language": "English",
     "shortDescription": "Presented the Viable System Model (VSM)",
     "wikipediaTitle": "Brain_of_the_Firm",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q140611064"
   },
   {
     "id": "object-industrial-dynamics-forrester",
@@ -1766,7 +1835,8 @@
     "language": "English",
     "shortDescription": "Proposed enaction—cognition as embodied action",
     "wikipediaTitle": "The_Embodied_Mind",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q1335050"
   },
   {
     "id": "object-edvac-report-neumann",
@@ -1833,7 +1903,8 @@
         "url": "https://en.wikipedia.org/wiki/I._J._Good"
       }
     ],
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q56594306"
   },
   {
     "id": "object-dartmouth-proposal",
@@ -1874,7 +1945,8 @@
         "url": "https://en.wikipedia.org/wiki/Man-Computer_Symbiosis"
       }
     ],
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q20650478"
   },
   {
     "id": "object-programs-common-sense-mccarthy",
@@ -2050,7 +2122,8 @@
     },
     "shortDescription": "Major center for cybernetics, information theory, and AI research",
     "wikipediaTitle": "Massachusetts_Institute_of_Technology",
-    "wikidataId": "Q49108"
+    "wikidataId": "Q49108",
+    "dateStart": "1861"
   },
   {
     "id": "location-bell-labs",
@@ -2064,7 +2137,8 @@
     },
     "shortDescription": "Birthplace of information theory",
     "wikipediaTitle": "Bell_Labs",
-    "wikidataId": "Q217365"
+    "wikidataId": "Q217365",
+    "dateStart": "1925"
   },
   {
     "id": "location-ias-princeton",
@@ -2078,7 +2152,8 @@
     },
     "shortDescription": "Where von Neumann built the IAS computer",
     "wikipediaTitle": "Institute_for_Advanced_Study",
-    "wikidataId": "Q635642"
+    "wikidataId": "Q635642",
+    "dateStart": "1930"
   },
   {
     "id": "location-bcl-illinois",
@@ -2108,7 +2183,8 @@
     },
     "shortDescription": "Home of the Newell-Simon AI collaboration",
     "wikipediaTitle": "Carnegie_Mellon_University",
-    "wikidataId": "Q190080"
+    "wikidataId": "Q190080",
+    "dateStart": "1900"
   },
   {
     "id": "location-stanford",
@@ -2122,7 +2198,8 @@
     },
     "shortDescription": "Home of Stanford AI Lab",
     "wikipediaTitle": "Stanford_University",
-    "wikidataId": "Q41506"
+    "wikidataId": "Q41506",
+    "dateStart": "1885"
   },
   {
     "id": "location-sri",
@@ -2136,7 +2213,8 @@
     },
     "shortDescription": "Where Engelbart developed the Mother of All Demos",
     "wikipediaTitle": "SRI_International",
-    "wikidataId": "Q604924"
+    "wikidataId": "Q604924",
+    "dateStart": "1946"
   },
   {
     "id": "location-cambridge",
@@ -2150,7 +2228,8 @@
     },
     "shortDescription": "Where Turing studied and Wilkes built EDSAC",
     "wikipediaTitle": "University_of_Cambridge",
-    "wikidataId": "Q35794"
+    "wikidataId": "Q35794",
+    "dateStart": "1209"
   },
   {
     "id": "location-manchester",
@@ -2164,7 +2243,8 @@
     },
     "shortDescription": "Where Turing worked on early computers",
     "wikipediaTitle": "University_of_Manchester",
-    "wikidataId": "Q230899"
+    "wikidataId": "Q230899",
+    "dateStart": "1824"
   },
   {
     "id": "location-bletchley-park",
@@ -2194,7 +2274,8 @@
     },
     "shortDescription": "Where Turing designed ACE computer",
     "wikipediaTitle": "National_Physical_Laboratory_(United_Kingdom)",
-    "wikidataId": "Q1967606"
+    "wikidataId": "Q1967606",
+    "dateStart": "1900"
   },
   {
     "id": "location-burden-institute",
@@ -2208,7 +2289,9 @@
     },
     "shortDescription": "Where Grey Walter built tortoise robots",
     "wikipediaTitle": "Burden_Neurological_Institute",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q7618485",
+    "dateStart": "1909"
   },
   {
     "id": "location-barnwood-house",
@@ -2224,7 +2307,9 @@
     },
     "shortDescription": "Where Ashby built the Homeostat",
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q4862031",
+    "wikipediaTitle": "Barnwood_House_Hospital"
   },
   {
     "id": "location-beekman-hotel",
@@ -2254,7 +2339,8 @@
     },
     "shortDescription": "Site of the 1956 conference that launched AI",
     "wikipediaTitle": "Dartmouth_College",
-    "wikidataId": "Q49116"
+    "wikidataId": "Q49116",
+    "dateStart": "1769"
   },
   {
     "id": "location-ratio-club-london",
@@ -2284,7 +2370,8 @@
     },
     "shortDescription": "Where autopoiesis was developed",
     "wikipediaTitle": "University_of_Chile",
-    "wikidataId": "Q232141"
+    "wikidataId": "Q232141",
+    "dateStart": "1842"
   },
   {
     "id": "location-opsroom-chile",
@@ -2314,7 +2401,8 @@
     },
     "shortDescription": "Home of Boltzmann, von Bertalanffy, and precursor ideas",
     "wikipediaTitle": "Vienna",
-    "wikidataId": "Q1741"
+    "wikidataId": "Q1741",
+    "dateStart": "-100"
   },
   {
     "id": "location-mcgill",
@@ -2328,7 +2416,8 @@
     },
     "shortDescription": "Where Hebb developed his theory of neural learning",
     "wikipediaTitle": "McGill_University",
-    "wikidataId": "Q201492"
+    "wikidataId": "Q201492",
+    "dateStart": "1821"
   },
   {
     "id": "location-michigan",
@@ -2342,7 +2431,8 @@
     },
     "shortDescription": "Home of general systems theory founders",
     "wikipediaTitle": "University_of_Michigan",
-    "wikidataId": "Q230492"
+    "wikidataId": "Q230492",
+    "dateStart": "1817"
   },
   {
     "id": "location-moore-school",
@@ -2356,7 +2446,8 @@
     },
     "shortDescription": "Where ENIAC was built",
     "wikipediaTitle": "Moore_School_of_Electrical_Engineering",
-    "wikidataId": "Q6908229"
+    "wikidataId": "Q6908229",
+    "dateStart": "1923"
   },
   {
     "id": "location-rand",
@@ -2370,7 +2461,8 @@
     },
     "shortDescription": "Defense think tank where early AI work was conducted",
     "wikipediaTitle": "RAND_Corporation",
-    "wikidataId": "Q861141"
+    "wikidataId": "Q861141",
+    "dateStart": "1948"
   },
   {
     "id": "location-cornell-aero",
@@ -2386,7 +2478,8 @@
     },
     "shortDescription": "Where Rosenblatt developed the perceptron",
     "wikipediaTitle": "Cornell_Aeronautical_Laboratory",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q5023963"
   },
   {
     "id": "location-los-alamos",
@@ -2400,7 +2493,8 @@
     },
     "shortDescription": "Manhattan Project site where von Neumann contributed",
     "wikipediaTitle": "Los_Alamos_National_Laboratory",
-    "wikidataId": "Q379848"
+    "wikidataId": "Q379848",
+    "dateStart": "1943"
   },
   {
     "id": "location-harvard",
@@ -2414,7 +2508,8 @@
     },
     "shortDescription": "Where Cannon developed homeostasis; Wiener's PhD",
     "wikipediaTitle": "Harvard_University",
-    "wikidataId": "Q13371"
+    "wikidataId": "Q13371",
+    "dateStart": "1636"
   },
   {
     "id": "entity-macy-conferences",
@@ -2518,7 +2613,8 @@
     "dateStart": "1963",
     "shortDescription": "West Coast AI research center founded by McCarthy",
     "wikipediaTitle": "Stanford_Artificial_Intelligence_Laboratory",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q2931153"
   },
   {
     "id": "entity-bell-labs-research",

--- a/public/datasets/enlightenment/enrich-ambiguous.json
+++ b/public/datasets/enlightenment/enrich-ambiguous.json
@@ -1,0 +1,304 @@
+[
+  {
+    "nodeId": "object-traite-dynamique",
+    "title": "Traité de dynamique",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Traité_de_Dynamique\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-essay-origin-knowledge",
+    "title": "Essay on the Origin of Human Knowledge",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Essay_on_the_Origin_of_Human_Knowledge\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-natural-history-soul",
+    "title": "Natural History of the Soul",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Natural History of the Soul\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-treatise-sensations",
+    "title": "Treatise on Sensations",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Treatise_on_Sensations\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-reflections-wealth",
+    "title": "Reflections on the Formation and Distribution of Wealth",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Reflections_on_the_Formation_and_Distribution_of_Riches\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-inquiry-beauty-virtue",
+    "title": "Inquiry into the Original of Our Ideas of Beauty and Virtue",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"An_Inquiry_into_the_Original_of_Our_Ideas_of_Beauty_and_Virtue\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-essays-morality-religion",
+    "title": "Essays on the Principles of Morality and Natural Religion",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Essays on the Principles of Morality and Natural Religion\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-history-scotland",
+    "title": "History of Scotland",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"History_of_Scotland_(Robertson)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-elements-criticism",
+    "title": "Elements of Criticism",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Elements_of_Criticism\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-inquiry-common-sense",
+    "title": "Inquiry into the Human Mind on the Principles of Common Sense",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Inquiry_into_the_Human_Mind\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-german-logic",
+    "title": "Rational Thoughts on God, the World, and the Soul of Man",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Rational Thoughts on God, the World, and the Soul of Man\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-metaphysica",
+    "title": "Metaphysica",
+    "type": "object",
+    "reason": "multiple-candidates",
+    "note": "5 Wikidata candidates for \"Metaphysica\"",
+    "candidates": [
+      {
+        "wikidataId": "Q15761526",
+        "label": "Metaphysica",
+        "description": "journal"
+      },
+      {
+        "wikidataId": "Q753683",
+        "label": "metaphysical painting",
+        "description": "painting movement"
+      },
+      {
+        "wikidataId": "Q56000",
+        "label": "naturalism",
+        "description": "belief that only natural laws, entities and forces operate in the universe"
+      },
+      {
+        "wikidataId": "Q35277",
+        "label": "metaphysics",
+        "description": "branch of philosophy dealing with the nature, structure, components and fundamental principles of reality"
+      },
+      {
+        "wikidataId": "Q3551307",
+        "label": "universals",
+        "description": "in metaphysics, repeatable or recurrent qualities that can be instantiated or exemplified by many particular things"
+      }
+    ]
+  },
+  {
+    "nodeId": "object-laocoon",
+    "title": "Laocoon: An Essay on the Limits of Painting and Poetry",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Laocoön_(essay)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-phadon",
+    "title": "Phädon",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Phädon\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-treatise-origin-language",
+    "title": "Treatise on the Origin of Language",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Treatise_on_the_Origin_of_Language\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-what-is-enlightenment",
+    "title": "What is Enlightenment?",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Answering_the_Question:_What_Is_Enlightenment%3F\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-ideas-philosophy-history",
+    "title": "Ideas for the Philosophy of History of Humanity",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Outlines_of_a_Philosophy_of_the_History_of_Man\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-institutions-physique",
+    "title": "Institutions de physique",
+    "type": "object",
+    "reason": "multiple-candidates",
+    "note": "2 Wikidata candidates for \"Institutions de physique\"",
+    "candidates": [
+      {
+        "wikidataId": "Q109039680",
+        "label": "Institutions de Physique",
+        "description": "Historical science text in French"
+      },
+      {
+        "wikidataId": "Q132188171",
+        "label": "Institutions de physique"
+      }
+    ]
+  },
+  {
+    "nodeId": "object-principia-translation",
+    "title": "French Translation of Newton's Principia",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"French Translation of Newton's Principia\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-salon-geoffrin",
+    "title": "Salon of Madame Geoffrin",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Salon of Madame Geoffrin\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-salon-holbach",
+    "title": "Salon of Baron d'Holbach",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Salon of Baron d'Holbach\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-salon-lespinasse",
+    "title": "Salon of Julie de Lespinasse",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Salon of Julie de Lespinasse\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-salon-deffand",
+    "title": "Salon of Madame du Deffand",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Salon of Madame du Deffand\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-salon-helvetius",
+    "title": "Salon of Madame Helvétius",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Salon of Madame Helvétius\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-amsterdam-publishing",
+    "title": "Amsterdam Publishing Houses",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Amsterdam Publishing Houses\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-london-publishing",
+    "title": "London Publishing (Fleet Street)",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"London Publishing (Fleet Street)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-geneva-publishing",
+    "title": "Geneva Publishing",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Geneva Publishing\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-holbach-circle",
+    "title": "D'Holbach's Circle",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"D'Holbach's Circle\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-edinburgh-literati",
+    "title": "Edinburgh Literati",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Edinburgh Literati\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-ephemerides",
+    "title": "Éphémérides du citoyen",
+    "type": "entity",
+    "reason": "multiple-candidates",
+    "note": "2 Wikidata candidates for \"Éphémérides du citoyen\"",
+    "candidates": [
+      {
+        "wikidataId": "Q17357427",
+        "label": "Éphémérides du citoyen",
+        "description": "newspaper"
+      },
+      {
+        "wikidataId": "Q19168338",
+        "label": "Éphémérides du Citoyen"
+      }
+    ]
+  },
+  {
+    "nodeId": "entity-criminal-justice-reform",
+    "title": "Criminal Justice Reform Movement",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Criminal Justice Reform Movement\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-enlightenment-atheism",
+    "title": "Enlightenment Atheism",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Enlightenment Atheism\"",
+    "candidates": []
+  }
+]

--- a/public/datasets/enlightenment/nodes.json
+++ b/public/datasets/enlightenment/nodes.json
@@ -268,7 +268,8 @@
     ],
     "nationality": "French",
     "wikipediaTitle": "Étienne_Noël_Damilaville",
-    "wikidataId": "Q3592308"
+    "wikidataId": "Q3592308",
+    "birthPlace": "Bordeaux"
   },
   {
     "id": "person-morellet",
@@ -1225,7 +1226,9 @@
     "language": "French",
     "subject": "Natural philosophy",
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q3721351",
+    "wikipediaTitle": "Elements_of_the_Philosophy_of_Newton"
   },
   {
     "id": "object-traite-dynamique",
@@ -1402,7 +1405,8 @@
     "language": "French",
     "subject": "Moral philosophy",
     "wikipediaTitle": "De_l'esprit",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q190302"
   },
   {
     "id": "object-tableau-economique",
@@ -1456,7 +1460,9 @@
     "language": "French",
     "subject": "Religious criticism",
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q1171098",
+    "wikipediaTitle": "Christianity_Unveiled"
   },
   {
     "id": "object-social-contract",
@@ -1588,7 +1594,8 @@
     "language": "English",
     "subject": "Philosophy",
     "wikipediaTitle": "Three_Dialogues_between_Hylas_and_Philonous",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q3110883"
   },
   {
     "id": "object-inquiry-beauty-virtue",
@@ -1951,7 +1958,8 @@
     "language": "German",
     "subject": "Political philosophy, Theology",
     "wikipediaTitle": "Jerusalem_(Mendelssohn)",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q6185071"
   },
   {
     "id": "object-what-is-enlightenment",
@@ -2209,7 +2217,8 @@
     "language": "French",
     "subject": "Mathematics, Political science",
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q42189328"
   },
   {
     "id": "location-paris",
@@ -2219,7 +2228,8 @@
     "locationType": "city",
     "country": "France",
     "wikipediaTitle": "Paris",
-    "wikidataId": "Q90"
+    "wikidataId": "Q90",
+    "dateStart": "-300"
   },
   {
     "id": "location-edinburgh",
@@ -2229,7 +2239,8 @@
     "locationType": "city",
     "country": "Scotland",
     "wikipediaTitle": "Edinburgh",
-    "wikidataId": "Q23436"
+    "wikidataId": "Q23436",
+    "dateStart": "601"
   },
   {
     "id": "location-london",
@@ -2239,7 +2250,8 @@
     "locationType": "city",
     "country": "England",
     "wikipediaTitle": "London",
-    "wikidataId": "Q84"
+    "wikidataId": "Q84",
+    "dateStart": "47"
   },
   {
     "id": "location-berlin",
@@ -2249,7 +2261,8 @@
     "locationType": "city",
     "country": "Prussia",
     "wikipediaTitle": "Berlin",
-    "wikidataId": "Q64"
+    "wikidataId": "Q64",
+    "dateStart": "1244"
   },
   {
     "id": "location-geneva",
@@ -2269,7 +2282,8 @@
     "locationType": "city",
     "country": "Dutch Republic",
     "wikipediaTitle": "Amsterdam",
-    "wikidataId": "Q727"
+    "wikidataId": "Q727",
+    "dateStart": "1300"
   },
   {
     "id": "location-glasgow",
@@ -2289,7 +2303,8 @@
     "locationType": "city",
     "country": "United States",
     "wikipediaTitle": "Philadelphia",
-    "wikidataId": "Q1345"
+    "wikidataId": "Q1345",
+    "dateStart": "1682"
   },
   {
     "id": "location-konigsberg",
@@ -2299,7 +2314,8 @@
     "locationType": "city",
     "country": "Prussia",
     "wikipediaTitle": "Königsberg",
-    "wikidataId": "Q4120832"
+    "wikidataId": "Q4120832",
+    "dateStart": "1255"
   },
   {
     "id": "location-vienna",
@@ -2309,7 +2325,8 @@
     "locationType": "city",
     "country": "Habsburg Empire",
     "wikipediaTitle": "Vienna",
-    "wikidataId": "Q1741"
+    "wikidataId": "Q1741",
+    "dateStart": "-100"
   },
   {
     "id": "location-st-petersburg",
@@ -2319,7 +2336,8 @@
     "locationType": "city",
     "country": "Russia",
     "wikipediaTitle": "Saint_Petersburg",
-    "wikidataId": "Q656"
+    "wikidataId": "Q656",
+    "dateStart": "1703"
   },
   {
     "id": "location-milan",
@@ -2329,7 +2347,8 @@
     "locationType": "city",
     "country": "Habsburg Italy",
     "wikipediaTitle": "Milan",
-    "wikidataId": "Q490"
+    "wikidataId": "Q490",
+    "dateStart": "-600"
   },
   {
     "id": "location-univ-edinburgh",
@@ -2340,7 +2359,8 @@
     "country": "Scotland",
     "parentLocation": "location-edinburgh",
     "wikipediaTitle": "University_of_Edinburgh",
-    "wikidataId": "Q160302"
+    "wikidataId": "Q160302",
+    "dateStart": "1583"
   },
   {
     "id": "location-univ-glasgow",
@@ -2351,7 +2371,8 @@
     "country": "Scotland",
     "parentLocation": "location-glasgow",
     "wikipediaTitle": "University_of_Glasgow",
-    "wikidataId": "Q192775"
+    "wikidataId": "Q192775",
+    "dateStart": "1451"
   },
   {
     "id": "location-cambridge",
@@ -2361,7 +2382,8 @@
     "locationType": "university",
     "country": "England",
     "wikipediaTitle": "University_of_Cambridge",
-    "wikidataId": "Q35794"
+    "wikidataId": "Q35794",
+    "dateStart": "1209"
   },
   {
     "id": "location-univ-halle",
@@ -2371,7 +2393,9 @@
     "locationType": "university",
     "country": "Prussia",
     "wikipediaTitle": "University_of_Halle",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q32120",
+    "dateStart": "1502"
   },
   {
     "id": "location-univ-konigsberg",
@@ -2382,7 +2406,8 @@
     "country": "Prussia",
     "parentLocation": "location-konigsberg",
     "wikipediaTitle": "University_of_Königsberg",
-    "wikidataId": "Q672420"
+    "wikidataId": "Q672420",
+    "dateStart": "1544"
   },
   {
     "id": "location-sorbonne",
@@ -2393,7 +2418,8 @@
     "country": "France",
     "parentLocation": "location-paris",
     "wikipediaTitle": "University_of_Paris",
-    "wikidataId": "Q209842"
+    "wikidataId": "Q209842",
+    "dateStart": "1150"
   },
   {
     "id": "location-academie-francaise",
@@ -2404,7 +2430,8 @@
     "country": "France",
     "parentLocation": "location-paris",
     "wikipediaTitle": "Académie_Française",
-    "wikidataId": "Q161806"
+    "wikidataId": "Q161806",
+    "dateStart": "1635"
   },
   {
     "id": "location-academie-sciences",
@@ -2415,7 +2442,8 @@
     "country": "France",
     "parentLocation": "location-paris",
     "wikipediaTitle": "French_Academy_of_Sciences",
-    "wikidataId": "Q188771"
+    "wikidataId": "Q188771",
+    "dateStart": "1666"
   },
   {
     "id": "location-berlin-academy",
@@ -2426,7 +2454,8 @@
     "country": "Prussia",
     "parentLocation": "location-berlin",
     "wikipediaTitle": "Prussian_Academy_of_Sciences",
-    "wikidataId": "Q329464"
+    "wikidataId": "Q329464",
+    "dateStart": "1700"
   },
   {
     "id": "location-royal-society",
@@ -2437,7 +2466,8 @@
     "country": "England",
     "parentLocation": "location-london",
     "wikipediaTitle": "Royal_Society",
-    "wikidataId": "Q123885"
+    "wikidataId": "Q123885",
+    "dateStart": "1660"
   },
   {
     "id": "location-amer-phil-society",
@@ -2448,7 +2478,8 @@
     "country": "United States",
     "parentLocation": "location-philadelphia",
     "wikipediaTitle": "American_Philosophical_Society",
-    "wikidataId": "Q466089"
+    "wikidataId": "Q466089",
+    "dateStart": "1743"
   },
   {
     "id": "location-academie-bordeaux",
@@ -2522,7 +2553,8 @@
     "locationType": "palace",
     "country": "Prussia",
     "wikipediaTitle": "Sanssouci",
-    "wikidataId": "Q151330"
+    "wikidataId": "Q151330",
+    "dateStart": "1745"
   },
   {
     "id": "location-versailles",
@@ -2532,7 +2564,8 @@
     "locationType": "palace",
     "country": "France",
     "wikipediaTitle": "Palace_of_Versailles",
-    "wikidataId": "Q2946"
+    "wikidataId": "Q2946",
+    "dateStart": "1661"
   },
   {
     "id": "location-ferney",
@@ -2563,7 +2596,8 @@
     "country": "Russia",
     "parentLocation": "location-st-petersburg",
     "wikipediaTitle": "Winter_Palace",
-    "wikidataId": "Q182147"
+    "wikidataId": "Q182147",
+    "dateStart": "1754"
   },
   {
     "id": "location-amsterdam-publishing",
@@ -2609,7 +2643,8 @@
     "country": "Scotland",
     "parentLocation": "location-edinburgh",
     "wikipediaTitle": "Select_Society",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q10369531"
   },
   {
     "id": "location-poker-club",
@@ -2634,7 +2669,8 @@
     "country": "Scotland",
     "parentLocation": "location-edinburgh",
     "wikipediaTitle": "Rankenian_Club",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q16931535"
   },
   {
     "id": "location-cafe-procope",
@@ -2645,7 +2681,8 @@
     "country": "France",
     "parentLocation": "location-paris",
     "wikipediaTitle": "Café_Procope",
-    "wikidataId": "Q751293"
+    "wikidataId": "Q751293",
+    "dateStart": "1686"
   },
   {
     "id": "entity-encyclopedie-project",
@@ -2786,7 +2823,8 @@
     "dateEnd": "1789",
     "entityType": "intellectual tendency",
     "wikipediaTitle": "Radical_Enlightenment",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q12539"
   },
   {
     "id": "entity-academie-francaise",
@@ -2933,7 +2971,8 @@
     "shortDescription": "Central Enlightenment cause",
     "entityType": "reform movement",
     "wikipediaTitle": "Religious_toleration",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q2086472"
   },
   {
     "id": "entity-criminal-justice-reform",
@@ -2986,7 +3025,8 @@
     "shortDescription": "Reconciling Christianity with Enlightenment values",
     "entityType": "religious tendency",
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q119038249"
   },
   {
     "id": "entity-united-states",

--- a/public/datasets/florentine-academy/enrich-ambiguous.json
+++ b/public/datasets/florentine-academy/enrich-ambiguous.json
@@ -1,0 +1,86 @@
+[
+  {
+    "nodeId": "person-giovanni-cavalcanti",
+    "title": "Giovanni Cavalcanti",
+    "type": "person",
+    "reason": "multiple-candidates",
+    "note": "5 Wikidata candidates for \"Giovanni Cavalcanti\"",
+    "candidates": [
+      {
+        "wikidataId": "Q104355656",
+        "label": "Giovanni Cavalcanti",
+        "description": "Florentine humanist"
+      },
+      {
+        "wikidataId": "Q3107131",
+        "label": "Giovanni Cavalcanti",
+        "description": "Italian bicycle racer"
+      },
+      {
+        "wikidataId": "Q3766991",
+        "label": "Giovanni Cavalcanti",
+        "description": "Florentine historian"
+      },
+      {
+        "wikidataId": "Q61704529",
+        "label": "Giovanni Cavalcanti",
+        "description": "1370-"
+      },
+      {
+        "wikidataId": "Q11752082",
+        "label": "Giovanni Cavalcanti",
+        "description": "Wikimedia disambiguation page"
+      }
+    ]
+  },
+  {
+    "nodeId": "person-giovanni-corsi",
+    "title": "Giovanni Corsi",
+    "type": "person",
+    "reason": "multiple-candidates",
+    "note": "5 Wikidata candidates for \"Giovanni Corsi\"",
+    "candidates": [
+      {
+        "wikidataId": "Q110386394",
+        "label": "Giovanni Corsi",
+        "description": "1519-1570"
+      },
+      {
+        "wikidataId": "Q5564033",
+        "label": "Giovanni di Bardo Corsi",
+        "description": "politician"
+      },
+      {
+        "wikidataId": "Q4234319",
+        "label": "Giovanni Corsi",
+        "description": "Italian singer and opera singer (1822–1890)"
+      },
+      {
+        "wikidataId": "Q21670076",
+        "label": "Giovanni Corsi",
+        "description": "Italian politician (1867-1953)"
+      },
+      {
+        "wikidataId": "Q106972004",
+        "label": "Giovanni Corsi",
+        "description": "Italian nobleman"
+      }
+    ]
+  },
+  {
+    "nodeId": "object-platonis-opera-omnia",
+    "title": "Platonis Opera Omnia (Complete Works of Plato)",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Platonis Opera Omnia (Complete Works of Plato)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-comento-sopra-divina-commedia",
+    "title": "Comento sopra la Divina Commedia",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Comento sopra la Divina Commedia\"",
+    "candidates": []
+  }
+]

--- a/public/datasets/protestant-reformation/enrich-ambiguous.json
+++ b/public/datasets/protestant-reformation/enrich-ambiguous.json
@@ -1,0 +1,195 @@
+[
+  {
+    "nodeId": "person-caspar-cruciger",
+    "title": "Caspar Cruciger the Elder",
+    "type": "person",
+    "reason": "id-mismatch",
+    "note": "Resolved Q67132 (\"Caspar Creuziger\") does not match \"Caspar Cruciger the Elder\"",
+    "existingWikidataId": "Q67132",
+    "candidates": [
+      {
+        "wikidataId": "Q67132",
+        "label": "Caspar Creuziger",
+        "description": "German humanist"
+      }
+    ]
+  },
+  {
+    "nodeId": "person-pierre-robert-olivetan",
+    "title": "Pierre Robert Olivétan",
+    "type": "person",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Olivétan\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "person-jacques-lefevre-detaples",
+    "title": "Jacques Lefèvre d'Étaples",
+    "type": "person",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Jacques_Lefèvre_d%27Étaples\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-sixty-seven-articles",
+    "title": "Sixty-Seven Articles",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Sixty-seven_Articles\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-true-false-religion",
+    "title": "Commentary on True and False Religion",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Commentary on True and False Religion\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-olivetan-bible",
+    "title": "Olivétan's French Bible",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Olivétan_Bible\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-small-catechism",
+    "title": "Small Catechism",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Luther%27s_Small_Catechism\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-large-catechism",
+    "title": "Large Catechism",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Luther%27s_Large_Catechism\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-strasbourg-liturgy",
+    "title": "Strasbourg Liturgy",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Strasbourg Liturgy\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-book-of-martyrs",
+    "title": "Actes and Monuments (Book of Martyrs)",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Foxe%27s_Book_of_Martyrs\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-erasmus-correspondence",
+    "title": "Erasmus's Correspondence",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Erasmus's Correspondence\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-luther-correspondence",
+    "title": "Luther's Correspondence",
+    "type": "object",
+    "reason": "multiple-candidates",
+    "note": "2 Wikidata candidates for \"Luther's Correspondence\"",
+    "candidates": [
+      {
+        "wikidataId": "Q19104154",
+        "label": "Luther's correspondence and other contemporary letters"
+      },
+      {
+        "wikidataId": "Q107781362",
+        "label": "Luther's correspondence and other contemporary letters",
+        "description": "English translation of letters by Martin Luther and his contemporaries"
+      }
+    ]
+  },
+  {
+    "nodeId": "object-bullinger-correspondence",
+    "title": "Bullinger's Correspondence",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Bullinger's Correspondence\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-castle-church-wittenberg",
+    "title": "Castle Church (Schlosskirche)",
+    "type": "location",
+    "reason": "not-found",
+    "note": "Wikipedia page \"All_Saints%27_Church,_Wittenberg\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-st-pierre-geneva",
+    "title": "St. Pierre Cathedral",
+    "type": "location",
+    "reason": "not-found",
+    "note": "Wikipedia page \"St._Pierre_Cathedral,_Geneva\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-st-giles-edinburgh",
+    "title": "St. Giles' Cathedral",
+    "type": "location",
+    "reason": "not-found",
+    "note": "Wikipedia page \"St_Giles%27_Cathedral\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-zurich-church",
+    "title": "Reformed Church of Zurich",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Reformed_Church_in_Zürich\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-geneva-church",
+    "title": "Genevan Reformed Church",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Genevan Reformed Church\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-meaux-circle",
+    "title": "Meaux Circle",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Circle_of_Meaux\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-zurich-disputation-1523",
+    "title": "First Zurich Disputation",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "Wikipedia page \"First_Disputation_of_Zurich\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-wittenberg-printers",
+    "title": "Wittenberg Printing Network",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Wittenberg Printing Network\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-geneva-printers",
+    "title": "Geneva Printing Network",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Geneva Printing Network\"",
+    "candidates": []
+  }
+]

--- a/public/datasets/protestant-reformation/nodes.json
+++ b/public/datasets/protestant-reformation/nodes.json
@@ -224,7 +224,8 @@
     "deathPlace": "Altenburg, Germany",
     "nationality": "German",
     "wikipediaTitle": "Georg_Spalatin",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q65368"
   },
   {
     "id": "person-andreas-karlstadt",
@@ -299,7 +300,8 @@
     "deathPlace": "Berlin, Germany",
     "nationality": "German",
     "wikipediaTitle": "Johann_Agricola",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q76554"
   },
   {
     "id": "person-thomas-muntzer",
@@ -638,7 +640,8 @@
     "deathPlace": "London, England",
     "nationality": "English",
     "wikipediaTitle": "Miles_Coverdale",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q778508"
   },
   {
     "id": "person-john-foxe",
@@ -1491,7 +1494,8 @@
       }
     ],
     "wikipediaTitle": "Loci_Communes",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q1542696"
   },
   {
     "id": "object-obedience-christian-man",
@@ -1647,7 +1651,8 @@
       "person-huldrych-zwingli"
     ],
     "wikipediaTitle": "Froschauer_Bible",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q248436"
   },
   {
     "id": "object-augsburg-confession",
@@ -1736,7 +1741,8 @@
       "person-leo-jud"
     ],
     "wikipediaTitle": "First_Helvetic_Confession",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q676162"
   },
   {
     "id": "object-second-helvetic-confession",
@@ -1764,7 +1770,8 @@
       "person-john-calvin"
     ],
     "wikipediaTitle": "Genevan_Catechism",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q189279"
   },
   {
     "id": "object-heidelberg-catechism",
@@ -1923,7 +1930,8 @@
       "person-erasmus-of-rotterdam"
     ],
     "wikipediaTitle": "The_Praise_of_Folly",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q569869"
   },
   {
     "id": "object-enchiridion",
@@ -1940,7 +1948,8 @@
       "person-erasmus-of-rotterdam"
     ],
     "wikipediaTitle": "Enchiridion_militis_Christiani",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q1340009"
   },
   {
     "id": "object-first-blast",
@@ -2025,7 +2034,8 @@
     "parentLocation": "location-wittenberg",
     "dateStart": "1502",
     "wikipediaTitle": "University_of_Wittenberg",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q32120"
   },
   {
     "id": "location-castle-church-wittenberg",
@@ -2050,7 +2060,8 @@
       "lng": 8.3507
     },
     "wikipediaTitle": "Worms,_Germany",
-    "wikidataId": "Q3852"
+    "wikidataId": "Q3852",
+    "dateStart": "-100"
   },
   {
     "id": "location-augsburg",
@@ -2064,7 +2075,8 @@
       "lng": 10.8978
     },
     "wikipediaTitle": "Augsburg",
-    "wikidataId": "Q2749"
+    "wikidataId": "Q2749",
+    "dateStart": "-15"
   },
   {
     "id": "location-marburg",
@@ -2078,7 +2090,8 @@
       "lng": 8.7670
     },
     "wikipediaTitle": "Marburg",
-    "wikidataId": "Q3869"
+    "wikidataId": "Q3869",
+    "dateStart": "1140"
   },
   {
     "id": "location-marburg-university",
@@ -2090,7 +2103,8 @@
     "parentLocation": "location-marburg",
     "dateStart": "1527",
     "wikipediaTitle": "University_of_Marburg",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q155354"
   },
   {
     "id": "location-nuremberg",
@@ -2132,7 +2146,8 @@
       "lng": 10.3067
     },
     "wikipediaTitle": "Wartburg",
-    "wikidataId": "Q151545"
+    "wikidataId": "Q151545",
+    "dateStart": "1067"
   },
   {
     "id": "location-erfurt",
@@ -2146,7 +2161,8 @@
       "lng": 11.0299
     },
     "wikipediaTitle": "Erfurt",
-    "wikidataId": "Q1729"
+    "wikidataId": "Q1729",
+    "dateStart": "742"
   },
   {
     "id": "location-muhlhausen",
@@ -2174,7 +2190,9 @@
       "lng": 8.5417
     },
     "wikipediaTitle": "Zürich",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q72",
+    "dateStart": "200"
   },
   {
     "id": "location-grossmunster",
@@ -2185,7 +2203,8 @@
     "country": "Switzerland",
     "parentLocation": "location-zurich",
     "wikipediaTitle": "Grossmünster",
-    "wikidataId": "Q684948"
+    "wikidataId": "Q684948",
+    "dateStart": "1201"
   },
   {
     "id": "location-geneva",
@@ -2262,7 +2281,8 @@
       "lng": 7.4474
     },
     "wikipediaTitle": "Bern",
-    "wikidataId": "Q70"
+    "wikidataId": "Q70",
+    "dateStart": "1191"
   },
   {
     "id": "location-lausanne",
@@ -2290,7 +2310,8 @@
       "lng": 7.7521
     },
     "wikipediaTitle": "Strasbourg",
-    "wikidataId": "Q6602"
+    "wikidataId": "Q6602",
+    "dateStart": "-12"
   },
   {
     "id": "location-london",
@@ -2304,7 +2325,8 @@
       "lng": 0.1278
     },
     "wikipediaTitle": "London",
-    "wikidataId": "Q84"
+    "wikidataId": "Q84",
+    "dateStart": "47"
   },
   {
     "id": "location-canterbury",
@@ -2332,7 +2354,8 @@
       "lng": -1.2577
     },
     "wikipediaTitle": "Oxford",
-    "wikidataId": "Q34217"
+    "wikidataId": "Q34217",
+    "dateStart": "1000"
   },
   {
     "id": "location-oxford-university",
@@ -2343,7 +2366,8 @@
     "country": "England",
     "parentLocation": "location-oxford",
     "wikipediaTitle": "University_of_Oxford",
-    "wikidataId": "Q34433"
+    "wikidataId": "Q34433",
+    "dateStart": "1096"
   },
   {
     "id": "location-cambridge",
@@ -2357,7 +2381,8 @@
       "lng": 0.1218
     },
     "wikipediaTitle": "Cambridge",
-    "wikidataId": "Q350"
+    "wikidataId": "Q350",
+    "dateStart": "1"
   },
   {
     "id": "location-cambridge-university",
@@ -2368,7 +2393,8 @@
     "country": "England",
     "parentLocation": "location-cambridge",
     "wikipediaTitle": "University_of_Cambridge",
-    "wikidataId": "Q35794"
+    "wikidataId": "Q35794",
+    "dateStart": "1209"
   },
   {
     "id": "location-white-horse-tavern",
@@ -2384,7 +2410,8 @@
     "dateStart": "1520",
     "dateEnd": "1530",
     "wikipediaTitle": "White_Horse_Inn,_Cambridge",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q15990356"
   },
   {
     "id": "location-antwerp",
@@ -2426,7 +2453,8 @@
       "lng": 2.3522
     },
     "wikipediaTitle": "Paris",
-    "wikidataId": "Q90"
+    "wikidataId": "Q90",
+    "dateStart": "-300"
   },
   {
     "id": "location-sorbonne",
@@ -2437,7 +2465,8 @@
     "country": "France",
     "parentLocation": "location-paris",
     "wikipediaTitle": "University_of_Paris",
-    "wikidataId": "Q209842"
+    "wikidataId": "Q209842",
+    "dateStart": "1150"
   },
   {
     "id": "location-meaux",
@@ -2465,7 +2494,8 @@
       "lng": 12.4964
     },
     "wikipediaTitle": "Rome",
-    "wikidataId": "Q220"
+    "wikidataId": "Q220",
+    "dateStart": "-753"
   },
   {
     "id": "location-ingolstadt",
@@ -2479,7 +2509,8 @@
       "lng": 11.4258
     },
     "wikipediaTitle": "Ingolstadt",
-    "wikidataId": "Q3004"
+    "wikidataId": "Q3004",
+    "dateStart": "1200"
   },
   {
     "id": "location-st-andrews",
@@ -2519,7 +2550,8 @@
       "lng": -3.1883
     },
     "wikipediaTitle": "Edinburgh",
-    "wikidataId": "Q23436"
+    "wikidataId": "Q23436",
+    "dateStart": "601"
   },
   {
     "id": "location-st-giles-edinburgh",
@@ -2544,7 +2576,8 @@
       "lng": 8.5333
     },
     "wikipediaTitle": "Battle_of_Kappel",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q233594"
   },
   {
     "id": "location-schleitheim",
@@ -2640,7 +2673,8 @@
     "dateStart": "1541",
     "headquarters": "location-geneva",
     "wikipediaTitle": "Consistory_of_Geneva",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q2994627"
   },
   {
     "id": "entity-church-of-scotland",
@@ -2672,7 +2706,8 @@
     "entityType": "movement",
     "dateStart": "1519",
     "wikipediaTitle": "Swiss_Reformed_Church",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q338309"
   },
   {
     "id": "entity-radical-reformation",
@@ -2764,7 +2799,8 @@
     "entityType": "political_alliance",
     "dateStart": "1291",
     "wikipediaTitle": "Old_Swiss_Confederacy",
-    "wikidataId": "Q435583"
+    "wikidataId": "Q435583",
+    "dateEnd": "1798"
   },
   {
     "id": "entity-augustinian-order",

--- a/public/datasets/renaissance-humanism/enrich-ambiguous.json
+++ b/public/datasets/renaissance-humanism/enrich-ambiguous.json
@@ -1,0 +1,499 @@
+[
+  {
+    "nodeId": "person-lorenzo-de-medici",
+    "title": "Lorenzo de' Medici",
+    "type": "person",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Lorenzo_de%27_Medici\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "person-niccolo-leonico-tomeo",
+    "title": "Niccolò Leonico Tomeo",
+    "type": "person",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Niccolò_Leonico_Tomeo\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "person-john-fisher",
+    "title": "John Fisher",
+    "type": "person",
+    "reason": "not-found",
+    "note": "Wikipedia page \"John_Fisher_(cardinal)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "person-jacques-lefevre-detaples",
+    "title": "Jacques Lefèvre d'Étaples",
+    "type": "person",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Jacques_Lefèvre_d%27Étaples\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "person-hernan-nunez",
+    "title": "Hernán Núñez de Toledo",
+    "type": "person",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Hernán_Núñez_de_Toledo\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "person-cosimo-de-medici",
+    "title": "Cosimo de' Medici",
+    "type": "person",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Cosimo_de%27_Medici\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-elegantiae",
+    "title": "Elegantiae linguae Latinae",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Elegantiae_linguae_Latinae\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-donation-constantine",
+    "title": "De falso credita et ementita Constantini donatione",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Discourse_on_the_Forgery_of_the_Alleged_Donation_of_Constantine\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-erotemata",
+    "title": "Erotemata",
+    "type": "object",
+    "reason": "multiple-candidates",
+    "note": "5 Wikidata candidates for \"Erotemata\"",
+    "candidates": [
+      {
+        "wikidataId": "Q5395405",
+        "label": "Erotemata",
+        "description": "1471 book on Greek grammar by Manuel Chrysoloras"
+      },
+      {
+        "wikidataId": "Q62052501",
+        "label": "Erotemata",
+        "description": "Bodleian Library Auct. K 4.35"
+      },
+      {
+        "wikidataId": "Q62052502",
+        "label": "Erotemata",
+        "description": "Bodleian Library Auct. K 6.1"
+      },
+      {
+        "wikidataId": "Q124728024",
+        "label": "Erotemata",
+        "description": "work by Zacharias Calliergi"
+      },
+      {
+        "wikidataId": "Q124727927",
+        "label": "Erotemata"
+      }
+    ]
+  },
+  {
+    "nodeId": "object-ficino-plato",
+    "title": "Complete Plato Translations",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Complete Plato Translations\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-theologia-platonica",
+    "title": "Theologia Platonica",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Theologia_Platonica\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-de-amore-ficino",
+    "title": "De amore",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Commentarium_in_Convivium_Platonis_de_Amore\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-900-theses",
+    "title": "900 Theses",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"900_Theses\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-ficino-plotinus",
+    "title": "Plotinus Translation (Enneads)",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Plotinus Translation (Enneads)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-laudatio-florentinae",
+    "title": "Laudatio Florentinae urbis",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Laudatio_Florentinae_urbis\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-storia-italia",
+    "title": "Storia d'Italia",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Storia_d%27Italia_(Guicciardini)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-ricordi",
+    "title": "Ricordi",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Ricordi_(Guicciardini)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-de-ordine-docendi",
+    "title": "De ordine docendi et studendi",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"De ordine docendi et studendi\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-de-inventione-dialectica",
+    "title": "De inventione dialectica",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"De_inventione_dialectica\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-de-tradendis",
+    "title": "De tradendis disciplinis",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"De tradendis disciplinis\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-de-copia",
+    "title": "De copia",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"De_Copia\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-valla-annotations-nt",
+    "title": "Annotations on the New Testament",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Annotations on the New Testament\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-french-bible-lefevre",
+    "title": "French Bible Translation",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"French Bible Translation\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-arcadia",
+    "title": "Arcadia",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Arcadia_(Sannazaro)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-stanze-giostra",
+    "title": "Stanze per la giostra",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Stanze_per_la_giostra\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-miscellanea",
+    "title": "Miscellanea",
+    "type": "object",
+    "reason": "multiple-candidates",
+    "note": "5 Wikidata candidates for \"Miscellanea\"",
+    "candidates": [
+      {
+        "wikidataId": "Q23768532",
+        "label": "Miscellanea",
+        "description": "genus of foraminifers"
+      },
+      {
+        "wikidataId": "Q92770553",
+        "label": "Miscellanea zoologica hungarica"
+      },
+      {
+        "wikidataId": "Q1295240",
+        "label": "miscellany",
+        "description": "publishing term; collection of various pieces of writing by different authors"
+      },
+      {
+        "wikidataId": "Q1780486",
+        "label": "miscellanea",
+        "description": "assembly of several literary genre"
+      },
+      {
+        "wikidataId": "Q112057554",
+        "label": "Miscellanea",
+        "description": "Czech book series"
+      }
+    ]
+  },
+  {
+    "nodeId": "object-bruni-aristotle-ethics",
+    "title": "Aristotle's Ethics Translation",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Aristotle's Ethics Translation\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-bruni-aristotle-politics",
+    "title": "Aristotle's Politics Translation",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Aristotle's Politics Translation\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-homer-editio-princeps",
+    "title": "Homer's Iliad (editio princeps)",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Homer's Iliad (editio princeps)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-thesaurus-linguae-latinae",
+    "title": "Thesaurus linguae Latinae",
+    "type": "object",
+    "reason": "multiple-candidates",
+    "note": "5 Wikidata candidates for \"Thesaurus linguae Latinae\"",
+    "candidates": [
+      {
+        "wikidataId": "Q125350474",
+        "label": "Thesaurus Linguae Latinae",
+        "description": "work group"
+      },
+      {
+        "wikidataId": "Q647422",
+        "label": "Thesaurus Linguae Latinae",
+        "description": "monumental dictionary of Latin"
+      },
+      {
+        "wikidataId": "Q55151880",
+        "label": "Thesaurus Linguae Latinae Epigraphicae. A Dictionary of the Latin Inscriptions. By George N. Olcott, Ph.D. Vol. I, fascicules 1–21 (a-aser). 10½ × 7, 504 pp. Rome: Loescher & Co. 1904–1912"
+      },
+      {
+        "wikidataId": "Q59739307",
+        "label": "Thesaurus linguae Latinae epigraphicae. Leslie F. Smith , John H. McLean , Clinton W. Keyes"
+      },
+      {
+        "wikidataId": "Q59731101",
+        "label": "Thesaurus Linguae Latinae Epigraphicae: A Dictionary of the Latin Inscriptions. George N. Olcott"
+      }
+    ]
+  },
+  {
+    "nodeId": "object-della-famiglia",
+    "title": "Della famiglia",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"I_Libri_della_Famiglia\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-italia-illustrata",
+    "title": "Italia illustrata",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Italia_Illustrata\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-pius-commentarii",
+    "title": "Commentarii",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Commentaries_(Pius_II)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-erasmus-letters",
+    "title": "Opus Epistolarum Des. Erasmi",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Opus Epistolarum Des. Erasmi\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-st-pauls-school",
+    "title": "St. Paul's School (London)",
+    "type": "location",
+    "reason": "not-found",
+    "note": "Wikipedia page \"St_Paul%27s_School,_London\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-deventer-school",
+    "title": "Deventer School",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Deventer School\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-strasbourg-gymnasium",
+    "title": "Strasbourg Gymnasium",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Strasbourg Gymnasium\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-selestat-school",
+    "title": "Sélestat School",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Sélestat School\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-froben-press",
+    "title": "Froben Press",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Froben Press\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-estienne-press",
+    "title": "Estienne Press",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Estienne Press\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-court-francis-i",
+    "title": "Court of Francis I",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Court of Francis I\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "location-english-court",
+    "title": "English Court (Henry VIII)",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"English Court (Henry VIII)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-aldine-academy",
+    "title": "Aldine Academy (New Academy)",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Aldine Academy (New Academy)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-collegium-poetarum",
+    "title": "Collegium poetarum (Vienna)",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Collegium poetarum (Vienna)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-german-sodalities",
+    "title": "German Humanist Sodalities",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"German Humanist Sodalities\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-philological-humanism",
+    "title": "Philological Humanism",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Philological Humanism\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-humanist-aristotelianism",
+    "title": "Humanist Aristotelianism",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Renaissance_Aristotelianism\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-froben-press",
+    "title": "Froben Press",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Froben Press\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-estienne-press",
+    "title": "Estienne Press",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Estienne_family\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-casa-giocosa",
+    "title": "Casa Giocosa (Mantua)",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Casa Giocosa (Mantua)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-guarino-school-ferrara",
+    "title": "Guarino's School (Ferrara)",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Guarino's School (Ferrara)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-papal-patronage",
+    "title": "Papal Patronage",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Papal Patronage\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-french-royal-patronage",
+    "title": "French Royal Patronage",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"French Royal Patronage\"",
+    "candidates": []
+  }
+]

--- a/public/datasets/renaissance-humanism/nodes.json
+++ b/public/datasets/renaissance-humanism/nodes.json
@@ -233,7 +233,8 @@
     "birthPlace": "Montepulciano",
     "nationality": "Italian",
     "wikipediaTitle": "Angelo_Poliziano",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q250414"
   },
   {
     "id": "person-lorenzo-de-medici",
@@ -394,7 +395,8 @@
     "birthPlace": "Florence",
     "nationality": "Italian",
     "wikipediaTitle": "Donato_Acciaiuoli",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q1240697"
   },
   {
     "id": "person-giannozzo-manetti",
@@ -463,7 +465,8 @@
     "birthPlace": "Rome",
     "nationality": "Italian",
     "wikipediaTitle": "Giulio_Pomponio_Leto",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q523923"
   },
   {
     "id": "person-bartolomeo-platina",
@@ -590,7 +593,8 @@
     "birthPlace": "Venice",
     "nationality": "Italian",
     "wikipediaTitle": "Ermolao_Barbaro_the_Younger",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q1236821"
   },
   {
     "id": "person-pietro-pomponazzi",
@@ -851,7 +855,8 @@
     "birthPlace": "Groningen",
     "nationality": "Dutch/German",
     "wikipediaTitle": "Rudolf_Agricola",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q365557"
   },
   {
     "id": "person-johannes-reuchlin",
@@ -868,7 +873,8 @@
     "birthPlace": "Pforzheim",
     "nationality": "German",
     "wikipediaTitle": "Johannes_Reuchlin",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q61067"
   },
   {
     "id": "person-conrad-celtis",
@@ -1147,7 +1153,8 @@
     "birthPlace": "Limoges",
     "nationality": "French",
     "wikipediaTitle": "Jean_Dorat",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q714921"
   },
   {
     "id": "person-guarino-da-verona",
@@ -1228,7 +1235,8 @@
     "birthPlace": "Athens",
     "nationality": "Byzantine",
     "wikipediaTitle": "Demetrius_Chalcondyles",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q983661"
   },
   {
     "id": "person-johannes-argyropoulos",
@@ -1294,7 +1302,8 @@
     "birthPlace": "Thessalonica",
     "nationality": "Byzantine",
     "wikipediaTitle": "Theodore_Gaza",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q287485"
   },
   {
     "id": "person-francesco-filelfo",
@@ -1638,7 +1647,8 @@
       }
     ],
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q138333085"
   },
   {
     "id": "object-ficino-plotinus",
@@ -1691,7 +1701,8 @@
       "person-leonardo-bruni"
     ],
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q127513869"
   },
   {
     "id": "object-il-principe",
@@ -1844,7 +1855,8 @@
       }
     ],
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q136609481"
   },
   {
     "id": "object-de-dignitate-manetti",
@@ -1868,7 +1880,8 @@
       }
     ],
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q135423802"
   },
   {
     "id": "object-de-ingenuis-moribus",
@@ -1892,7 +1905,8 @@
       }
     ],
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q42188494"
   },
   {
     "id": "object-de-ordine-docendi",
@@ -2050,7 +2064,8 @@
       }
     ],
     "wikipediaTitle": "Handbook_of_a_Christian_Knight",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q1340009"
   },
   {
     "id": "object-complutensian-polyglot",
@@ -2095,7 +2110,8 @@
       "person-johannes-reuchlin"
     ],
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q42188609"
   },
   {
     "id": "object-de-arte-cabalistica",
@@ -2326,7 +2342,8 @@
       "person-guillaume-bude"
     ],
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q139584268"
   },
   {
     "id": "object-de-pictura",
@@ -2398,7 +2415,8 @@
       }
     ],
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q3704168"
   },
   {
     "id": "object-della-famiglia",
@@ -2437,7 +2455,8 @@
       }
     ],
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q55599373"
   },
   {
     "id": "object-italia-illustrata",
@@ -2475,7 +2494,8 @@
       "person-beatus-rhenanus"
     ],
     "wikipediaTitle": null,
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q37865627"
   },
   {
     "id": "object-pius-commentarii",
@@ -3062,7 +3082,8 @@
       "person-marsilio-ficino"
     ],
     "wikipediaTitle": "Florentine_Academy",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q4585397"
   },
   {
     "id": "entity-roman-academy",
@@ -3077,7 +3098,8 @@
       "person-pomponio-leto"
     ],
     "wikipediaTitle": "Roman_Academy",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q7361569"
   },
   {
     "id": "entity-accademia-pontaniana",
@@ -3159,7 +3181,8 @@
     "dateStart": "1462",
     "dateEnd": "1600",
     "wikipediaTitle": "Renaissance_Neoplatonism",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q7202435"
   },
   {
     "id": "entity-northern-humanism",
@@ -3291,7 +3314,8 @@
     "dateStart": "1434",
     "dateEnd": "1494",
     "wikipediaTitle": "Medici",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q170022"
   },
   {
     "id": "entity-papal-patronage",

--- a/public/datasets/rosicrucian-network/enrich-ambiguous.json
+++ b/public/datasets/rosicrucian-network/enrich-ambiguous.json
@@ -1,0 +1,323 @@
+[
+  {
+    "nodeId": "person-petrus-severinus",
+    "title": "Petrus Severinus",
+    "type": "person",
+    "reason": "id-mismatch",
+    "note": "Resolved Q430754 (\"Peder Soerensen\") does not match \"Petrus Severinus\"",
+    "existingWikidataId": "Q430754",
+    "candidates": [
+      {
+        "wikidataId": "Q430754",
+        "label": "Peder Soerensen",
+        "description": "Danish physician"
+      }
+    ]
+  },
+  {
+    "nodeId": "person-johannes-hartmann",
+    "title": "Johannes Hartmann",
+    "type": "person",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Johannes_Hartmann_(chemist)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "person-raphael-eglin",
+    "title": "Raphael Eglin",
+    "type": "person",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Raphael_Egli\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "person-vilem-rozmberk",
+    "title": "Vilém of Rožmberk",
+    "type": "person",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Vilém_of_Rosenberg\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-aurora",
+    "title": "Aurora",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Aurora_(Boehme)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-true-christianity",
+    "title": "True Christianity",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"True_Christianity_(book)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-amphitheatrum",
+    "title": "Amphitheatrum Sapientiae Aeternae",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Amphitheatrum_Sapientiae_Aeternae\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-basilica-chymica",
+    "title": "Basilica Chymica",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Basilica_chymica\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-utriusque-cosmi",
+    "title": "Utriusque Cosmi Historia",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Utriusque_Cosmi\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-apologia-compendiaria",
+    "title": "Apologia Compendiaria",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Apologia Compendiaria\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-alchymia",
+    "title": "Alchymia",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Alchymia_(Libavius)\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-analysis-confessionis",
+    "title": "Analysis Confessionis Fraternitatis de Rosea Cruce",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Analysis Confessionis Fraternitatis de Rosea Cruce\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-christianopolis",
+    "title": "Christianopolis",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"Christianopolis\" has no linked Wikidata item",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-idea-medicinae",
+    "title": "Idea Medicinae Philosophicae",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Idea Medicinae Philosophicae\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "person-wilhelm-von-wense",
+    "title": "Wilhelm von Wense",
+    "type": "person",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Wilhelm von Wense\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-tubingen-circle",
+    "title": "Tübingen Circle",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Tübingen Circle\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-boehme-circle",
+    "title": "Boehme Circle (Görlitz)",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Boehme Circle (Görlitz)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-manuscript-collector-network",
+    "title": "Manuscript Collector Network",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Manuscript Collector Network\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-heidelberg-circle",
+    "title": "Heidelberg Intellectual Circle",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Heidelberg Intellectual Circle\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-hague-exile-court",
+    "title": "The Hague Exile Court",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"The Hague Exile Court\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-weigelianism",
+    "title": "Weigelianism",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Weigelianism\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-severinian-school",
+    "title": "Severinian Paracelsianism",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Severinian Paracelsianism\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-rosicrucian-furor",
+    "title": "The Rosicrucian Furor",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"The Rosicrucian Furor\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-marburg-laboratory",
+    "title": "Marburg Chemical Laboratory",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Marburg Chemical Laboratory\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-court-rudolf-ii",
+    "title": "Court of Rudolf II",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Court of Rudolf II\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-court-moritz",
+    "title": "Court of Moritz of Hesse-Kassel",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Court of Moritz of Hesse-Kassel\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-court-frederick-v",
+    "title": "Palatine Court (Heidelberg)",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Palatine Court (Heidelberg)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-rozmberk-court",
+    "title": "Rožmberk Court (Třeboň)",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Rožmberk Court (Třeboň)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-leibarzt",
+    "title": "Imperial Court Physician",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Imperial Court Physician\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-professor-chymiatrie",
+    "title": "Professor of Chymiatrie",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Professor of Chymiatrie\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-rosicrucian-emblems-cramer",
+    "title": "The Rosicrucian Emblems of Daniel Cramer",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"The Rosicrucian Emblems of Daniel Cramer\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-via-lucis",
+    "title": "Via Lucis",
+    "type": "object",
+    "reason": "multiple-candidates",
+    "note": "5 Wikidata candidates for \"Via Lucis\"",
+    "candidates": [
+      {
+        "wikidataId": "Q60983044",
+        "label": "Via Lucis"
+      },
+      {
+        "wikidataId": "Q122121584",
+        "label": "Via lucis: Stanislav Libenský a Jaroslava Brychtová pro sakrální prostory v Čechách a na Moravě",
+        "description": "book edition published in 2021"
+      },
+      {
+        "wikidataId": "Q127033515",
+        "label": "VIA LUCIS (Prout)",
+        "description": "hymn tune"
+      },
+      {
+        "wikidataId": "Q127033513",
+        "label": "VIA LUCIS (Best)",
+        "description": "hymn tune"
+      },
+      {
+        "wikidataId": "Q127033514",
+        "label": "VIA LUCIS (Lomas)",
+        "description": "hymn tune"
+      }
+    ]
+  },
+  {
+    "nodeId": "object-holy-guide",
+    "title": "The Holy Guide",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"The Holy Guide\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-reformed-school",
+    "title": "The Reformed School",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"The Reformed School\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-reformed-librarie-keeper",
+    "title": "The Reformed Librarie-Keeper",
+    "type": "object",
+    "reason": "multiple-candidates",
+    "note": "2 Wikidata candidates for \"The Reformed Librarie-Keeper\"",
+    "candidates": [
+      {
+        "wikidataId": "Q70677772",
+        "label": "The Reformed Librarie-Keeper"
+      },
+      {
+        "wikidataId": "Q58637906",
+        "label": "THE REFORMED LIBRARIE-KEEPER: OR Two Copies of Letters concerning the Place and Office of a Librarie-Keeper"
+      }
+    ]
+  }
+]

--- a/public/datasets/rosicrucian-network/nodes.json
+++ b/public/datasets/rosicrucian-network/nodes.json
@@ -142,7 +142,8 @@
         "url": "https://www.britannica.com/biography/Johann-Arndt"
       }
     ],
-    "wikidataId": "Q61359"
+    "wikidataId": "Q61359",
+    "birthPlace": "Ballenstedt"
   },
   {
     "id": "person-michael-maier",
@@ -216,7 +217,8 @@
         "url": "https://en.wikipedia.org/wiki/Adam_Haslmayr"
       }
     ],
-    "wikidataId": "Q4679195"
+    "wikidataId": "Q4679195",
+    "birthPlace": "Bolzano"
   },
   {
     "id": "person-valentin-weigel",
@@ -240,7 +242,8 @@
         "url": "https://en.wikipedia.org/wiki/Valentin_Weigel"
       }
     ],
-    "wikidataId": "Q77397"
+    "wikidataId": "Q77397",
+    "birthPlace": "Großenhain"
   },
   {
     "id": "person-sebastian-franck",
@@ -263,7 +266,8 @@
         "url": "https://en.wikipedia.org/wiki/Sebastian_Franck"
       }
     ],
-    "wikidataId": "Q63170"
+    "wikidataId": "Q63170",
+    "birthPlace": "Donauwörth"
   },
   {
     "id": "person-caspar-schwenckfeld",
@@ -368,7 +372,8 @@
         "url": "https://en.wikipedia.org/wiki/Adam_von_Bodenstein"
       }
     ],
-    "wikidataId": "Q91466"
+    "wikidataId": "Q91466",
+    "birthPlace": "Karlstadt am Main"
   },
   {
     "id": "person-heinrich-khunrath",
@@ -392,7 +397,8 @@
         "url": "https://en.wikipedia.org/wiki/Heinrich_Khunrath"
       }
     ],
-    "wikidataId": "Q73366"
+    "wikidataId": "Q73366",
+    "birthPlace": "Leipzig"
   },
   {
     "id": "person-conrad-khunrath",
@@ -415,7 +421,8 @@
         "url": "https://en.wikipedia.org/wiki/Conrad_Khunrath"
       }
     ],
-    "wikidataId": "Q1126858"
+    "wikidataId": "Q1126858",
+    "birthPlace": "Leipzig"
   },
   {
     "id": "person-oswald-croll",
@@ -442,7 +449,8 @@
         "url": "https://en.wikipedia.org/wiki/Oswald_Croll"
       }
     ],
-    "wikidataId": "Q899007"
+    "wikidataId": "Q899007",
+    "birthPlace": "Wetter"
   },
   {
     "id": "person-andreas-libavius",
@@ -466,7 +474,8 @@
         "url": "https://en.wikipedia.org/wiki/Andreas_Libavius"
       }
     ],
-    "wikidataId": "Q31161"
+    "wikidataId": "Q31161",
+    "birthPlace": "Halle (Saale)"
   },
   {
     "id": "person-petrus-severinus",
@@ -767,7 +776,8 @@
         "url": "https://en.wikipedia.org/wiki/Michael_M%C3%A4stlin"
       }
     ],
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q75797"
   },
   {
     "id": "person-vilem-rozmberk",
@@ -1449,7 +1459,8 @@
         "url": "https://en.wikipedia.org/wiki/T%C3%BCbingen"
       }
     ],
-    "wikidataId": "Q3806"
+    "wikidataId": "Q3806",
+    "dateStart": "1078"
   },
   {
     "id": "loc-prague",
@@ -1470,7 +1481,8 @@
         "url": "https://en.wikipedia.org/wiki/Prague"
       }
     ],
-    "wikidataId": "Q1085"
+    "wikidataId": "Q1085",
+    "dateStart": "800"
   },
   {
     "id": "loc-heidelberg",
@@ -1512,7 +1524,8 @@
         "url": "https://en.wikipedia.org/wiki/Marburg"
       }
     ],
-    "wikidataId": "Q3869"
+    "wikidataId": "Q3869",
+    "dateStart": "1140"
   },
   {
     "id": "loc-gorlitz",
@@ -1554,7 +1567,8 @@
         "url": "https://en.wikipedia.org/wiki/Kassel"
       }
     ],
-    "wikidataId": "Q2865"
+    "wikidataId": "Q2865",
+    "dateStart": "1330"
   },
   {
     "id": "loc-london",
@@ -1575,7 +1589,8 @@
         "url": "https://en.wikipedia.org/wiki/London"
       }
     ],
-    "wikidataId": "Q84"
+    "wikidataId": "Q84",
+    "dateStart": "47"
   },
   {
     "id": "loc-basel",
@@ -1617,7 +1632,8 @@
         "url": "https://en.wikipedia.org/wiki/Augsburg"
       }
     ],
-    "wikidataId": "Q2749"
+    "wikidataId": "Q2749",
+    "dateStart": "-15"
   },
   {
     "id": "loc-the-hague",
@@ -1638,7 +1654,8 @@
         "url": "https://en.wikipedia.org/wiki/The_Hague"
       }
     ],
-    "wikidataId": "Q36600"
+    "wikidataId": "Q36600",
+    "dateStart": "1201"
   },
   {
     "id": "loc-trebon",
@@ -1676,7 +1693,9 @@
     ],
     "wikipediaTitle": null,
     "notes": "Biographical details sparse; dates approximate based on active period. German Wikipedia article available at de.wikipedia.org/wiki/Abraham_Hölzel",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q22969219",
+    "birthPlace": "Tyrol"
   },
   {
     "id": "person-wilhelm-von-wense",
@@ -1709,7 +1728,8 @@
       "physician"
     ],
     "wikipediaTitle": "Heinrich_Petraeus",
-    "wikidataId": "Q5700295"
+    "wikidataId": "Q5700295",
+    "birthPlace": "Brotterode"
   },
   {
     "id": "entity-tubingen-circle",
@@ -2010,7 +2030,8 @@
       "person-daniel-cramer"
     ],
     "wikipediaTitle": "University_of_Marburg",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q155354"
   },
   {
     "id": "entity-marburg-laboratory",
@@ -2497,7 +2518,8 @@
       }
     ],
     "notes": "Originally written in Czech, published in Latin in 1657. Proposes education for all regardless of birth, wealth, nation, or gender. Influenced the entire Hartlib Circle's educational agenda.",
-    "wikidataId": null
+    "wikidataId": null,
+    "wikidataId": "Q1210397"
   },
   {
     "id": "object-holy-guide",
@@ -2593,7 +2615,8 @@
         "url": "https://en.wikipedia.org/wiki/Elbl%C4%85g"
       }
     ],
-    "wikidataId": "Q104712"
+    "wikidataId": "Q104712",
+    "dateStart": "1237"
   },
   {
     "id": "loc-amsterdam",
@@ -2614,6 +2637,7 @@
         "url": "https://en.wikipedia.org/wiki/Amsterdam"
       }
     ],
-    "wikidataId": "Q727"
+    "wikidataId": "Q727",
+    "dateStart": "1300"
   }
 ]

--- a/public/datasets/scientific-revolution/nodes.json
+++ b/public/datasets/scientific-revolution/nodes.json
@@ -505,7 +505,8 @@
     "shortDescription": "Seat of papal authority and the Roman Inquisition",
     "country": "Italy",
     "wikipediaTitle": "Rome",
-    "wikidataId": "Q220"
+    "wikidataId": "Q220",
+    "dateStart": "-753"
   },
   {
     "id": "location-prague",
@@ -515,7 +516,8 @@
     "shortDescription": "Habsburg imperial court; Tycho and Kepler's base under Rudolf II",
     "country": "Bohemia",
     "wikipediaTitle": "Prague",
-    "wikidataId": "Q1085"
+    "wikidataId": "Q1085",
+    "dateStart": "800"
   },
   {
     "id": "location-london",
@@ -525,7 +527,8 @@
     "shortDescription": "Royal Society headquarters; center of English scientific culture",
     "country": "England",
     "wikipediaTitle": "London",
-    "wikidataId": "Q84"
+    "wikidataId": "Q84",
+    "dateStart": "47"
   },
   {
     "id": "location-oxford",
@@ -535,7 +538,8 @@
     "shortDescription": "University town; Wilkins's group and experimental philosophy",
     "country": "England",
     "wikipediaTitle": "Oxford",
-    "wikidataId": "Q34217"
+    "wikidataId": "Q34217",
+    "dateStart": "1000"
   },
   {
     "id": "location-paris",
@@ -545,7 +549,8 @@
     "shortDescription": "Académie des Sciences; center of French scientific culture",
     "country": "France",
     "wikipediaTitle": "Paris",
-    "wikidataId": "Q90"
+    "wikidataId": "Q90",
+    "dateStart": "-300"
   },
   {
     "id": "entity-royal-society",

--- a/public/datasets/speculative-freemasonry/enrich-ambiguous.json
+++ b/public/datasets/speculative-freemasonry/enrich-ambiguous.json
@@ -1,0 +1,66 @@
+[
+  {
+    "nodeId": "loc-goose-gridiron-tavern",
+    "title": "Goose and Gridiron Ale-house",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Goose and Gridiron Ale-house\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "loc-apple-tree-tavern",
+    "title": "Apple Tree Tavern",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Apple Tree Tavern\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-lodge-antiquity",
+    "title": "Lodge of Antiquity No. 2",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Lodge of Antiquity No. 2\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-lodge-fortitude-cumberland",
+    "title": "Lodge of Fortitude and Old Cumberland No. 12",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Lodge of Fortitude and Old Cumberland No. 12\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "entity-lodge-royal-somerset-inverness",
+    "title": "Royal Somerset House and Inverness Lodge No. 4",
+    "type": "entity",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Royal Somerset House and Inverness Lodge No. 4\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "object-constitutions-1723",
+    "title": "The Constitutions of the Free-Masons (1723)",
+    "type": "object",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"The Constitutions of the Free-Masons (1723)\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "person-henry-mainwaring",
+    "title": "Colonel Henry Mainwaring",
+    "type": "person",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Colonel Henry Mainwaring\"",
+    "candidates": []
+  },
+  {
+    "nodeId": "loc-rummer-grapes-tavern",
+    "title": "Rummer and Grapes Tavern",
+    "type": "location",
+    "reason": "not-found",
+    "note": "No Wikidata search results for \"Rummer and Grapes Tavern\"",
+    "candidates": []
+  }
+]

--- a/public/datasets/speculative-freemasonry/nodes.json
+++ b/public/datasets/speculative-freemasonry/nodes.json
@@ -62,7 +62,8 @@
     "country": "England",
     "shortDescription": "City in North East England where Sir Robert Moray was initiated into the Lodge of Edinburgh in 1641.",
     "wikipediaTitle": "Newcastle_upon_Tyne",
-    "wikidataId": "Q1425428"
+    "wikidataId": "Q1425428",
+    "dateStart": "200"
   },
   {
     "id": "loc-london",
@@ -72,7 +73,8 @@
     "country": "England",
     "shortDescription": "Capital city of England, location of the Premier Grand Lodge of England (founded 1717) and numerous Masonic lodges.",
     "wikipediaTitle": "London",
-    "wikidataId": "Q84"
+    "wikidataId": "Q84",
+    "dateStart": "47"
   },
   {
     "id": "loc-edinburgh",
@@ -82,7 +84,8 @@
     "country": "Scotland",
     "shortDescription": "Capital city of Scotland, home to the Lodge of Edinburgh (Mary's Chapel) No. 1, the oldest Masonic lodge with continuous records.",
     "wikipediaTitle": "Edinburgh",
-    "wikidataId": "Q23436"
+    "wikidataId": "Q23436",
+    "dateStart": "601"
   },
   {
     "id": "entity-premier-grand-lodge-england",
@@ -93,7 +96,8 @@
     "dateEnd": "1813-12-27",
     "shortDescription": "The first Masonic Grand Lodge in the world, founded in 1717 in London. Also known as the 'Moderns' after 1751.",
     "headquarters": "loc-london",
-    "wikipediaTitle": "Premier_Grand_Lodge_of_England"
+    "wikipediaTitle": "Premier_Grand_Lodge_of_England",
+    "wikidataId": "Q1637868"
   },
   {
     "id": "entity-lodge-edinburgh",
@@ -102,7 +106,9 @@
     "entityType": "organization",
     "shortDescription": "The oldest Masonic lodge with continuous records, dating to 1599. Initiated Sir Robert Moray in Newcastle in 1641.",
     "headquarters": "loc-edinburgh",
-    "wikipediaTitle": "Lodge_of_Edinburgh_(Mary's_Chapel)_No._1"
+    "wikipediaTitle": "Lodge_of_Edinburgh_(Mary's_Chapel)_No._1",
+    "wikidataId": "Q3257879",
+    "dateStart": "1599"
   },
   {
     "id": "person-anthony-sayer",
@@ -118,7 +124,8 @@
       "freemason"
     ],
     "wikipediaTitle": "Anthony_Sayer",
-    "wikidataId": "Q3618535"
+    "wikidataId": "Q3618535",
+    "birthPlace": "London"
   },
   {
     "id": "person-george-payne",
@@ -276,7 +283,8 @@
       "designer"
     ],
     "wikipediaTitle": "John_Pine",
-    "wikidataId": "Q6252938"
+    "wikidataId": "Q6252938",
+    "birthPlace": "London"
   },
   {
     "id": "person-william-stukeley",

--- a/public/datasets/statistics-social-physics/enrich-ambiguous.json
+++ b/public/datasets/statistics-social-physics/enrich-ambiguous.json
@@ -1,0 +1,10 @@
+[
+  {
+    "nodeId": "object-sur-l-homme",
+    "title": "Sur l'homme et le développement de ses facultés",
+    "type": "object",
+    "reason": "not-found",
+    "note": "Wikipedia page \"A_Treatise_on_Man_and_the_Development_of_His_Faculties\" has no linked Wikidata item",
+    "candidates": []
+  }
+]

--- a/scripts/enrich-dataset/enricher.ts
+++ b/scripts/enrich-dataset/enricher.ts
@@ -18,6 +18,8 @@ import {
   claimItemIds,
   claimYear,
   entityDescription,
+  entityLabel,
+  entityNames,
   entitySitelinkTitle,
   isInstanceOf,
   type WikidataEntity,
@@ -43,6 +45,72 @@ interface ResolvedTarget {
   status?: NodeEnrichmentResult['status'];
   candidates?: MatchCandidate[];
   note?: string;
+}
+
+/** Trailing tokens that are honorifics/ordinals, not part of a surname. */
+const NAME_SUFFIXES = new Set([
+  'the',
+  'elder',
+  'younger',
+  'jr',
+  'sr',
+  'i',
+  'ii',
+  'iii',
+  'iv',
+  'v',
+]);
+
+/** Normalize a name to lowercase, accent-free, alphabetic tokens. Drops any
+ *  parenthetical disambiguator (e.g. "Alex Paterson (The Orb)"). */
+function nameTokens(s: string): string[] {
+  return s
+    .replace(/\s*\([^)]*\)/g, '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/[^a-z ]/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+/** The last meaningful token, ignoring trailing honorifics/ordinals. */
+function surnameToken(tokens: string[]): string {
+  const t = [...tokens];
+  while (t.length > 1 && NAME_SUFFIXES.has(t[t.length - 1])) t.pop();
+  return t[t.length - 1];
+}
+
+/** Two name tokens match if equal or share a >=4-char common prefix
+ *  (tolerates transliteration variants like Chalcondyles/Chalkokondyles). */
+function tokensMatch(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (a.length < 4 || b.length < 4) return false;
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i++;
+  return i >= 4;
+}
+
+/**
+ * Does a resolved entity plausibly refer to the same *person* as the node?
+ * Guards against corrupt/stale wikidataIds that resolve to an unrelated entity
+ * (e.g. a node titled "Sam Altman" whose id points at a baseball player). The
+ * node's surname must fuzzily appear in the entity's label, an alias, or the
+ * Wikipedia sitelink. If the entity has no usable English name we cannot
+ * verify, so we trust rather than falsely quarantine.
+ */
+function personNameMatches(title: string, names: string[]): boolean {
+  const titleTokens = nameTokens(title);
+  if (titleTokens.length === 0) return true;
+  const surname = surnameToken(titleTokens);
+
+  const usable = names.map(nameTokens).filter((t) => t.length > 0);
+  if (usable.length === 0) return true; // nothing to check against
+
+  return usable.some((tokens) =>
+    tokens.some((token) => tokensMatch(token, surname))
+  );
 }
 
 /** Is a node field considered absent (and therefore fillable)? */
@@ -253,6 +321,28 @@ export async function enrichDataset(
         status: 'not-found',
         filled: {},
         note: `Wikidata entity ${target.qid} could not be fetched`,
+      });
+      continue;
+    }
+
+    // Identity guard: a person node's resolved entity must actually name that
+    // person. Catches corrupt/stale wikidataIds pointing at unrelated entities.
+    if (node.type === 'person' && !personNameMatches(node.title, entityNames(entity))) {
+      results.push({
+        ...base,
+        status: 'id-mismatch',
+        filled: {},
+        candidates: [
+          {
+            wikidataId: entity.id,
+            label: entityLabel(entity) ?? '(no label)',
+            description: entityDescription(entity),
+          },
+        ],
+        note:
+          target.provenance === 'id'
+            ? `Existing wikidataId ${entity.id} resolves to "${entityLabel(entity) ?? '?'}", not "${node.title}"`
+            : `Resolved ${entity.id} ("${entityLabel(entity) ?? '?'}") does not match "${node.title}"`,
       });
       continue;
     }

--- a/scripts/enrich-dataset/index.ts
+++ b/scripts/enrich-dataset/index.ts
@@ -32,6 +32,7 @@ import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { existsSync } from 'node:fs';
 import { enrichDataset } from './enricher.js';
+import { applyFills } from './write-nodes.js';
 import {
   ENRICHABLE_FIELDS,
   type AmbiguousEntry,
@@ -171,6 +172,16 @@ function collectAmbiguous(results: NodeEnrichmentResult[]): AmbiguousEntry[] {
         note: r.note,
         candidates: r.candidates ?? [],
       });
+    } else if (r.status === 'id-mismatch') {
+      entries.push({
+        nodeId: r.nodeId,
+        title: r.title,
+        type: r.type,
+        reason: 'id-mismatch',
+        note: r.note,
+        existingWikidataId: r.candidates?.[0]?.wikidataId,
+        candidates: r.candidates ?? [],
+      });
     } else if (r.status === 'not-found') {
       entries.push({
         nodeId: r.nodeId,
@@ -204,6 +215,7 @@ function summarize(
     ambiguous: count('ambiguous'),
     notFound: count('not-found'),
     typeMismatch: count('type-mismatch'),
+    idMismatch: count('id-mismatch'),
     errors: count('error'),
     fieldsFilled,
     results,
@@ -232,6 +244,8 @@ function printSummary(
         );
       } else if (r.status === 'type-mismatch') {
         console.log(`  ✗ ${r.title}: type mismatch (quarantined)`);
+      } else if (r.status === 'id-mismatch') {
+        console.log(`  ✗ ${r.title}: ${r.note} (quarantined)`);
       } else if (r.status === 'not-found') {
         console.log(`  – ${r.title}: no match (quarantined)`);
       } else if (r.status === 'error') {
@@ -243,8 +257,8 @@ function printSummary(
   console.log(
     `  ${summary.fieldsFilled} fields filled across ${summary.enriched} nodes | ` +
       `complete: ${summary.complete}, ambiguous: ${summary.ambiguous}, ` +
-      `type-mismatch: ${summary.typeMismatch}, not-found: ${summary.notFound}, ` +
-      `errors: ${summary.errors}`
+      `id-mismatch: ${summary.idMismatch}, type-mismatch: ${summary.typeMismatch}, ` +
+      `not-found: ${summary.notFound}, errors: ${summary.errors}`
   );
 }
 
@@ -269,7 +283,8 @@ async function main(): Promise<void> {
 
   for (const datasetId of datasets) {
     const nodesPath = join(datasetsPath, datasetId, 'nodes.json');
-    const nodes = JSON.parse(await readFile(nodesPath, 'utf-8')) as GraphNode[];
+    const originalText = await readFile(nodesPath, 'utf-8');
+    const nodes = JSON.parse(originalText) as GraphNode[];
 
     const results = await enrichDataset(nodes, options.fields, {
       dryRun: options.dryRun,
@@ -277,9 +292,10 @@ async function main(): Promise<void> {
     const summary = summarize(datasetId, nodes.length, results);
     summaries.push(summary);
 
-    // Persist enriched nodes (unless dry-run and nothing changed).
+    // Persist enriched nodes by splicing new fields into the original text,
+    // preserving the file's existing formatting (see write-nodes.ts).
     if (!options.dryRun && summary.fieldsFilled > 0) {
-      await writeFile(nodesPath, JSON.stringify(nodes, null, 2) + '\n', 'utf-8');
+      await writeFile(nodesPath, applyFills(originalText, results), 'utf-8');
     }
 
     // Write / clear the quarantine file for nodes needing human attention.
@@ -315,6 +331,7 @@ async function main(): Promise<void> {
       ambiguous: s.ambiguous,
       notFound: s.notFound,
       typeMismatch: s.typeMismatch,
+      idMismatch: s.idMismatch,
       errors: s.errors,
       fieldsFilled: s.fieldsFilled,
     }));

--- a/scripts/enrich-dataset/types.ts
+++ b/scripts/enrich-dataset/types.ts
@@ -79,6 +79,7 @@ export interface NodeEnrichmentResult {
     | 'ambiguous' // multiple candidates - quarantined for human review
     | 'not-found' // no Wikidata match at all
     | 'type-mismatch' // best match's instance-of contradicts node.type
+    | 'id-mismatch' // existing wikidataId resolves to an unrelated entity
     | 'error'; // API/network failure
   /** Fields that were filled, with their resolved values. */
   filled: Partial<Record<EnrichableField, string | string[]>>;
@@ -93,7 +94,13 @@ export interface AmbiguousEntry {
   nodeId: string;
   title: string;
   type: NodeType;
-  reason: 'multiple-candidates' | 'type-mismatch' | 'not-found';
+  reason:
+    | 'multiple-candidates'
+    | 'type-mismatch'
+    | 'id-mismatch'
+    | 'not-found';
+  /** The existing (suspect) wikidataId, when reason is 'id-mismatch'. */
+  existingWikidataId?: string;
   note?: string;
   candidates: MatchCandidate[];
 }
@@ -121,6 +128,7 @@ export interface DatasetEnrichmentSummary {
   ambiguous: number;
   notFound: number;
   typeMismatch: number;
+  idMismatch: number;
   errors: number;
   /** Total number of individual fields filled across all nodes. */
   fieldsFilled: number;

--- a/scripts/enrich-dataset/wikidata.ts
+++ b/scripts/enrich-dataset/wikidata.ts
@@ -37,6 +37,7 @@ export interface WikidataEntity {
   id: string;
   labels?: Record<string, { value: string }>;
   descriptions?: Record<string, { value: string }>;
+  aliases?: Record<string, Array<{ value: string }>>;
   claims?: Record<string, WikidataClaim[]>;
   sitelinks?: Record<string, { title: string }>;
 }
@@ -139,7 +140,7 @@ export async function getEntities(
     const data = await apiGet(WIKIDATA_API, {
       action: 'wbgetentities',
       ids: batch.join('|'),
-      props: 'labels|descriptions|claims|sitelinks',
+      props: 'labels|descriptions|aliases|claims|sitelinks',
       languages: 'en',
     });
     const entities = (data.entities as
@@ -227,6 +228,19 @@ export function claimYear(
 /** English label for the entity itself. */
 export function entityLabel(entity: WikidataEntity): string | undefined {
   return entity.labels?.en?.value;
+}
+
+/** All English names for an entity: label + aliases + Wikipedia sitelink. */
+export function entityNames(entity: WikidataEntity): string[] {
+  const names: string[] = [];
+  const label = entity.labels?.en?.value;
+  if (label) names.push(label);
+  for (const alias of entity.aliases?.en ?? []) {
+    if (alias.value) names.push(alias.value);
+  }
+  const sitelink = entity.sitelinks?.enwiki?.title;
+  if (sitelink) names.push(sitelink);
+  return names;
 }
 
 /** English one-line description for the entity. */

--- a/scripts/enrich-dataset/write-nodes.ts
+++ b/scripts/enrich-dataset/write-nodes.ts
@@ -1,0 +1,151 @@
+/**
+ * Format-preserving writer for nodes.json.
+ *
+ * enrich only ever *adds* missing fields, so rewriting the whole file with
+ * JSON.stringify would reflow untouched nodes whose hand-authored formatting
+ * differs from the serializer (e.g. inline vs. expanded arrays). That buries a
+ * handful of real changes under hundreds of noise lines.
+ *
+ * Instead we splice the new keys directly into the original text, leaving every
+ * untouched byte identical. The result is a minimal diff: one comma added to
+ * each affected node's previously-last property, plus the new lines.
+ */
+
+import type { EnrichableField, NodeEnrichmentResult } from './types.js';
+
+/** [start, end] char offsets of each top-level object (end = its `}`). */
+function topLevelObjectSpans(text: string): Array<[number, number]> {
+  const spans: Array<[number, number]> = [];
+  let i = 0;
+  const n = text.length;
+
+  // Advance to the opening bracket of the top-level array.
+  while (i < n && text[i] !== '[') i++;
+  i++; // step past '['
+
+  let inStr = false;
+  let esc = false;
+  let depth = 0; // brace/bracket depth *inside* the top-level array
+  let objStart = -1;
+
+  for (; i < n; i++) {
+    const c = text[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === '\\') esc = true;
+      else if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '"') {
+      inStr = true;
+    } else if (c === '{') {
+      if (depth === 0) objStart = i;
+      depth++;
+    } else if (c === '}') {
+      depth--;
+      if (depth === 0 && objStart >= 0) {
+        spans.push([objStart, i]);
+        objStart = -1;
+      }
+    } else if (c === '[') {
+      depth++;
+    } else if (c === ']') {
+      if (depth === 0) break; // closing bracket of the top-level array
+      depth--;
+    }
+  }
+
+  return spans;
+}
+
+/** The leading whitespace of an object's property lines (e.g. "    "). */
+function propertyIndent(objText: string): string {
+  const m = /\n(\s+)"/.exec(objText);
+  return m ? m[1] : '    ';
+}
+
+/** Extract a node's `"id"` value from its raw object text. */
+function objectId(objText: string): string | undefined {
+  const m = /"id"\s*:\s*"([^"]+)"/.exec(objText);
+  return m ? m[1] : undefined;
+}
+
+/**
+ * Serialize a value at a given indent. Strings become a quoted scalar; arrays
+ * and objects expand across lines, each continuation line indented to match.
+ */
+function serializeValue(value: string | string[], indent: string): string {
+  const json = JSON.stringify(value, null, 2);
+  // Re-indent every line after the first to sit under `indent`.
+  return json.replace(/\n/g, '\n' + indent);
+}
+
+/**
+ * Apply enrichment fills to the original nodes.json text without disturbing the
+ * formatting of untouched content. `results` must be in the same order as the
+ * nodes in `originalText`; we additionally match on node id as a safety check
+ * and throw rather than risk writing a corrupted file.
+ */
+export function applyFills(
+  originalText: string,
+  results: NodeEnrichmentResult[]
+): string {
+  const spans = topLevelObjectSpans(originalText);
+  if (spans.length !== results.length) {
+    throw new Error(
+      `Node count mismatch: text has ${spans.length} objects but ${results.length} results`
+    );
+  }
+
+  // Build the edits, then apply them back-to-front so earlier offsets stay valid.
+  interface Edit {
+    at: number;
+    insert: string;
+  }
+  const edits: Edit[] = [];
+
+  for (let i = 0; i < spans.length; i++) {
+    const result = results[i];
+    const filledFields = Object.keys(result.filled) as EnrichableField[];
+    if (filledFields.length === 0) continue;
+
+    const [start, end] = spans[i];
+    const objText = originalText.slice(start, end + 1);
+
+    const id = objectId(objText);
+    if (id && id !== result.nodeId) {
+      throw new Error(
+        `Node order mismatch at index ${i}: text id "${id}" != result id "${result.nodeId}"`
+      );
+    }
+
+    const indent = propertyIndent(objText);
+
+    // Insertion point: just after the object's last property value, which is
+    // the last non-whitespace character before the closing brace at `end`.
+    let insertAt = end - 1;
+    while (insertAt > start && /\s/.test(originalText[insertAt])) insertAt--;
+    insertAt += 1;
+
+    const additions = filledFields
+      .map((field) => {
+        const value = result.filled[field];
+        if (value === undefined) return null;
+        return `,\n${indent}${JSON.stringify(field)}: ${serializeValue(
+          value,
+          indent
+        )}`;
+      })
+      .filter((s): s is string => s !== null)
+      .join('');
+
+    if (additions) edits.push({ at: insertAt, insert: additions });
+  }
+
+  edits.sort((a, b) => b.at - a.at);
+  let text = originalText;
+  for (const edit of edits) {
+    text = text.slice(0, edit.at) + edit.insert + text.slice(edit.at);
+  }
+  return text;
+}


### PR DESCRIPTION
Runs `enrich` (Thread 2A-1) against the real datasets — and hardens the tool based on what that surfaced.

## Result: 268 fields filled across 9 datasets
Only-missing fields resolved from Wikidata/Wikipedia (no prose, no overwrites):

| Field | New |
|---|--:|
| dateStart | +101 |
| wikidataId | +80 |
| birthPlace | +79 |
| wikipediaTitle | +5 |
| dateEnd | +3 |

All 12 datasets validate; manifests in sync. Each dataset's unresolved nodes are written to `enrich-ambiguous.json` as a disambiguation worklist.

## Two tool-hardening fixes (surfaced by real data)

**1. Format-preserving writer** (`write-nodes.ts`). The first real run reflowed `ai-llm-research` — 1200 lines of noise for 52 real fills — because its hand-authored inline arrays don't match `JSON.stringify`. The writer now splices new fields into the original text, leaving every untouched byte alone. Diffs are now minimal (a comma + the new lines) for every file.

**2. Person identity guard** (`enricher.ts`). enrich trusted existing `wikidataId`s — but some are wrong. It verifies a person node's surname fuzzily appears in the resolved entity's label/aliases/sitelink before adopting its facts; mismatches are quarantined as `id-mismatch`. Tolerates parentheticals, honorific suffixes, and transliteration variants; entities with no usable English name are trusted (no false positives on the clean datasets — 2 residual flags are genuinely ambiguous Latinized names, Cruciger & Severinus, safely quarantined).

## ⚠️ Finding: `ai-llm-research` has corrupt Wikidata IDs — EXCLUDED here

**57 of 69 person `wikidataId`s point at unrelated entities.** Examples caught by the guard:

| Node | Its `wikidataId` actually is |
|---|---|
| Geoffrey Hinton | "Category: Works Progress Administration in Georgia" |
| Yann LeCun | "ethnic media" |
| Sam Altman | "Sam Moffet" (a baseball player) |
| Trevor Blackwell | "Trent Frayne" (a sportswriter) |

These predate enrich (likely hallucinated when that dataset was built) and would have poisoned it with baseball-player dates. `ai-llm-research` is left **completely untouched** in this PR — it needs ID remediation, not enrichment. **Recommended follow-up**: clear the bad IDs and re-resolve from names (a dedicated pass).

## Verification
- `npm run validate:datasets` — 12/12 pass.
- `npm run sync-manifest:check` — all in sync.
- Diffs confirmed proportionate (268 net new fields; the large raw `wikidataId` count is trailing-comma flips, not a reflow).
- Guard confirmed: catches all 57 ai-llm-research corruptions, 0 false positives on clean datasets after refinement.
- `npm run lint` clean.

## Follow-ups (not in this PR)
- Remediate `ai-llm-research` corrupt IDs.
- enrich retry/backoff on transient Wikimedia API errors (one mid-run blip required a re-run of 5 datasets; no data was corrupted — failed datasets just wrote nothing).
- Decide whether `enrich-ambiguous.json` worklists stay committed or move to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)