### PR TITLE
fetch-banner: Wikimedia Commons banner fetch (Thread 2A)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "enrich:dry-run": "npx tsx scripts/enrich-dataset/index.ts --dry-run",
     "sync-manifest": "npx tsx scripts/sync-manifest/index.ts",
     "sync-manifest:check": "npx tsx scripts/sync-manifest/index.ts --check",
+    "fetch-banner": "npx tsx scripts/fetch-banner/index.ts",
     "check-evidence": "npx tsx scripts/check-evidence/index.ts",
     "new-dataset": "npx tsx scripts/new-dataset/index.ts",
     "verify-ids": "npx tsx scripts/verify-ids/index.ts",

--- a/scripts/fetch-banner/commons.ts
+++ b/scripts/fetch-banner/commons.ts
@@ -1,0 +1,247 @@
+/**
+ * Thin, deterministic client for the Wikimedia Commons API.
+ *
+ * Searches the File namespace for images matching a themed query and returns
+ * candidates with their imageinfo - full URL, dimensions, MIME type and the
+ * `extmetadata` block that carries license + attribution. No language model is
+ * involved: the LLM/human supplies the search query, this module just fetches.
+ *
+ * Wikimedia asks that automated clients send a descriptive User-Agent:
+ * https://meta.wikimedia.org/wiki/User-Agent_policy
+ */
+
+const COMMONS_API = 'https://commons.wikimedia.org/w/api.php';
+const USER_AGENT =
+  'HistoryNet-fetch-banner/1.0 (https://github.com/moxious/historynet; dataset banner tool)';
+
+/** Max attempts before giving up on a request that keeps being throttled. */
+const MAX_RETRIES = 7;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * GET a Commons API endpoint with retry/backoff. Honors Retry-After on 429/5xx
+ * and otherwise backs off exponentially. Mirrors the approach used by the
+ * enrich-dataset Wikidata client.
+ */
+async function apiGet(
+  params: Record<string, string>
+): Promise<Record<string, unknown>> {
+  const url = new URL(COMMONS_API);
+  url.search = new URLSearchParams({ ...params, format: 'json' }).toString();
+
+  let lastError = '';
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    let res: Response;
+    try {
+      res = await fetch(url, { headers: { 'User-Agent': USER_AGENT } });
+    } catch (err) {
+      lastError = (err as Error).message;
+      await sleep(1000 * 2 ** attempt); // network blip - back off and retry
+      continue;
+    }
+
+    if (res.status === 429 || res.status >= 500) {
+      lastError = `HTTP ${res.status} ${res.statusText}`;
+      const retryAfter = Number(res.headers.get('retry-after'));
+      const wait =
+        Number.isFinite(retryAfter) && retryAfter > 0
+          ? retryAfter * 1000
+          : 1000 * 2 ** attempt;
+      await sleep(wait);
+      continue;
+    }
+    if (!res.ok) {
+      throw new Error(
+        `Commons API returned HTTP ${res.status} ${res.statusText}`
+      );
+    }
+    return (await res.json()) as Record<string, unknown>;
+  }
+
+  throw new Error(`Commons API failed after ${MAX_RETRIES} retries: ${lastError}`);
+}
+
+/** A single value entry inside an imageinfo `extmetadata` block. */
+interface ExtMetaValue {
+  value?: string;
+  source?: string;
+}
+
+interface RawImageInfo {
+  url?: string;
+  descriptionurl?: string;
+  mime?: string;
+  width?: number;
+  height?: number;
+  extmetadata?: Record<string, ExtMetaValue>;
+}
+
+interface RawPage {
+  pageid?: number;
+  title?: string;
+  index?: number;
+  imageinfo?: RawImageInfo[];
+}
+
+/** A Commons image candidate with license + attribution extracted. */
+export interface CommonsImage {
+  /** File page title, e.g. "File:Some painting.jpg". */
+  title: string;
+  /** Direct URL to the full-resolution binary. */
+  imageUrl: string;
+  /** Human-facing Commons file description page URL (provenance). */
+  descriptionUrl: string;
+  mime: string;
+  width: number;
+  height: number;
+  /** Short license name, e.g. "CC BY-SA 4.0" or "Public domain". */
+  license: string;
+  /** Machine license code from Commons, e.g. "cc-by-sa-4.0", "pd". */
+  licenseCode: string;
+  /** Plain-text author/artist (HTML stripped), best-effort. */
+  artist: string;
+  /** Whether the license requires attribution. */
+  attributionRequired: boolean;
+  /** True when the license is a free/open one (CC / public domain). */
+  isFree: boolean;
+  /** Search relevance rank from the API (lower is better). */
+  searchIndex: number;
+}
+
+/** Strip HTML tags and collapse whitespace from an extmetadata value. */
+function stripHtml(html: string | undefined): string {
+  if (!html) return '';
+  return html
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;|&apos;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Decide whether an extmetadata License code represents a free/open license.
+ * We accept Creative Commons and public-domain variants and reject anything
+ * marked non-free (fair use, "used with permission", etc.).
+ */
+function classifyLicense(meta: Record<string, ExtMetaValue>): {
+  isFree: boolean;
+  code: string;
+  short: string;
+} {
+  const code = (meta.License?.value ?? '').toLowerCase().trim();
+  const shortRaw = stripHtml(meta.LicenseShortName?.value);
+  const usage = (meta.UsageTerms?.value ?? '').toLowerCase();
+
+  const pdHints =
+    /public domain|cc0|creative commons zero|no known copyright/;
+
+  const isFree =
+    code.startsWith('cc0') ||
+    code.startsWith('cc-by') ||
+    code.startsWith('cc-sa') ||
+    code.startsWith('pd') ||
+    code.startsWith('public') ||
+    code === 'no restrictions' ||
+    pdHints.test(shortRaw.toLowerCase()) ||
+    pdHints.test(usage);
+
+  // Normalize a display string for public-domain cases that lack a short name.
+  let short = shortRaw;
+  if (!short) {
+    if (/^pd|public/.test(code) || pdHints.test(usage)) short = 'Public domain';
+    else if (code) short = code.toUpperCase();
+  }
+
+  return { isFree, code, short };
+}
+
+/**
+ * Search Commons (File namespace) for images matching `query` and return
+ * candidates ordered by search relevance, each with license + attribution
+ * resolved from its `extmetadata`.
+ */
+export async function searchImages(
+  query: string,
+  limit = 15
+): Promise<CommonsImage[]> {
+  const data = await apiGet({
+    action: 'query',
+    generator: 'search',
+    gsrnamespace: '6', // File namespace
+    gsrsearch: query,
+    gsrlimit: String(limit),
+    prop: 'imageinfo',
+    iiprop: 'url|size|mime|extmetadata',
+  });
+
+  const pages =
+    (data.query as { pages?: Record<string, RawPage> } | undefined)?.pages ?? {};
+
+  const images: CommonsImage[] = [];
+  for (const page of Object.values(pages)) {
+    const info = page.imageinfo?.[0];
+    if (!info?.url) continue;
+    const meta = info.extmetadata ?? {};
+    const { isFree, code, short } = classifyLicense(meta);
+    const artist =
+      stripHtml(meta.Artist?.value) || stripHtml(meta.Credit?.value) || '';
+    const attributionRequired =
+      (meta.AttributionRequired?.value ?? '').toLowerCase() === 'true';
+
+    images.push({
+      title: page.title ?? '(untitled)',
+      imageUrl: info.url,
+      descriptionUrl: info.descriptionurl ?? '',
+      mime: info.mime ?? '',
+      width: info.width ?? 0,
+      height: info.height ?? 0,
+      license: short || '(unknown license)',
+      licenseCode: code,
+      artist,
+      attributionRequired,
+      isFree,
+      searchIndex: page.index ?? Number.MAX_SAFE_INTEGER,
+    });
+  }
+
+  images.sort((a, b) => a.searchIndex - b.searchIndex);
+  return images;
+}
+
+/**
+ * Choose the best candidate for a banner: prefer freely-licensed raster images
+ * (JPEG/PNG), then fall back to search relevance. Returns null if nothing
+ * usable was found.
+ */
+export function pickBest(images: CommonsImage[]): CommonsImage | null {
+  const raster = images.filter(
+    (img) => img.mime === 'image/jpeg' || img.mime === 'image/png'
+  );
+  const pool = raster.length > 0 ? raster : images;
+
+  const free = pool.filter((img) => img.isFree);
+  const candidates = free.length > 0 ? free : pool;
+  if (candidates.length === 0) return null;
+
+  // Among the acceptable pool, honor search relevance first; the API already
+  // orders by how well the file matches the themed query.
+  return candidates[0];
+}
+
+/** Download a binary image, returning its bytes. */
+export async function downloadImage(imageUrl: string): Promise<Buffer> {
+  const res = await fetch(imageUrl, { headers: { 'User-Agent': USER_AGENT } });
+  if (!res.ok) {
+    throw new Error(
+      `Failed to download image: HTTP ${res.status} ${res.statusText}`
+    );
+  }
+  const arrayBuffer = await res.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}

--- a/scripts/fetch-banner/index.ts
+++ b/scripts/fetch-banner/index.ts
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+/**
+ * Banner Image Fetch CLI
+ *
+ * Queries the Wikimedia Commons API for a themed image relevant to a dataset,
+ * picks the best freely-licensed candidate, and captures its license +
+ * attribution. The LLM/human supplies the search query; the fetch and license
+ * capture are scripted.
+ *
+ * Design:
+ *   - Dry-run by default: prints the chosen image (title, URL, license,
+ *     attribution) and writes NOTHING. Choosing "the" banner and committing a
+ *     binary asset are deliberate decisions for the repo owner - the tool
+ *     proposes, a human confirms.
+ *   - --download opts in to actually fetching the binary and writing files:
+ *     saves to public/img/banners/<id>.jpg and records the path + license +
+ *     attribution in the dataset's manifest.json (format-preserving).
+ *   - Prefers CC / public-domain images; non-free candidates are flagged.
+ *
+ * Usage:
+ *   npx tsx scripts/fetch-banner/index.ts --dataset <id> --query "..." [options]
+ *
+ * Options:
+ *   --dataset <id>   Dataset directory name (required).
+ *   --query <text>   Commons search query (required). Quote multi-word queries.
+ *   --download       Actually fetch the image + update the manifest.
+ *                    Default: dry-run (report only, no writes).
+ *   --limit <n>      Number of Commons candidates to consider. Default: 15.
+ *   --quiet          Suppress the alternative-candidates listing.
+ *   --json           Emit the chosen candidate as JSON (implies --quiet).
+ *   --help, -h       Show this help.
+ */
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+import {
+  searchImages,
+  pickBest,
+  downloadImage,
+  type CommonsImage,
+} from './commons.js';
+import { updateManifestText, type BannerFields } from './manifest.js';
+
+const DATASETS_DIR = 'public/datasets';
+const BANNERS_DIR = 'public/img/banners';
+
+interface CLIOptions {
+  dataset?: string;
+  query?: string;
+  download: boolean;
+  limit: number;
+  quiet: boolean;
+  json: boolean;
+}
+
+function parseArgs(args: string[]): CLIOptions {
+  const options: CLIOptions = {
+    download: false,
+    limit: 15,
+    quiet: false,
+    json: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case '--dataset':
+        options.dataset = args[++i];
+        break;
+      case '--query':
+        options.query = args[++i];
+        break;
+      case '--download':
+        options.download = true;
+        break;
+      case '--limit': {
+        const n = Number(args[++i]);
+        if (!Number.isInteger(n) || n <= 0) {
+          console.error('--limit must be a positive integer');
+          process.exit(1);
+        }
+        options.limit = n;
+        break;
+      }
+      case '--quiet':
+        options.quiet = true;
+        break;
+      case '--json':
+        options.json = true;
+        options.quiet = true;
+        break;
+      case '--help':
+      case '-h':
+        showHelp();
+        process.exit(0);
+        break;
+      default:
+        if (arg.startsWith('-')) {
+          console.error(`Unknown option: ${arg}`);
+          showHelp();
+          process.exit(1);
+        }
+    }
+  }
+
+  return options;
+}
+
+function showHelp(): void {
+  console.log(`
+Banner Image Fetch CLI for Scenius
+
+Queries Wikimedia Commons for a themed banner image, picks the best
+freely-licensed candidate, and captures its license + attribution.
+
+Dry-run by default: it reports the chosen image and writes nothing. Pass
+--download to actually fetch the binary and update the manifest.
+
+Usage:
+  npx tsx scripts/fetch-banner/index.ts --dataset <id> --query "..." [options]
+
+Options:
+  --dataset <id>   Dataset directory name (required).
+  --query <text>   Commons search query (required). Quote multi-word queries.
+  --download       Actually fetch the image + update the manifest.
+                   Default: dry-run (report only, no writes).
+  --limit <n>      Number of Commons candidates to consider. Default: 15.
+  --quiet          Suppress the alternative-candidates listing.
+  --json           Emit the chosen candidate as JSON (implies --quiet).
+  --help, -h       Show this help.
+
+Examples:
+  npm run fetch-banner -- --dataset enlightenment --query "Enlightenment salon painting"
+  npm run fetch-banner -- --dataset enlightenment --query "Enlightenment salon painting" --download
+`);
+}
+
+/** Compose a plain-text attribution for the manifest. */
+function buildAttribution(image: CommonsImage): string {
+  const author = image.artist.trim();
+  const base = author && author.toLowerCase() !== 'unknown author'
+    ? author
+    : 'Unknown author';
+  return `${base}, via Wikimedia Commons`;
+}
+
+function printChosen(image: CommonsImage, options: CLIOptions): void {
+  console.log('\nChosen Commons image:');
+  console.log(`  Title:       ${image.title}`);
+  console.log(`  Image URL:   ${image.imageUrl}`);
+  console.log(`  File page:   ${image.descriptionUrl}`);
+  console.log(`  Dimensions:  ${image.width} x ${image.height} (${image.mime})`);
+  console.log(`  License:     ${image.license}${image.isFree ? '' : '  [NON-FREE - review!]'}`);
+  console.log(`  Attribution: ${buildAttribution(image)}`);
+  console.log(
+    `  Attribution required: ${image.attributionRequired ? 'yes' : 'no'}`
+  );
+
+  if (!options.quiet && !options.download) {
+    console.log('\n  (dry-run: no files written; pass --download to fetch + update manifest)');
+  }
+}
+
+function printAlternatives(images: CommonsImage[], chosen: CommonsImage): void {
+  const others = images.filter((i) => i !== chosen).slice(0, 5);
+  if (others.length === 0) return;
+  console.log('\nOther candidates:');
+  for (const img of others) {
+    const flag = img.isFree ? '' : ' [non-free]';
+    console.log(`  - ${img.title} (${img.license}${flag})`);
+  }
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (!options.dataset || !options.query) {
+    console.error('Both --dataset and --query are required.\n');
+    showHelp();
+    process.exit(1);
+  }
+
+  const datasetsPath = resolve(process.cwd(), DATASETS_DIR);
+  const manifestPath = join(datasetsPath, options.dataset, 'manifest.json');
+  if (!existsSync(manifestPath)) {
+    console.error(
+      `Dataset "${options.dataset}" not found or missing manifest.json`
+    );
+    process.exit(1);
+  }
+
+  const images = await searchImages(options.query, options.limit);
+  if (images.length === 0) {
+    console.error(`No Commons images found for query: "${options.query}"`);
+    process.exit(1);
+  }
+
+  const chosen = pickBest(images);
+  if (!chosen) {
+    console.error('No usable image candidate found.');
+    process.exit(1);
+  }
+
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          dataset: options.dataset,
+          title: chosen.title,
+          imageUrl: chosen.imageUrl,
+          descriptionUrl: chosen.descriptionUrl,
+          license: chosen.license,
+          licenseCode: chosen.licenseCode,
+          attribution: buildAttribution(chosen),
+          attributionRequired: chosen.attributionRequired,
+          isFree: chosen.isFree,
+          mime: chosen.mime,
+          width: chosen.width,
+          height: chosen.height,
+          downloaded: false,
+        },
+        null,
+        2
+      )
+    );
+  } else {
+    printChosen(chosen, options);
+    if (!options.quiet) printAlternatives(images, chosen);
+  }
+
+  if (!options.download) {
+    process.exit(0);
+  }
+
+  // --- Download mode: fetch the binary and update the manifest. ---
+  if (!chosen.isFree) {
+    console.error(
+      '\nRefusing to download a non-free image. Re-run with a query that ' +
+        'surfaces a CC / public-domain image, or choose one manually.'
+    );
+    process.exit(1);
+  }
+
+  const bannersDir = resolve(process.cwd(), BANNERS_DIR);
+  await mkdir(bannersDir, { recursive: true });
+  const relPath = `img/banners/${options.dataset}.jpg`;
+  const outPath = join(bannersDir, `${options.dataset}.jpg`);
+
+  if (chosen.mime !== 'image/jpeg') {
+    console.warn(
+      `\nNote: source MIME is ${chosen.mime}; saving bytes as ${relPath} ` +
+        'to match the repo convention.'
+    );
+  }
+
+  const bytes = await downloadImage(chosen.imageUrl);
+  await writeFile(outPath, bytes);
+
+  const fields: BannerFields = {
+    bannerImage: relPath,
+    bannerImageLicense: chosen.license,
+    bannerImageAttribution: buildAttribution(chosen),
+    bannerImageSource: chosen.descriptionUrl || undefined,
+  };
+  const originalText = await readFile(manifestPath, 'utf-8');
+  await writeFile(manifestPath, updateManifestText(originalText, fields), 'utf-8');
+
+  console.log(`\nWrote image:    ${outPath} (${bytes.length} bytes)`);
+  console.log(`Updated manifest: ${manifestPath}`);
+  console.log(`  bannerImage:            ${fields.bannerImage}`);
+  console.log(`  bannerImageLicense:     ${fields.bannerImageLicense}`);
+  console.log(`  bannerImageAttribution: ${fields.bannerImageAttribution}`);
+  if (fields.bannerImageSource) {
+    console.log(`  bannerImageSource:      ${fields.bannerImageSource}`);
+  }
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error(`Unexpected error: ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/fetch-banner/manifest.ts
+++ b/scripts/fetch-banner/manifest.ts
@@ -1,0 +1,81 @@
+/**
+ * Format-preserving manifest updater for banner fields.
+ *
+ * Rather than re-serialize the whole manifest (which would reorder keys and
+ * churn formatting), this splices the banner keys in as text, anchored on the
+ * required `bannerImage` line. Existing license/attribution/source lines are
+ * removed first so re-running the tool is idempotent.
+ */
+
+/** The banner-related fields written into a manifest. */
+export interface BannerFields {
+  /** Relative path, e.g. "img/banners/enlightenment.jpg". */
+  bannerImage: string;
+  /** Short license name, e.g. "CC BY-SA 4.0" or "Public domain". */
+  bannerImageLicense: string;
+  /** Plain-text author/attribution. */
+  bannerImageAttribution: string;
+  /** Commons file description page URL (provenance). */
+  bannerImageSource?: string;
+}
+
+const EXTRA_KEYS = [
+  'bannerImageLicense',
+  'bannerImageAttribution',
+  'bannerImageSource',
+] as const;
+
+/**
+ * Return a new manifest text with the banner fields set/updated, preserving the
+ * surrounding formatting. Throws if the input is not valid JSON, if it has no
+ * `bannerImage` field to anchor on, or if the result would not parse.
+ */
+export function updateManifestText(text: string, fields: BannerFields): string {
+  JSON.parse(text); // validate input up front
+
+  const newline = text.includes('\r\n') ? '\r\n' : '\n';
+  const hadTrailingNewline = /\r?\n$/.test(text);
+  let lines = text.replace(/\r?\n$/, '').split(/\r?\n/);
+
+  // Drop existing extra-key lines so re-runs don't accumulate duplicates.
+  const keyLineRe = (k: string) => new RegExp(`^\\s*"${k}"\\s*:`);
+  lines = lines.filter((l) => !EXTRA_KEYS.some((k) => keyLineRe(k).test(l)));
+
+  const biIdx = lines.findIndex((l) => /^\s*"bannerImage"\s*:/.test(l));
+  if (biIdx === -1) {
+    throw new Error(
+      'manifest has no "bannerImage" field to anchor banner updates'
+    );
+  }
+
+  const indent = /^(\s*)/.exec(lines[biIdx])?.[1] ?? '  ';
+
+  // Is bannerImage currently the last property (next real line is the "}")?
+  let nextIdx = biIdx + 1;
+  while (nextIdx < lines.length && lines[nextIdx].trim() === '') nextIdx++;
+  const isLastProperty =
+    nextIdx >= lines.length || lines[nextIdx].trim().startsWith('}');
+
+  const entries: Array<[string, string]> = [
+    ['bannerImage', fields.bannerImage],
+    ['bannerImageLicense', fields.bannerImageLicense],
+    ['bannerImageAttribution', fields.bannerImageAttribution],
+  ];
+  if (fields.bannerImageSource) {
+    entries.push(['bannerImageSource', fields.bannerImageSource]);
+  }
+
+  const block = entries.map(([k, v], i) => {
+    const isLastInBlock = i === entries.length - 1;
+    const comma = isLastProperty && isLastInBlock ? '' : ',';
+    return `${indent}${JSON.stringify(k)}: ${JSON.stringify(v)}${comma}`;
+  });
+
+  lines.splice(biIdx, 1, ...block);
+
+  let result = lines.join(newline);
+  if (hadTrailingNewline) result += newline;
+
+  JSON.parse(result); // guard against corrupting the file
+  return result;
+}

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -69,6 +69,12 @@ export interface DatasetManifest {
   bannerEmoji?: string;
   /** Path to banner image (relative to public/, e.g., "img/banners/enlightenment.jpg") */
   bannerImage?: string;
+  /** Short license name for the banner image, e.g. "CC BY-SA 4.0" or "Public domain" */
+  bannerImageLicense?: string;
+  /** Plain-text author/attribution for the banner image */
+  bannerImageAttribution?: string;
+  /** Source page for the banner image (e.g. Wikimedia Commons file page URL) */
+  bannerImageSource?: string;
   /** Structured scope information */
   scope?: DatasetScope;
   /** Legacy temporal scope string (e.g., "2012-2025") */


### PR DESCRIPTION
## Summary

Adds `scripts/fetch-banner/` — the last remaining Thread 2A pipeline script (2A-4). It queries the Wikimedia Commons API for a themed image relevant to a dataset, picks the best freely-licensed candidate, and captures its license + attribution.

Run it with:

```
npm run fetch-banner -- --dataset <id> --query "..."
```

## Defaults to dry-run; does not commit binaries

- **Dry-run by default.** With no `--download` flag, the tool writes nothing. It prints the chosen Commons image: title, full image URL, license (e.g. `CC BY-SA 4.0` / `Public domain`), attribution/author, and whether attribution is required — plus a few alternative candidates. Choosing "the" banner and committing a binary asset are deliberate calls for the repo owner; the tool proposes, a human confirms.
- **`--download` opts in** to actually fetching the binary to `public/img/banners/<id>.jpg` and recording the path + license/attribution in the dataset's `manifest.json` (format-preserving text splice, verified idempotent). Non-free images are refused for download.
- **No binary image assets are included in this PR.** The download path was exercised during testing and then fully reverted (`git checkout`), so the diff is source-only.

## License / attribution capture

License and attribution come from each file's `imageinfo` `extmetadata`: `LicenseShortName` / `License` for the license, `Artist` (falling back to `Credit`) for the author, and `AttributionRequired`. Author HTML is stripped to plain text. Candidates are classified free (CC / public-domain) vs non-free, and `pickBest` prefers freely-licensed raster (JPEG/PNG) images by search relevance.

Manifest fields written on `--download`: `bannerImageLicense`, `bannerImageAttribution` (`"<author>, via Wikimedia Commons"`), and `bannerImageSource` (the Commons file-page URL). These are added to the `DatasetManifest` type as optional fields; the dataset validator accepts them (it does not reject unknown keys).

## Conventions

- `scripts/<name>/index.ts` run via `npx tsx`, `#!/usr/bin/env node` + JSDoc usage header, `--dataset` / `--download` / `--quiet` / `--json` / `--help` flags, ESM `.js` imports, `node:fs/promises`.
- Reuses the enrich-dataset retry/backoff pattern (honor `Retry-After`, exponential backoff on 429/5xx) and sends a descriptive Wikimedia `User-Agent`.
- `"fetch-banner"` npm script inserted immediately after `"sync-manifest:check"`.

## Validation

- `npx eslint scripts/fetch-banner/` exits 0.
- Real dry-run against `enlightenment` prints a sensible PD image + license + attribution with no file writes (see below).

```
Chosen Commons image:
  Title:       File:Jean-Jacques Rousseau (painted portrait).jpg
  Image URL:   https://upload.wikimedia.org/wikipedia/commons/b/b7/Jean-Jacques_Rousseau_%28painted_portrait%29.jpg
  File page:   https://commons.wikimedia.org/wiki/File:Jean-Jacques_Rousseau_(painted_portrait).jpg
  Dimensions:  1448 x 2016 (image/jpeg)
  License:     Public domain
  Attribution: Maurice Quentin de La Tour, via Wikimedia Commons
  Attribution required: no
```

This completes Thread 2A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)