### PR TITLE
check-evidence: dead-link + missing-evidence QA for edges (Thread 2A)

### DIFF
--- a/.github/workflows/data-health.yml
+++ b/.github/workflows/data-health.yml
@@ -57,3 +57,34 @@ jobs:
           md += '\n_A few "wrong" per dataset are usually matcher false positives (renames, book→author links). A ⚠️ high rate indicates likely ID corruption — inspect with_ `npm run verify-ids -- --dataset <id>` _and remediate with_ `npm run verify-ids:fix -- --dataset <id> --clear-unverifiable`.';
           console.log(md);
           EOF
+
+      - name: Check evidence links (report only)
+        if: always()
+        run: npm run check-evidence --silent -- --json > check-evidence-report.json || true
+
+      - name: Publish evidence summary
+        if: always()
+        run: |
+          node <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          const fs = require('fs');
+          let rows;
+          try {
+            rows = JSON.parse(fs.readFileSync('check-evidence-report.json', 'utf8'));
+          } catch {
+            console.log('\n## Evidence Link Check\n\n_Report unavailable — check-evidence produced no parseable output._');
+            process.exit(0);
+          }
+          const problems = rows.filter((d) => d.dead > 0 || d.missingEvidence > 0);
+          let md = '\n## Evidence Link Check\n\n';
+          if (problems.length === 0) {
+            md += '✅ No dead links or missing evidence across all datasets.';
+          } else {
+            md += '| Dataset | dead | missing-evidence | dead URLs |\n|---|--:|--:|:--|\n';
+            for (const d of problems) {
+              const urls = (d.deadLinks || []).map((l) => l.url).join('<br>') || '—';
+              md += `| ${d.datasetId} | ${d.dead} | ${d.missingEvidence} | ${urls} |\n`;
+            }
+            md += '\n_Fix dead links / add evidence, then re-check with_ `npm run check-evidence -- --dataset <id>`.';
+          }
+          console.log(md);
+          EOF

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "enrich:dry-run": "npx tsx scripts/enrich-dataset/index.ts --dry-run",
     "sync-manifest": "npx tsx scripts/sync-manifest/index.ts",
     "sync-manifest:check": "npx tsx scripts/sync-manifest/index.ts --check",
+    "check-evidence": "npx tsx scripts/check-evidence/index.ts",
     "verify-ids": "npx tsx scripts/verify-ids/index.ts",
     "verify-ids:fix": "npx tsx scripts/verify-ids/index.ts --fix",
     "test:graph-equivalence": "npx tsx scripts/test-graph-equivalence/index.ts",

--- a/public/datasets/rosicrucian-network/edges.json
+++ b/public/datasets/rosicrucian-network/edges.json
@@ -1453,7 +1453,7 @@
     "relationship": "member_of",
     "label": "Central figure",
     "evidence": "Boehme is considered the central figure of Christian theosophy, synthesizing theology with nature mysticism and alchemical symbolism.",
