### PR TITLE
Harden CI: manifest-sync PR gate + weekly Wikidata ID health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,6 @@ jobs:
 
       - name: Validate datasets
         run: npm run validate:datasets
+
+      - name: Check manifest sync
+        run: npm run sync-manifest:check

--- a/.github/workflows/data-health.yml
+++ b/.github/workflows/data-health.yml
@@ -1,0 +1,59 @@
+name: Data Health Check
+
+# Weekly Wikidata ID audit across all datasets. This hits the live Wikidata API
+# (~1,500 lookups) and a small number of "wrong" results are expected matcher
+# false positives, so it is intentionally NOT a PR gate: it reports to the run
+# summary and never fails the build. A sharp spike in the wrong-rate for a
+# dataset is the signal that its ID layer has been corrupted.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-ids:
+    name: Wikidata ID health check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit Wikidata IDs (report only)
+        run: npm run verify-ids --silent -- --json > verify-ids-report.json || true
+
+      - name: Publish summary
+        if: always()
+        run: |
+          node <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          const fs = require('fs');
+          let rows;
+          try {
+            rows = JSON.parse(fs.readFileSync('verify-ids-report.json', 'utf8'));
+          } catch {
+            console.log('## Wikidata ID Health Check\n\n_Report unavailable — verify-ids produced no parseable output, likely a transient Wikidata API issue. Re-run the workflow._');
+            process.exit(0);
+          }
+          let md = '## Wikidata ID Health Check\n\n| Dataset | checked | ok | wrong | rate |  |\n|---|--:|--:|--:|--:|:--|\n';
+          for (const d of rows) {
+            const rate = d.checked ? Math.round((100 * d.wrong) / d.checked) : 0;
+            const flag = rate >= 20 ? '⚠️ likely corruption' : '';
+            md += `| ${d.datasetId} | ${d.checked} | ${d.ok} | ${d.wrong} | ${rate}% | ${flag} |\n`;
+          }
+          md += '\n_A few "wrong" per dataset are usually matcher false positives (renames, book→author links). A ⚠️ high rate indicates likely ID corruption — inspect with_ `npm run verify-ids -- --dataset <id>` _and remediate with_ `npm run verify-ids:fix -- --dataset <id> --clear-unverifiable`.';
+          console.log(md);
+          EOF


### PR DESCRIPTION
Locks in the data-integrity work from the recent PRs (enrich, sync-manifest, verify-ids, 5 datasets remediated) so it can't silently regress.

## Two guards, deliberately different

**1. `sync-manifest:check` → PR gate** (in `ci.yml`)
Deterministic and offline, so it belongs in the blocking gate. Fails a PR if any manifest's `nodeCount`/`edgeCount` drifts from the actual data. (This check already caught one real bug — christian-kabbalah 75→81 edges.)

**2. `verify-ids` → weekly scheduled report** (new `data-health.yml`), **not** a PR gate
`verify-ids` hits the live Wikidata API (~1,500 lookups) and a few "wrong" results per dataset are expected matcher false positives (renames, book→author links). Making it block PRs would mean flaky failures on Wikidata hiccups and constant red from known false positives. Instead it:
- runs weekly (Mondays 06:00 UTC) + on-demand (`workflow_dispatch`),
- posts a per-dataset table to the run summary,
- flags any dataset over a **20% wrong-rate** as ⚠️ likely corruption,
- never fails the build (`|| true`, graceful on API errors).

Example summary output:

| Dataset | checked | ok | wrong | rate |  |
|---|--:|--:|--:|--:|:--|
| enlightenment | 172 | 168 | 4 | 2% |  |
| florentine-academy | 46 | 5 | 39 | 85% | ⚠️ likely corruption |
| ai-llm-research | 106 | 106 | 0 | 0% |  |

The 20% threshold cleanly separates real corruption (the 63–85% datasets we just fixed) from the ~2% false-positive baseline — it's exactly the signal that would have caught all of this at authoring time.

## Verification
- `sync-manifest:check` passes on current main (all 12 in sync).
- Summary script tested against mock data (table + threshold flagging correct).
- Both workflow YAMLs parse cleanly.

## Follow-ups
- Recover the ~150 nodes cleared to null across the 5 fixed datasets (quarantined).
- Resume Thread 2A features (`check-evidence` next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
