### PR TITLE
docs(roadmap): refresh for Thread 2A completion + Track D reassessment

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,6 +24,29 @@ This document outlines the future direction for Scenius.
 
 **Shipped Datasets**: AI-LLM Research, Rosicrucian Network, Enlightenment, Ambient Music, Cybernetics, Protestant Reformation, Renaissance Humanism, Scientific Revolution, Florentine Academy, Christian Kabbalah, Statistics & Social Physics
 
+### Dataset Pipeline Tooling — Thread 2A ✅ Complete (2026-07)
+
+Converted the deterministic steps of the "idea → dataset" pipeline from full-LLM
+work into CLI tools (all under `scripts/`, all with `--help`; see the
+[Dataset Tooling inventory in AGENTS.md](AGENTS.md#dataset-tooling)):
+
+- `new-dataset` — scaffold a dataset skeleton
+- `enrich` — fill missing mechanical fields (IDs, dates, places, occupations) from Wikidata/Wikipedia
+- `check-evidence` — flag dead evidence links and unsupported edges
+- `sync-manifest` — reconcile node/edge counts (+ CI gate)
+- `suggest` — cross-dataset gap detection (down payment on M38)
+- `fetch-banner` — Wikimedia Commons banner + license capture
+
+### Data Integrity Remediation ✅ (2026-07)
+
+While building the pipeline, `verify-ids` surfaced systematic Wikidata-ID
+corruption (fabricated IDs pointing at unrelated entities) in **5 of 12
+datasets** — up to 88% wrong. All remediated:
+
+- `verify-ids` / `resolve-ids` — audit, clear, and date-aware re-resolution of IDs
+- 5 datasets corrected; ~146 wrong IDs cleared/restored, 72 recovered to the correct entity
+- Manifest drift fixed; guards added to CI (`sync-manifest:check` gate + weekly `data-health` report for `verify-ids` and `check-evidence`)
+
 ---
 
 ## Upcoming Milestones
@@ -41,7 +64,7 @@ This document outlines the future direction for Scenius.
 
 | # | Milestone | Description | Dependencies |
 |---|-----------|-------------|--------------|
-| M34 | Migration Infrastructure & Testing | Build migration tooling and comprehensive tests for atomic architecture transition ⏸ **Paused** — Phases 1–2 landed (PR #36); Phases 3–5 + blockers deferred behind Thread 2A | None |
+| M34 | Migration Infrastructure & Testing | Build migration tooling and comprehensive tests for atomic architecture transition ⏸ **Paused** — Phases 1–2 landed (PR #36); Phases 3–5 + P0 blockers B1–B4 open. **See Track D reassessment below before resuming.** | None |
 | M35 | Research Tooling | CLI tools for efficient entity management (find, create, edit, add-to-dataset) | M34 |
 | M36 | Atomic Architecture - Persons | Migrate Person entities to atomic files, prove architecture pattern | M34, M35 |
 | M37 | Full POLE Atomization | Extend atomization to Objects, Locations, Entities - complete architecture | M36 |
@@ -78,13 +101,31 @@ Completed Foundation
 ```
 
 **Recommended next**:
-- **Thread 2A (active)**: Pipeline scripting on the current data format — no
-  migration required. `enrich` and `sync-manifest` shipped; `new-dataset`,
-  `check-evidence`, `fetch-banner`, `suggest` remain. See
-  `milestones/thread2-pipeline-optimization.md`.
-- **Track B**: M26 (Custom Domain) - independent, quick win
-- **Track D**: M34 is ⏸ **paused** behind Thread 2A — resume deliberately once
-  2A is in hand (Phases 3–5 + blockers B1–B4 still open).
+- **Dogfood the pipeline**: build a brand-new dataset end-to-end
+  (`new-dataset → enrich → suggest → check-evidence → sync-manifest → validate:datasets`).
+  Validates that Thread 2A actually made dataset creation cheap, and grows content.
+- **Track B**: M26 (Custom Domain) — independent, quick win. M27 (Spam Protection).
+- **Track D (see reassessment below)**: M34 remains ⏸ paused (Phases 3–5 +
+  blockers B1–B4). Reconsider scope before resuming.
+
+### ⚠️ Track D reassessment (2026-07)
+
+Thread 2A was the "cheap high-ROI work first, then return to the atomic
+migration" detour. In doing it, **2A captured much of the value that originally
+motivated Track D (M34–M38)** on the *current* data format:
+
+| Original Track D goal | Delivered by Thread 2A on current format |
+|---|---|
+| Token-efficient entity edits | `enrich` turns per-node lookup into a command |
+| Cross-dataset entity identity | clean `wikidataId`s via `verify-ids`/`resolve-ids` (this was M34 blocker B1's concern) |
+| Inter-dataset research / gap detection | `suggest` (a working M38 down payment) |
+
+So the open decision is **not** "when to resume M34" but **"how much of the
+atomic migration is still worth doing"** now that its main benefits exist on the
+current format. Options: (a) resume M34–M38 as planned; (b) a lighter subset
+targeting only what 2A didn't cover; (c) keep it parked and invest in content
+(new datasets) and Track B. Decide deliberately with fresh evidence of pain that
+2A didn't already solve.
 
 ---
 

--- a/milestones/index.md
+++ b/milestones/index.md
@@ -97,20 +97,23 @@ M1-M20 (Core Application Complete) ✅
 
 ## Next Steps
 
-**Active direction (2026-07-27)**: **Thread 2A — pipeline scripting** (see
-`thread2-pipeline-optimization.md`). Format-agnostic scripts that speed up the
-"idea → dataset" pipeline on the *current* data format, no migration required.
-Shipped so far: `enrich` (Wikidata/Wikipedia field lookup) and `sync-manifest`
-(manifest count reconciliation + CI `--check`).
+**✅ Done (2026-07)**: **Thread 2A — pipeline scripting** is complete. All six
+scripts shipped (`new-dataset`, `enrich`, `check-evidence`, `sync-manifest`,
+`suggest`, `fetch-banner`), plus `verify-ids`/`resolve-ids` which emerged from a
+data-integrity issue those tools uncovered (5 datasets remediated). See the
+[Dataset Tooling inventory](../AGENTS.md#dataset-tooling) and
+`thread2-pipeline-optimization.md`.
 
-**Ready to implement** (dependencies satisfied):
-- **Thread 2A remainder**: `new-dataset`, `check-evidence`, `fetch-banner`, `suggest`
+**Recommended next**:
+- **Dogfood the pipeline** — create a new dataset end-to-end with the 2A tools.
 - **M26: Custom Domain** - Depends on M24 ✅ (quick, unblocked)
 - **M27: Spam Protection** - Depends on M25 ✅
 
-**Paused**:
+**Paused — reassess before resuming**:
 - **M34: Migration Infrastructure** - Phases 1–2 landed (PR #36); Phases 3–5 +
-  blockers B1–B4 consciously deferred behind Thread 2A. Resume deliberately later.
+  blockers B1–B4 open. Thread 2A delivered much of Track D's intended value on
+  the current format, so reconsider the atomic migration's scope — see the
+  "Track D reassessment" in `../ROADMAP.md`.
 
 **Track B progress**: M30 (Cross-Scene UI) complete. Full cross-scene discovery experience deployed with visual indicators, progressive disclosure, and seamless navigation across datasets.
 

--- a/milestones/thread2-pipeline-optimization.md
+++ b/milestones/thread2-pipeline-optimization.md
@@ -1,13 +1,24 @@
-# Thread 2: "Idea → Dataset" Pipeline Optimization (Plan)
+# Thread 2: "Idea → Dataset" Pipeline Optimization
 
-**Status**: 🟢 In progress — 2A-1 (`enrich`) and 2A-3 (`sync-manifest`) shipped 2026-07-27
+**Status**: ✅ **2A complete (2026-07)** — all six scripts shipped and merged.
 **Goal**: Make the "idea → validated dataset" pipeline faster and cheaper by
 converting *deterministic* steps from full-LLM work into scripts, leaving the
 LLM to do only what requires judgment.
 
-> Direction chosen 2026-07-27: **2A first**, Track D (M34 atomic migration)
-> paused behind it. It complements (does not replace) the atomic-architecture
-> milestones M35–M38.
+> **Outcome**: Sub-track 2A shipped in full: `new-dataset`, `enrich`,
+> `check-evidence`, `sync-manifest`, `suggest`, `fetch-banner` — plus two tools
+> that emerged when `enrich`/`verify-ids` uncovered systematic Wikidata-ID
+> corruption: `verify-ids` and `resolve-ids` (5 datasets remediated). See the
+> [Dataset Tooling inventory](../AGENTS.md#dataset-tooling) for usage.
+>
+> Sub-track 2B (Track D / M34–M38 atomic migration) remains paused. Because 2A
+> delivered token-efficient edits, cross-dataset identity, and gap detection on
+> the *current* format, the value case for the full atomic migration has shrunk —
+> see the "Track D reassessment" in `ROADMAP.md` before resuming it.
+
+> _(Historical note: direction chosen 2026-07-27 was "2A first, Track D paused
+> behind it." 2A is now done; the sections below are the original plan, kept for
+> reference — each PR-sized item shipped.)_
 
 ---
 


### PR DESCRIPTION
Brings the roadmap docs in line with reality after the Thread 2A arc. They still described 2A as in-progress and didn't mention the data-integrity work at all.

## Changes (docs-only)
- **`ROADMAP.md`**
  - "What's Shipped" now records **Thread 2A (all 6 pipeline tools)** and the **Data Integrity Remediation** (5 datasets' fabricated Wikidata IDs fixed, CI guards added).
  - "Recommended next" rewritten: **dogfood the pipeline** first, then Track B quick wins.
  - New **"Track D reassessment"**: 2A captured much of the atomic migration's intended value (token-efficient edits, cross-dataset identity, gap detection) on the *current* format — so the open question is no longer "when to resume M34" but "how much of M34–M38 is still worth doing." Lays out three options.
- **`milestones/index.md`**: Thread 2A marked done; Next Steps recommend dogfooding; M34 pause reframed around the reassessment.
- **`thread2-pipeline-optimization.md`**: status → ✅ complete; records shipped tools + the emergent `verify-ids`/`resolve-ids` remediation; original plan kept below for reference.

No code or data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
