### PR TITLE
docs(agents): add Dataset Tooling inventory to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,6 +326,48 @@ Manual checklist for dataset review:
 
 ---
 
+## Dataset Tooling
+
+All dataset operations are CLI tools under `scripts/<tool>/`, exposed as `npm run`
+scripts. **Every tool supports `--help`** — run `npm run <tool> -- --help` for its
+full flags and usage rather than re-reading the source. (The `--` is required so
+npm forwards the flag to the tool.) Most accept `--dataset <id>` (default: all),
+and `--dry-run`/`--json`/`--quiet` where meaningful.
+
+These form an "idea → validated dataset" pipeline. Build a dataset roughly in
+this order:
+
+| Command | Purpose |
+|---------|---------|
+| `npm run new-dataset -- --id <slug>` | Scaffold a new dataset: `manifest.json` skeleton + empty `nodes.json`/`edges.json`. `--from-idea "..."` seeds a scope stub to refine. |
+| `npm run enrich -- --dataset <id>` | Fill *missing* mechanical node fields (`wikidataId`, `wikipediaTitle`, dates, `birthPlace`, `nationality`, `occupations`, `shortDescription`) from Wikidata/Wikipedia. Only-missing; never overwrites prose. `enrich:dry-run` previews. |
+| `npm run check-evidence -- --dataset <id>` | Flag dead `evidenceUrl` links and edges with no evidence at all. |
+| `npm run sync-manifest -- --dataset <id>` | Recompute `nodeCount`/`edgeCount`, bump `lastUpdated`. `sync-manifest:check` is the read-only CI gate (fails on drift). |
+| `npm run validate:datasets -- --dataset <id>` | Schema + referential-integrity validation (see the checks table above). `:strict` treats warnings as errors. |
+
+**Wikidata ID integrity** (IDs power Wikipedia links + cross-dataset identity):
+
+| Command | Purpose |
+|---------|---------|
+| `npm run verify-ids -- --dataset <id>` | Audit existing `wikidataId`s against the real Wikidata entities; flags IDs pointing at the wrong thing. Read-only; exits non-zero on findings. `verify-ids:fix` clears/re-resolves wrong IDs (`--clear-unverifiable` also nulls unresolvable ones). |
+| `npm run resolve-ids -- --dataset <id>` | Assign correct IDs to null-`wikidataId` nodes via date-aware disambiguation (only high-confidence matches). `resolve-ids:dry-run` previews. |
+
+**Research & assets:**
+
+| Command | Purpose |
+|---------|---------|
+| `npm run suggest -- --dataset <id>` | Suggest people the dataset is missing, via cross-dataset gap detection (era overlap + edges linking a candidate to your existing members in another network). Report only. |
+| `npm run fetch-banner -- --dataset <id> --query "..."` | Find a themed banner on Wikimedia Commons and capture its license/attribution. **Dry-run by default** (prints the pick, writes nothing); pass `--download` to fetch the image + update the manifest. |
+
+> **Scheduled health checks**: `verify-ids` and `check-evidence` also run weekly
+> (non-blocking, report-only) via `.github/workflows/data-health.yml`, so
+> ID corruption or link rot surface even without a PR touching the data.
+
+**Maintenance**: when you add a `scripts/<tool>/`, wire it into `package.json`,
+give it a `--help`, and add a row to this inventory.
+
+---
+
 ## Common Tasks by Type
 
 ### Frontend Implementation Tasks
@@ -343,6 +385,7 @@ Manual checklist for dataset review:
 - Creating new datasets in `public/datasets/`
 - Validating existing datasets
 - Adding evidence to edges
+- **Use the CLI tools** — see [Dataset Tooling](#dataset-tooling) for the full inventory (`new-dataset`, `enrich`, `verify-ids`, `resolve-ids`, `check-evidence`, `sync-manifest`, `suggest`, `fetch-banner`)
 
 ### Infrastructure Tasks
 - GitHub Actions workflow configuration


### PR DESCRIPTION
Closes out Thread 2A by making the tools we built discoverable to agents.

## The problem
The Thread 2A work added ~8 CLI tools, but `AGENTS.md` still only mentioned `validate:datasets`. Agents had no way to discover the rest except grepping `package.json` — which gives *names* but not *purpose* or *when to use*, and buries the dataset tools among `dev`/`build`/`test:*`/`migrate:*`.

## The approach (layered, no duplication)
- **`--help` stays the per-tool contract** — every tool already implements it (verified). Documented the convention: run `npm run <tool> -- --help`, don't re-read source.
- **New "Dataset Tooling" inventory** — the discovery index `package.json` can't provide. Organized by the actual workflow:
  - Create pipeline: new-dataset, enrich, check-evidence, sync-manifest, validate:datasets
  - ID integrity: verify-ids, resolve-ids
  - Research & assets: suggest, fetch-banner
- **Maintenance rule** so it doesn't rot: adding a `scripts/<tool>/` means wiring `package.json` + a `--help` + an inventory row.

Deliberately **not** writing per-tool markdown files — they'd duplicate `--help` and drift. Discovery via the inventory, detail via `--help`.

## Verified
Every documented command/flag was checked against the tools' actual `--help` output (including the agent-built `fetch-banner`). Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