-    "evidenceUrl": "https://plato.stanford.edu/entries/boehme/",
+    "evidenceUrl": "https://en.wikipedia.org/wiki/Jacob_Böhme",
     "strength": "strong"
   },
   {

--- a/scripts/check-evidence/index.ts
+++ b/scripts/check-evidence/index.ts
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+/**
+ * Evidence Check CLI
+ *
+ * Mechanical QA for dataset edges:
+ *   1. Link rot - HEAD/GET every `evidenceUrl` and flag dead links.
+ *   2. Missing evidence - flag edges with no evidence at all (no prose
+ *      `evidence`, no `evidenceUrl`, and no `evidenceNodeId`).
+ *
+ * Link results are graded to avoid false alarms: 2xx/3xx is live; 404/410 or a
+ * DNS failure is dead (a real problem); 401/403/405/429/5xx/timeout is
+ * "uncertain" (often bot-blocking or a transient hiccup) and reported without
+ * failing the run.
+ *
+ * Exit code is 1 only on confirmed problems (dead links or missing evidence),
+ * so uncertain/transient results don't produce flaky failures.
+ *
+ * Usage:
+ *   npx tsx scripts/check-evidence/index.ts [options]
+ *
+ * Options:
+ *   --dataset <id>      Only this dataset (directory name). Default: all.
+ *   --timeout <ms>      Per-request timeout. Default: 10000.
+ *   --concurrency <n>   Max simultaneous requests. Default: 8.
+ *   --quiet             Only show the per-dataset summary.
+ *   --json              Emit the summary as JSON (implies --quiet).
+ *   --help, -h          Show this help.
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+
+const DATASETS_DIR = 'public/datasets';
+const USER_AGENT =
+  'Scenius-check-evidence/1.0 (https://scenius-seven.vercel.app; link checker)';
+
+interface GraphEdge {
+  id: string;
+  source: string;
+  target: string;
+  evidence?: string;
+  evidenceUrl?: string;
+  evidenceNodeId?: string;
+  [key: string]: unknown;
+}
+
+interface CLIOptions {
+  dataset?: string;
+  timeout: number;
+  concurrency: number;
+  quiet: boolean;
+  json: boolean;
+}
+
+type LinkStatus = 'ok' | 'dead' | 'uncertain';
+
+interface LinkResult {
+  url: string;
+  status: LinkStatus;
+  code?: number;
+  note?: string;
+  edgeIds: string[];
+}
+
+interface DatasetEvidenceSummary {
+  datasetId: string;
+  edges: number;
+  urls: number;
+  ok: number;
+  dead: number;
+  uncertain: number;
+  missingEvidence: string[];
+  deadLinks: LinkResult[];
+  uncertainLinks: LinkResult[];
+}
+
+function parseArgs(args: string[]): CLIOptions {
+  const options: CLIOptions = {
+    timeout: 10000,
+    concurrency: 8,
+    quiet: false,
+    json: false,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case '--quiet':
+        options.quiet = true;
+        break;
+      case '--json':
+        options.json = true;
+        options.quiet = true;
+        break;
+      case '--dataset':
+        options.dataset = args[++i];
+        break;
+      case '--timeout':
+        options.timeout = parseInt(args[++i], 10);
+        break;
+      case '--concurrency':
+        options.concurrency = parseInt(args[++i], 10);
+        break;
+      case '--help':
+      case '-h':
+        showHelp();
+        process.exit(0);
+        break;
+      default:
+        if (arg.startsWith('-')) {
+          console.error(`Unknown option: ${arg}`);
+          showHelp();
+          process.exit(1);
+        }
+    }
+  }
+  return options;
+}
+
+function showHelp(): void {
+  console.log(`
+Evidence Check CLI for Scenius
+
+Flags dead evidenceUrls and edges with no evidence at all.
+
+Usage:
+  npx tsx scripts/check-evidence/index.ts [options]
+
+Options:
+  --dataset <id>      Only this dataset. Default: all.
+  --timeout <ms>      Per-request timeout. Default: 10000.
+  --concurrency <n>   Max simultaneous requests. Default: 8.
+  --quiet             Only show the per-dataset summary.
+  --json              Emit the summary as JSON (implies --quiet).
+  --help, -h          Show this help.
+
+Examples:
+  npx tsx scripts/check-evidence/index.ts --dataset enlightenment
+  npx tsx scripts/check-evidence/index.ts --json
+`);
+}
+
+async function getDatasetDirectories(
+  datasetsPath: string,
+  specificDataset?: string
+): Promise<string[]> {
+  if (specificDataset) {
+    const edgesPath = join(datasetsPath, specificDataset, 'edges.json');
+    if (!existsSync(edgesPath)) {
+      throw new Error(`Dataset "${specificDataset}" not found or has no edges.json`);
+    }
+    return [specificDataset];
+  }
+  const entries = await readdir(datasetsPath, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isDirectory())
+    .filter((e) => existsSync(join(datasetsPath, e.name, 'edges.json')))
+    .map((e) => e.name);
+}
+
+/** One request with a timeout; returns the Response or throws. */
+async function request(
+  url: string,
+  method: 'HEAD' | 'GET',
+  timeout: number
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  try {
+    return await fetch(url, {
+      method,
+      redirect: 'follow',
+      headers: { 'User-Agent': USER_AGENT },
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Grade a single URL. HEAD first, falling back to GET when HEAD is rejected. */
+async function checkUrl(url: string, timeout: number): Promise<Omit<LinkResult, 'edgeIds'>> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { url, status: 'dead', note: 'malformed URL' };
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { url, status: 'dead', note: `unsupported protocol ${parsed.protocol}` };
+  }
+
+  try {
+    let res = await request(url, 'HEAD', timeout);
+    // Many servers don't implement HEAD - retry with GET before judging.
+    if (res.status === 405 || res.status === 403 || res.status === 501) {
+      res = await request(url, 'GET', timeout);
+    }
+    if (res.ok || (res.status >= 300 && res.status < 400)) {
+      return { url, status: 'ok', code: res.status };
+    }
+    if (res.status === 404 || res.status === 410) {
+      return { url, status: 'dead', code: res.status };
+    }
+    // 401/403/429/5xx etc. - can't confirm dead (often bot protection).
+    return { url, status: 'uncertain', code: res.status };
+  } catch (err) {
+    const msg = (err as Error).message || String(err);
+    // DNS resolution failure is a strong dead signal; timeouts are not.
+    if (/ENOTFOUND|EAI_AGAIN|getaddrinfo/i.test(msg)) {
+      return { url, status: 'dead', note: 'DNS failure' };
+    }
+    return { url, status: 'uncertain', note: msg.slice(0, 80) };
+  }
+}
+
+/** Run an async mapper over items with a bounded concurrency. */
+async function pool<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function run(): Promise<void> {
+    while (next < items.length) {
+      const i = next++;
+      results[i] = await worker(items[i]);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, run)
+  );
+  return results;
+}
+
+async function checkDataset(
+  datasetsPath: string,
+  datasetId: string,
+  options: CLIOptions
+): Promise<DatasetEvidenceSummary> {
+  const edgesPath = join(datasetsPath, datasetId, 'edges.json');
+  const edges = JSON.parse(await readFile(edgesPath, 'utf-8')) as GraphEdge[];
+
+  // Edges with no evidence of any kind.
+  const missingEvidence = edges
+    .filter(
+      (e) =>
+        !(e.evidence && String(e.evidence).trim()) &&
+        !e.evidenceUrl &&
+        !e.evidenceNodeId
+    )
+    .map((e) => e.id);
+
+  // Unique URLs -> the edges that cite them.
+  const urlToEdges = new Map<string, string[]>();
+  for (const e of edges) {
+    if (!e.evidenceUrl) continue;
+    const list = urlToEdges.get(e.evidenceUrl) ?? [];
+    list.push(e.id);
+    urlToEdges.set(e.evidenceUrl, list);
+  }
+
+  const urls = [...urlToEdges.keys()];
+  const graded = await pool(urls, options.concurrency, (u) =>
+    checkUrl(u, options.timeout)
+  );
+  const results: LinkResult[] = graded.map((g) => ({
+    ...g,
+    edgeIds: urlToEdges.get(g.url) ?? [],
+  }));
+
+  return {
+    datasetId,
+    edges: edges.length,
+    urls: urls.length,
+    ok: results.filter((r) => r.status === 'ok').length,
+    dead: results.filter((r) => r.status === 'dead').length,
+    uncertain: results.filter((r) => r.status === 'uncertain').length,
+    missingEvidence,
+    deadLinks: results.filter((r) => r.status === 'dead'),
+    uncertainLinks: results.filter((r) => r.status === 'uncertain'),
+  };
+}
+
+function printSummary(s: DatasetEvidenceSummary, options: CLIOptions): void {
+  if (options.json) return;
+  console.log(`\n${s.datasetId}`);
+
+  if (!options.quiet) {
+    for (const d of s.deadLinks) {
+      console.log(
+        `  ✗ DEAD ${d.code ?? d.note}: ${d.url} (${d.edgeIds.length} edge(s))`
+      );
+    }
+    for (const u of s.uncertainLinks) {
+      console.log(`  ? ${u.code ?? u.note}: ${u.url}`);
+    }
+    for (const id of s.missingEvidence) {
+      console.log(`  ! no evidence: ${id}`);
+    }
+  }
+
+  console.log(
+    `  ${s.edges} edges, ${s.urls} urls | ok: ${s.ok}, dead: ${s.dead}, ` +
+      `uncertain: ${s.uncertain}, missing-evidence: ${s.missingEvidence.length}`
+  );
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const datasetsPath = resolve(process.cwd(), DATASETS_DIR);
+
+  let datasets: string[];
+  try {
+    datasets = await getDatasetDirectories(datasetsPath, options.dataset);
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exit(1);
+  }
+
+  const summaries: DatasetEvidenceSummary[] = [];
+  for (const datasetId of datasets) {
+    const summary = await checkDataset(datasetsPath, datasetId, options);
+    summaries.push(summary);
+    printSummary(summary, options);
+  }
+
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        summaries.map((s) => ({
+          datasetId: s.datasetId,
+          edges: s.edges,
+          urls: s.urls,
+          ok: s.ok,
+          dead: s.dead,
+          uncertain: s.uncertain,
+          missingEvidence: s.missingEvidence.length,
+          deadLinks: s.deadLinks.map((d) => ({ url: d.url, edgeIds: d.edgeIds })),
+        })),
+        null,
+        2
+      )
+    );
+  }
+
+  const problems = summaries.reduce(
+    (n, s) => n + s.dead + s.missingEvidence.length,
+    0
+  );
+  if (problems > 0 && !options.json) {
+    console.log(
+      `\n${problems} confirmed problem(s): dead links or edges with no evidence.`
+    );
+  }
+  process.exit(problems > 0 ? 1 : 0);
+}
+
+main().catch((error) => {
+  console.error(`Unexpected error: ${error.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Resumes the original **Thread 2A** pipeline goal (after the data-integrity detour) with the next mechanical QA script: dead-link and missing-evidence checking for edges.

## What it does
`check-evidence` HEAD/GETs every edge `evidenceUrl` and flags edges with no evidence at all (no prose `evidence`, no `evidenceUrl`, no `evidenceNodeId`).

Results are **graded to avoid false alarms**:
- `2xx/3xx` → live
- `404/410` or DNS failure → **dead** (real problem, non-zero exit)
- `401/403/405/429/5xx`/timeout → **uncertain** (usually bot-blocking or transient) — reported, never fails the run

HEAD-first with a GET fallback (many servers reject HEAD), bounded concurrency, per-request timeout.

## It found (and this PR fixes) a real dead link
Running across all 12 datasets: the corpus is well-sourced — **all 2,288 edges have prose evidence** (0 missing), and only 35 carry URLs. One was dead:

> `rosicrucian-network` → `edge-boehme-member-christian-theosophy` cited `https://plato.stanford.edu/entries/boehme/` → **404** (the Stanford Encyclopedia has no Böhme entry; verified `/entries/schelling/` returns 200 as a control).

Replaced with the canonical Wikipedia page (prose evidence unchanged). The 2 Britannica `403`s are correctly graded "uncertain" (bot-blocking), not failures. Re-check: **0 dead** corpus-wide.

## CI wiring
Added to the weekly `data-health.yml` workflow (report-only, alongside `verify-ids`), **not** the PR gate — external URLs are too flaky to block PRs on. It posts any dead links to the run summary; when clean it shows ✅.

## Verification
- Full corpus run: 0 dead (after fix), 0 missing-evidence.
- All 12 datasets validate; `npm run lint` clean; both workflow YAMLs parse.

## Thread 2A status
- ✅ `enrich` (2A-1), `sync-manifest` (2A-3), `check-evidence` (2A-5)
- Remaining: `new-dataset` (2A-2), `fetch-banner` (2A-4), `suggest` (2A-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
