### PR TITLE
fix(data): repair duplicate keys + entity-id collisions; Track D decision

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,8 @@ datasets** — up to 88% wrong. All remediated:
 
 - `verify-ids` / `resolve-ids` — audit, clear, and date-aware re-resolution of IDs
 - 5 datasets corrected; ~146 wrong IDs cleared/restored, 72 recovered to the correct entity
-- Manifest drift fixed; guards added to CI (`sync-manifest:check` gate + weekly `data-health` report for `verify-ids` and `check-evidence`)
+- Manifest drift fixed; guards added to CI (`sync-manifest:check` gate + weekly `data-health` report for `verify-ids`, `check-evidence`, and `cross-dataset`)
+- `cross-dataset` — cross-dataset entity consistency report (groundwork for the atomic decision below); repaired 82 nodes with duplicate JSON keys (leftover from an enrich bug) and fixed genuine two-entity id collisions
 
 ---
 
@@ -64,7 +65,7 @@ datasets** — up to 88% wrong. All remediated:
 
 | # | Milestone | Description | Dependencies |
 |---|-----------|-------------|--------------|
-| M34 | Migration Infrastructure & Testing | Build migration tooling and comprehensive tests for atomic architecture transition ⏸ **Paused** — Phases 1–2 landed (PR #36); Phases 3–5 + P0 blockers B1–B4 open. **See Track D reassessment below before resuming.** | None |
+| M34 | Migration Infrastructure & Testing | Build migration tooling and comprehensive tests for atomic architecture transition. Phases 1–2 landed (PR #36). **Decision (2026-07): resume, scoped to persons + places — see Track D decision below.** Next: clear P0 blockers B1–B4, then Phases 3–5. | None |
 | M35 | Research Tooling | CLI tools for efficient entity management (find, create, edit, add-to-dataset) | M34 |
 | M36 | Atomic Architecture - Persons | Migrate Person entities to atomic files, prove architecture pattern | M34, M35 |
 | M37 | Full POLE Atomization | Extend atomization to Objects, Locations, Entities - complete architecture | M36 |
@@ -100,32 +101,43 @@ Completed Foundation
                                                                   Research)
 ```
 
-**Recommended next**:
-- **Dogfood the pipeline**: build a brand-new dataset end-to-end
-  (`new-dataset → enrich → suggest → check-evidence → sync-manifest → validate:datasets`).
-  Validates that Thread 2A actually made dataset creation cheap, and grows content.
-- **Track B**: M26 (Custom Domain) — independent, quick win. M27 (Spam Protection).
-- **Track D (see reassessment below)**: M34 remains ⏸ paused (Phases 3–5 +
-  blockers B1–B4). Reconsider scope before resuming.
+**Recommended next**: proceed with **Track D (scoped)** — see the decision below.
+Track B quick wins (M26 Custom Domain, M27 Spam Protection) remain available as
+independent side quests.
 
-### ⚠️ Track D reassessment (2026-07)
+### ✅ Track D decision (2026-07): proceed, scoped to persons + places
 
-Thread 2A was the "cheap high-ROI work first, then return to the atomic
-migration" detour. In doing it, **2A captured much of the value that originally
-motivated Track D (M34–M38)** on the *current* data format:
+The Track D reassessment asked whether the atomic migration was still worth doing
+after Thread 2A. **Decision: yes — do it, scoped.** The reasoning corrected an
+error in the earlier reassessment:
 
-| Original Track D goal | Delivered by Thread 2A on current format |
-|---|---|
-| Token-efficient entity edits | `enrich` turns per-node lookup into a command |
-| Cross-dataset entity identity | clean `wikidataId`s via `verify-ids`/`resolve-ids` (this was M34 blocker B1's concern) |
-| Inter-dataset research / gap detection | `suggest` (a working M38 down payment) |
+**2A delivered identity *detection*, not identity *unification*.** 2A made it
+possible to *know* two nodes are the same entity (shared `wikidataId`), and that
+powers `suggest`, cross-scene discovery, and cheap enrichment. But it left the
+underlying duplication in place: the same entity still exists as **independent,
+drifting copies** per dataset. That single-canonical-record + contextual-override
+model is the distinct thing only the atomic architecture provides — and it's the
+real reason to do Track D.
 
-So the open decision is **not** "when to resume M34" but **"how much of the
-atomic migration is still worth doing"** now that its main benefits exist on the
-current format. Options: (a) resume M34–M38 as planned; (b) a lighter subset
-targeting only what 2A didn't cover; (c) keep it parked and invest in content
-(new datasets) and Track B. Decide deliberately with fresh evidence of pain that
-2A didn't already solve.
+**The evidence is measurable now** (`npm run cross-dataset`): **91 entities are
+shared/duplicated across datasets**, with real drift — London dated 47 vs 1490,
+Reuchlin's biography differing across 4 datasets, and one-`wikidataId`-two-entities
+collisions (a person and their book sharing an id). Every new overlapping dataset
+makes it worse.
+
+**Scope**: persons and locations are where reuse concentrates (33 persons, 39
+locations shared), so target **M36 + the locations half of M37**. Objects/full
+POLE (M37 remainder) and M38 can follow or be deferred.
+
+**Sequence**:
+1. **Cross-dataset consistency tooling + collision cleanup** — *done* (`cross-dataset`
+   report; 82 duplicate-key nodes repaired; genuine two-entity id collisions
+   fixed). Shrinks the problem and de-risks the migration.
+2. **M34 blockers B1–B4** — B1 (key canonical merge on `type + wikidataId`) and B2
+   (intra-dataset dedup) are exactly the mechanics of collapsing the duplicates
+   into canonical records. Then M34 Phases 3–5.
+3. **M35** — entity CLI.
+4. **M36 + locations** — atomic persons and places, with per-dataset overrides.
 
 ---
 

--- a/milestones/index.md
+++ b/milestones/index.md
@@ -104,16 +104,18 @@ data-integrity issue those tools uncovered (5 datasets remediated). See the
 [Dataset Tooling inventory](../AGENTS.md#dataset-tooling) and
 `thread2-pipeline-optimization.md`.
 
-**Recommended next**:
-- **Dogfood the pipeline** — create a new dataset end-to-end with the 2A tools.
-- **M26: Custom Domain** - Depends on M24 ✅ (quick, unblocked)
-- **M27: Spam Protection** - Depends on M25 ✅
+**Direction (2026-07): resume Track D, scoped to persons + places.** Dogfooding
+(the Blaxploitation dataset) confirmed 2A made creation cheap. The `cross-dataset`
+consistency report then showed 2A delivered identity *detection* but not
+*unification* — 91 entities are duplicated across datasets and drifting — which is
+the distinct value the atomic architecture provides. See the "Track D decision" in
+`../ROADMAP.md`.
 
-**Paused — reassess before resuming**:
-- **M34: Migration Infrastructure** - Phases 1–2 landed (PR #36); Phases 3–5 +
-  blockers B1–B4 open. Thread 2A delivered much of Track D's intended value on
-  the current format, so reconsider the atomic migration's scope — see the
-  "Track D reassessment" in `../ROADMAP.md`.
+**Next**:
+- **Track D**: clear M34 blockers B1–B4 (canonical merge on `type + wikidataId`;
+  intra-dataset dedup — the mechanics of collapsing the duplicates), then Phases
+  3–5 → M35 → M36 + locations.
+- **M26: Custom Domain** / **M27: Spam Protection** — independent quick wins.
 
 **Track B progress**: M30 (Cross-Scene UI) complete. Full cross-scene discovery experience deployed with visual indicators, progressive disclosure, and seamless navigation across datasets.
 

--- a/public/datasets/ai-llm-research/nodes.json
+++ b/public/datasets/ai-llm-research/nodes.json
@@ -229,7 +229,6 @@
     "nationality": "American",
     "occupations": ["AI researcher"],
     "biography": "Alec Radford is a research scientist at OpenAI since its early days. Primary author on GPT-1, GPT-2, CLIP, and DALL-E papers. Rarely gives interviews but considered one of most impactful researchers in the field.",
-    "wikipediaTitle": null,
     "wikidataId": "Q29180956",
     "wikipediaTitle": "Alec_Radford"
   },
@@ -1130,7 +1129,6 @@
     "nationality": "French",
     "occupations": ["engineer", "executive"],
     "biography": "Julien Chaumond is co-founder and CTO of Hugging Face. Technical leadership of Hugging Face platform and infrastructure.",
-    "wikipediaTitle": null,
     "wikidataId": "Q140533344",
     "wikipediaTitle": "Julien_Chaumond"
   },
@@ -1215,7 +1213,6 @@
     "shortDescription": "Co-founder of Cohere; former Google Brain researcher; worked with Hinton on capsule networks",
     "occupations": ["AI researcher", "entrepreneur"],
     "biography": "Nick Frosst co-founded Cohere. Former Google Brain researcher who worked with Geoffrey Hinton on capsule networks. Bridged Hinton's research to commercial applications.",
-    "wikipediaTitle": null,
     "wikidataId": "Q133538772",
     "wikipediaTitle": "Nick_Frosst",
     "dateStart": "1993",

--- a/public/datasets/ambient-music/nodes.json
+++ b/public/datasets/ambient-music/nodes.json
@@ -1518,8 +1518,6 @@
     "creators": [
       "person-michael-nyman"
     ],
-    "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q5248828",
     "wikipediaTitle": "Decay_Music"
   },
@@ -1560,7 +1558,6 @@
       "person-haruomi-hosono"
     ],
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q11614996"
   },
   {
@@ -1703,8 +1700,8 @@
     "creators": [
       "person-don-buchla"
     ],
-    "wikipediaTitle": "Buchla_Electronic_Musical_Instruments",
-    "wikidataId": "Q4676716"
+    "wikipediaTitle": null,
+    "wikidataId": null
   },
   {
     "id": "object-buchla-easel",
@@ -1962,8 +1959,8 @@
     "shortDescription": "Crucible of German electronic music and Eno collaborations",
     "country": "Germany",
     "parentLocation": "loc-cologne",
-    "wikipediaTitle": "Conny_Plank",
-    "wikidataId": "Q61428"
+    "wikipediaTitle": null,
+    "wikidataId": null
   },
   {
     "id": "loc-grm",
@@ -1974,8 +1971,7 @@
     "country": "France",
     "parentLocation": "loc-paris",
     "wikipediaTitle": "Groupe_de_recherches_musicales",
-    "wikidataId": null,
-    "wikidataId": "Q823560",
+    "wikidataId": "Q1780333",
     "dateStart": "1948"
   },
   {
@@ -2025,7 +2021,6 @@
     "dateStart": "1973",
     "dateEnd": "1979",
     "wikipediaTitle": "Black_Ark",
-    "wikidataId": null,
     "wikidataId": "Q2331306"
   },
   {
@@ -2107,7 +2102,6 @@
     "shortDescription": "International summer courses where avant-garde traditions met",
     "country": "Germany",
     "wikipediaTitle": "Darmstadt_International_Summer_Courses_for_New_Music",
-    "wikidataId": null,
     "wikidataId": "Q694704",
     "dateStart": "1946"
   },
@@ -2156,7 +2150,6 @@
     "parentLocation": "loc-new-york",
     "dateStart": "1971",
     "wikipediaTitle": "The_Kitchen",
-    "wikidataId": null,
     "wikidataId": "Q1743849"
   },
   {
@@ -2470,7 +2463,6 @@
     "dateStart": "1981",
     "headquarters": "loc-london",
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q118256298"
   },
   {
@@ -2641,8 +2633,7 @@
     ],
     "headquarters": "loc-paris",
     "wikipediaTitle": "Groupe_de_recherches_musicales",
-    "wikidataId": null,
-    "wikidataId": "Q823560"
+    "wikidataId": "Q1780333"
   },
   {
     "id": "entity-sftmc-org",
@@ -2742,8 +2733,6 @@
     ],
     "birthPlace": "Japan",
     "nationality": "Japanese",
-    "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q96187424",
     "wikipediaTitle": "Satoshi_Ashikawa"
   },

--- a/public/datasets/christian-kabbalah/nodes.json
+++ b/public/datasets/christian-kabbalah/nodes.json
@@ -329,7 +329,6 @@
     "language": "Latin/Hebrew",
     "subject": "Hebrew language",
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q42188609"
   },
   {
@@ -405,7 +404,6 @@
     "language": "Latin",
     "subject": "angel magic, philosophy of history",
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q121991644"
   },
   {
@@ -455,7 +453,6 @@
       "Conclusiones"
     ],
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q42294258"
   },
   {
@@ -701,7 +698,7 @@
     "dateStart": "1388",
     "headquarters": "location-cologne",
     "wikipediaTitle": "University_of_Cologne",
-    "wikidataId": "Q151510"
+    "wikidataId": "Q54096"
   },
   {
     "id": "entity-dominican-order",

--- a/public/datasets/cybernetics-information-theory/nodes.json
+++ b/public/datasets/cybernetics-information-theory/nodes.json
@@ -562,7 +562,6 @@
     ],
     "nationality": "American",
     "subgroup": "Macy Conference Core",
-    "wikidataId": null,
     "wikidataId": "Q2406358",
     "birthPlace": "Harvey"
   },
@@ -1479,8 +1478,8 @@
     ],
     "language": "English",
     "shortDescription": "Book version with Shannon's paper and Weaver's accessible introduction",
-    "wikipediaTitle": "A_Mathematical_Theory_of_Communication",
-    "wikidataId": "Q724029"
+    "wikipediaTitle": null,
+    "wikidataId": null
   },
   {
     "id": "object-computable-numbers-turing",
@@ -1623,7 +1622,6 @@
     "language": "English",
     "shortDescription": "Proposed Hebbian learning: 'neurons that fire together wire together'",
     "wikipediaTitle": "The_Organization_of_Behavior",
-    "wikidataId": null,
     "wikidataId": "Q7755339"
   },
   {
@@ -1719,9 +1717,8 @@
     ],
     "language": "English",
     "shortDescription": "Foundational text for systems theory",
-    "wikipediaTitle": "General_System_Theory",
-    "wikidataId": null,
-    "wikidataId": "Q269699"
+    "wikipediaTitle": null,
+    "wikidataId": null
   },
   {
     "id": "object-cybernetics-management-beer",
@@ -1749,7 +1746,6 @@
     "language": "English",
     "shortDescription": "Presented the Viable System Model (VSM)",
     "wikipediaTitle": "Brain_of_the_Firm",
-    "wikidataId": null,
     "wikidataId": "Q140611064"
   },
   {
@@ -1835,7 +1831,6 @@
     "language": "English",
     "shortDescription": "Proposed enaction—cognition as embodied action",
     "wikipediaTitle": "The_Embodied_Mind",
-    "wikidataId": null,
     "wikidataId": "Q1335050"
   },
   {
@@ -1903,7 +1898,6 @@
         "url": "https://en.wikipedia.org/wiki/I._J._Good"
       }
     ],
-    "wikidataId": null,
     "wikidataId": "Q56594306"
   },
   {
@@ -1920,8 +1914,8 @@
     ],
     "language": "English",
     "shortDescription": "Coined 'artificial intelligence' and launched AI as a field",
-    "wikipediaTitle": "Dartmouth_workshop",
-    "wikidataId": "Q2453355"
+    "wikipediaTitle": null,
+    "wikidataId": null
   },
   {
     "id": "object-man-computer-symbiosis-licklider",
@@ -1945,7 +1939,6 @@
         "url": "https://en.wikipedia.org/wiki/Man-Computer_Symbiosis"
       }
     ],
-    "wikidataId": null,
     "wikidataId": "Q20650478"
   },
   {
@@ -2289,7 +2282,6 @@
     },
     "shortDescription": "Where Grey Walter built tortoise robots",
     "wikipediaTitle": "Burden_Neurological_Institute",
-    "wikidataId": null,
     "wikidataId": "Q7618485",
     "dateStart": "1909"
   },
@@ -2306,8 +2298,6 @@
       "lng": -2.1976
     },
     "shortDescription": "Where Ashby built the Homeostat",
-    "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q4862031",
     "wikipediaTitle": "Barnwood_House_Hospital"
   },
@@ -2386,8 +2376,8 @@
       "lng": -70.6541
     },
     "shortDescription": "Cybersyn control room for economic management",
-    "wikipediaTitle": "Project_Cybersyn",
-    "wikidataId": "Q1147211"
+    "wikipediaTitle": null,
+    "wikidataId": null
   },
   {
     "id": "location-vienna",
@@ -2478,7 +2468,6 @@
     },
     "shortDescription": "Where Rosenblatt developed the perceptron",
     "wikipediaTitle": "Cornell_Aeronautical_Laboratory",
-    "wikidataId": null,
     "wikidataId": "Q5023963"
   },
   {
@@ -2591,8 +2580,8 @@
     "entityType": "research_laboratory",
     "dateStart": "1959",
     "shortDescription": "Premier AI research laboratory",
-    "wikipediaTitle": "MIT_Computer_Science_and_Artificial_Intelligence_Laboratory",
-    "wikidataId": "Q1354917"
+    "wikipediaTitle": "MIT_Artificial_Intelligence_Laboratory",
+    "wikidataId": "Q4584054"
   },
   {
     "id": "entity-bcl",
@@ -2613,7 +2602,6 @@
     "dateStart": "1963",
     "shortDescription": "West Coast AI research center founded by McCarthy",
     "wikipediaTitle": "Stanford_Artificial_Intelligence_Laboratory",
-    "wikidataId": null,
     "wikidataId": "Q2931153"
   },
   {
@@ -2776,7 +2764,7 @@
     "dateStart": "1963",
     "shortDescription": "MIT project for time-sharing and AI",
     "wikipediaTitle": "Project_MAC",
-    "wikidataId": "Q1354917"
+    "wikidataId": "Q1053094"
   },
   {
     "id": "entity-arpanet",

--- a/public/datasets/enlightenment/nodes.json
+++ b/public/datasets/enlightenment/nodes.json
@@ -1135,7 +1135,7 @@
     "language": "English",
     "subject": "Moral philosophy",
     "wikipediaTitle": "Characteristics_of_Men,_Manners,_Opinions,_Times",
-    "wikidataId": "Q335112"
+    "wikidataId": "Q42187797"
   },
   {
     "id": "object-fable-bees",
@@ -1225,8 +1225,6 @@
     ],
     "language": "French",
     "subject": "Natural philosophy",
-    "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q3721351",
     "wikipediaTitle": "Elements_of_the_Philosophy_of_Newton"
   },
@@ -1404,9 +1402,8 @@
     ],
     "language": "French",
     "subject": "Moral philosophy",
-    "wikipediaTitle": "De_l'esprit",
-    "wikidataId": null,
-    "wikidataId": "Q190302"
+    "wikipediaTitle": null,
+    "wikidataId": null
   },
   {
     "id": "object-tableau-economique",
@@ -1459,8 +1456,6 @@
     ],
     "language": "French",
     "subject": "Religious criticism",
-    "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q1171098",
     "wikipediaTitle": "Christianity_Unveiled"
   },
@@ -1594,7 +1589,6 @@
     "language": "English",
     "subject": "Philosophy",
     "wikipediaTitle": "Three_Dialogues_between_Hylas_and_Philonous",
-    "wikidataId": null,
     "wikidataId": "Q3110883"
   },
   {
@@ -1958,7 +1952,6 @@
     "language": "German",
     "subject": "Political philosophy, Theology",
     "wikipediaTitle": "Jerusalem_(Mendelssohn)",
-    "wikidataId": null,
     "wikidataId": "Q6185071"
   },
   {
@@ -2217,7 +2210,6 @@
     "language": "French",
     "subject": "Mathematics, Political science",
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q42189328"
   },
   {
@@ -2393,7 +2385,6 @@
     "locationType": "university",
     "country": "Prussia",
     "wikipediaTitle": "University_of_Halle",
-    "wikidataId": null,
     "wikidataId": "Q32120",
     "dateStart": "1502"
   },
@@ -2643,7 +2634,6 @@
     "country": "Scotland",
     "parentLocation": "location-edinburgh",
     "wikipediaTitle": "Select_Society",
-    "wikidataId": null,
     "wikidataId": "Q10369531"
   },
   {
@@ -2669,7 +2659,6 @@
     "country": "Scotland",
     "parentLocation": "location-edinburgh",
     "wikipediaTitle": "Rankenian_Club",
-    "wikidataId": null,
     "wikidataId": "Q16931535"
   },
   {
@@ -2823,7 +2812,6 @@
     "dateEnd": "1789",
     "entityType": "intellectual tendency",
     "wikipediaTitle": "Radical_Enlightenment",
-    "wikidataId": null,
     "wikidataId": "Q12539"
   },
   {
@@ -2971,7 +2959,6 @@
     "shortDescription": "Central Enlightenment cause",
     "entityType": "reform movement",
     "wikipediaTitle": "Religious_toleration",
-    "wikidataId": null,
     "wikidataId": "Q2086472"
   },
   {
@@ -3025,7 +3012,6 @@
     "shortDescription": "Reconciling Christianity with Enlightenment values",
     "entityType": "religious tendency",
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q119038249"
   },
   {

--- a/public/datasets/protestant-reformation/nodes.json
+++ b/public/datasets/protestant-reformation/nodes.json
@@ -224,7 +224,6 @@
     "deathPlace": "Altenburg, Germany",
     "nationality": "German",
     "wikipediaTitle": "Georg_Spalatin",
-    "wikidataId": null,
     "wikidataId": "Q65368"
   },
   {
@@ -300,7 +299,6 @@
     "deathPlace": "Berlin, Germany",
     "nationality": "German",
     "wikipediaTitle": "Johann_Agricola",
-    "wikidataId": null,
     "wikidataId": "Q76554"
   },
   {
@@ -640,7 +638,6 @@
     "deathPlace": "London, England",
     "nationality": "English",
     "wikipediaTitle": "Miles_Coverdale",
-    "wikidataId": null,
     "wikidataId": "Q778508"
   },
   {
@@ -1494,7 +1491,6 @@
       }
     ],
     "wikipediaTitle": "Loci_Communes",
-    "wikidataId": null,
     "wikidataId": "Q1542696"
   },
   {
@@ -1582,8 +1578,8 @@
     "creators": [
       "person-william-tyndale"
     ],
-    "wikipediaTitle": "Tyndale_Bible",
-    "wikidataId": "Q2462802"
+    "wikipediaTitle": null,
+    "wikidataId": null
   },
   {
     "id": "object-coverdale-bible",
@@ -1651,7 +1647,6 @@
       "person-huldrych-zwingli"
     ],
     "wikipediaTitle": "Froschauer_Bible",
-    "wikidataId": null,
     "wikidataId": "Q248436"
   },
   {
@@ -1740,9 +1735,8 @@
       "person-heinrich-bullinger",
       "person-leo-jud"
     ],
-    "wikipediaTitle": "First_Helvetic_Confession",
-    "wikidataId": null,
-    "wikidataId": "Q676162"
+    "wikipediaTitle": null,
+    "wikidataId": null
   },
   {
     "id": "object-second-helvetic-confession",
@@ -1755,8 +1749,8 @@
     "creators": [
       "person-heinrich-bullinger"
     ],
-    "wikipediaTitle": "Second_Helvetic_Confession",
-    "wikidataId": "Q676162"
+    "wikipediaTitle": null,
+    "wikidataId": null
   },
   {
     "id": "object-genevan-catechism",
@@ -1770,7 +1764,6 @@
       "person-john-calvin"
     ],
     "wikipediaTitle": "Genevan_Catechism",
-    "wikidataId": null,
     "wikidataId": "Q189279"
   },
   {
@@ -1930,7 +1923,6 @@
       "person-erasmus-of-rotterdam"
     ],
     "wikipediaTitle": "The_Praise_of_Folly",
-    "wikidataId": null,
     "wikidataId": "Q569869"
   },
   {
@@ -1948,7 +1940,6 @@
       "person-erasmus-of-rotterdam"
     ],
     "wikipediaTitle": "Enchiridion_militis_Christiani",
-    "wikidataId": null,
     "wikidataId": "Q1340009"
   },
   {
@@ -2033,9 +2024,8 @@
     "country": "Germany",
     "parentLocation": "location-wittenberg",
     "dateStart": "1502",
-    "wikipediaTitle": "University_of_Wittenberg",
-    "wikidataId": null,
-    "wikidataId": "Q32120"
+    "wikipediaTitle": null,
+    "wikidataId": null
   },
   {
     "id": "location-castle-church-wittenberg",
@@ -2103,7 +2093,6 @@
     "parentLocation": "location-marburg",
     "dateStart": "1527",
     "wikipediaTitle": "University_of_Marburg",
-    "wikidataId": null,
     "wikidataId": "Q155354"
   },
   {
@@ -2190,7 +2179,6 @@
       "lng": 8.5417
     },
     "wikipediaTitle": "Zürich",
-    "wikidataId": null,
     "wikidataId": "Q72",
     "dateStart": "200"
   },
@@ -2410,7 +2398,6 @@
     "dateStart": "1520",
     "dateEnd": "1530",
     "wikipediaTitle": "White_Horse_Inn,_Cambridge",
-    "wikidataId": null,
     "wikidataId": "Q15990356"
   },
   {
@@ -2576,7 +2563,6 @@
       "lng": 8.5333
     },
     "wikipediaTitle": "Battle_of_Kappel",
-    "wikidataId": null,
     "wikidataId": "Q233594"
   },
   {
@@ -2673,7 +2659,6 @@
     "dateStart": "1541",
     "headquarters": "location-geneva",
     "wikipediaTitle": "Consistory_of_Geneva",
-    "wikidataId": null,
     "wikidataId": "Q2994627"
   },
   {
@@ -2706,7 +2691,6 @@
     "entityType": "movement",
     "dateStart": "1519",
     "wikipediaTitle": "Swiss_Reformed_Church",
-    "wikidataId": null,
     "wikidataId": "Q338309"
   },
   {
@@ -2897,8 +2881,8 @@
     "dateStart": "1491",
     "dateEnd": "1527",
     "headquarters": "location-basel",
-    "wikipediaTitle": "Johann_Froben",
-    "wikidataId": "Q116611"
+    "wikipediaTitle": null,
+    "wikidataId": null
   },
   {
     "id": "entity-wittenberg-printers",

--- a/public/datasets/renaissance-humanism/nodes.json
+++ b/public/datasets/renaissance-humanism/nodes.json
@@ -233,7 +233,6 @@
     "birthPlace": "Montepulciano",
     "nationality": "Italian",
     "wikipediaTitle": "Angelo_Poliziano",
-    "wikidataId": null,
     "wikidataId": "Q250414"
   },
   {
@@ -395,7 +394,6 @@
     "birthPlace": "Florence",
     "nationality": "Italian",
     "wikipediaTitle": "Donato_Acciaiuoli",
-    "wikidataId": null,
     "wikidataId": "Q1240697"
   },
   {
@@ -465,7 +463,6 @@
     "birthPlace": "Rome",
     "nationality": "Italian",
     "wikipediaTitle": "Giulio_Pomponio_Leto",
-    "wikidataId": null,
     "wikidataId": "Q523923"
   },
   {
@@ -593,7 +590,6 @@
     "birthPlace": "Venice",
     "nationality": "Italian",
     "wikipediaTitle": "Ermolao_Barbaro_the_Younger",
-    "wikidataId": null,
     "wikidataId": "Q1236821"
   },
   {
@@ -855,7 +851,6 @@
     "birthPlace": "Groningen",
     "nationality": "Dutch/German",
     "wikipediaTitle": "Rudolf_Agricola",
-    "wikidataId": null,
     "wikidataId": "Q365557"
   },
   {
@@ -873,7 +868,6 @@
     "birthPlace": "Pforzheim",
     "nationality": "German",
     "wikipediaTitle": "Johannes_Reuchlin",
-    "wikidataId": null,
     "wikidataId": "Q61067"
   },
   {
@@ -1153,7 +1147,6 @@
     "birthPlace": "Limoges",
     "nationality": "French",
     "wikipediaTitle": "Jean_Dorat",
-    "wikidataId": null,
     "wikidataId": "Q714921"
   },
   {
@@ -1235,7 +1228,6 @@
     "birthPlace": "Athens",
     "nationality": "Byzantine",
     "wikipediaTitle": "Demetrius_Chalcondyles",
-    "wikidataId": null,
     "wikidataId": "Q983661"
   },
   {
@@ -1302,7 +1294,6 @@
     "birthPlace": "Thessalonica",
     "nationality": "Byzantine",
     "wikipediaTitle": "Theodore_Gaza",
-    "wikidataId": null,
     "wikidataId": "Q287485"
   },
   {
@@ -1647,7 +1638,6 @@
       }
     ],
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q138333085"
   },
   {
@@ -1701,7 +1691,6 @@
       "person-leonardo-bruni"
     ],
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q127513869"
   },
   {
@@ -1855,7 +1844,6 @@
       }
     ],
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q136609481"
   },
   {
@@ -1880,7 +1868,6 @@
       }
     ],
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q135423802"
   },
   {
@@ -1905,7 +1892,6 @@
       }
     ],
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q42188494"
   },
   {
@@ -2064,7 +2050,6 @@
       }
     ],
     "wikipediaTitle": "Handbook_of_a_Christian_Knight",
-    "wikidataId": null,
     "wikidataId": "Q1340009"
   },
   {
@@ -2110,7 +2095,6 @@
       "person-johannes-reuchlin"
     ],
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q42188609"
   },
   {
@@ -2342,7 +2326,6 @@
       "person-guillaume-bude"
     ],
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q139584268"
   },
   {
@@ -2415,7 +2398,6 @@
       }
     ],
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q3704168"
   },
   {
@@ -2455,7 +2437,6 @@
       }
     ],
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q55599373"
   },
   {
@@ -2494,7 +2475,6 @@
       "person-beatus-rhenanus"
     ],
     "wikipediaTitle": null,
-    "wikidataId": null,
     "wikidataId": "Q37865627"
   },
   {
@@ -3082,7 +3062,6 @@
       "person-marsilio-ficino"
     ],
     "wikipediaTitle": "Florentine_Academy",
-    "wikidataId": null,
     "wikidataId": "Q4585397"
   },
   {
@@ -3098,7 +3077,6 @@
       "person-pomponio-leto"
     ],
     "wikipediaTitle": "Roman_Academy",
-    "wikidataId": null,
     "wikidataId": "Q7361569"
   },
   {
@@ -3181,7 +3159,6 @@
     "dateStart": "1462",
     "dateEnd": "1600",
     "wikipediaTitle": "Renaissance_Neoplatonism",
-    "wikidataId": null,
     "wikidataId": "Q7202435"
   },
   {
@@ -3314,7 +3291,6 @@
     "dateStart": "1434",
     "dateEnd": "1494",
     "wikipediaTitle": "Medici",
-    "wikidataId": null,
     "wikidataId": "Q170022"
   },
   {

--- a/public/datasets/rosicrucian-network/nodes.json
+++ b/public/datasets/rosicrucian-network/nodes.json
@@ -776,7 +776,6 @@
         "url": "https://en.wikipedia.org/wiki/Michael_M%C3%A4stlin"
       }
     ],
-    "wikidataId": null,
     "wikidataId": "Q75797"
   },
   {
@@ -1693,7 +1692,6 @@
     ],
     "wikipediaTitle": null,
     "notes": "Biographical details sparse; dates approximate based on active period. German Wikipedia article available at de.wikipedia.org/wiki/Abraham_Hölzel",
-    "wikidataId": null,
     "wikidataId": "Q22969219",
     "birthPlace": "Tyrol"
   },
@@ -2030,7 +2028,6 @@
       "person-daniel-cramer"
     ],
     "wikipediaTitle": "University_of_Marburg",
-    "wikidataId": null,
     "wikidataId": "Q155354"
   },
   {
@@ -2518,7 +2515,6 @@
       }
     ],
     "notes": "Originally written in Czech, published in Latin in 1657. Proposes education for all regardless of birth, wealth, nation, or gender. Influenced the entire Hartlib Circle's educational agenda.",
-    "wikidataId": null,
     "wikidataId": "Q1210397"
   },
   {


### PR DESCRIPTION
The quick data-fix pass on the entity-id collisions the `cross-dataset` report surfaced (PR #54) — plus the Track D decision it informed.

## What it fixes

**1. Duplicate JSON keys — 82 nodes across 8 datasets.** Chasing the collision fixes uncovered latent damage from the enrich null-append bug (fixed as a *tool* in PR #53): datasets enriched *before* that fix, where a node had an explicit `null` field, ended up with a **duplicate key** (the `null` plus the appended value). Repaired by removing the earlier duplicate and keeping the last value — which is exactly what `JSON.parse` already returned, so **app behavior is unchanged; only the malformed text is fixed**. Format-preserving, and verified the parsed data is identical (order-insensitive) before writing.

**2. One-`wikidataId`-two-entities collisions.** Cases where two genuinely different real-world entities shared one id — a person and their book (Helvétius / *De l'esprit*), two different universities (Cologne / Heidelberg both `Q151510`), an org and a concept (GRM / musique concrète). For each, the mis-assigned node gets a **verified distinct id** where the entity has its own Wikidata item (Cologne → Q54096, Project MAC → Q1053094, MIT AI Lab → Q4584054, GRM → Q1780333, Characteristics → Q42187797) or **null** where it genuinely doesn't (books folded into the author's item, sub-components, combined items).

**Result**: cross-dataset conflicts **54 → 40**, intra-dataset duplicates **22 → 11**. The remainder are *same-entity* location/entity duplicates (one entity, two nodes) — a **merge**, which the atomic migration (M34 blocker B2) will handle systematically rather than by hand. All 13 datasets validate; manifests in sync; lint clean; diffs are surgical (no reflows).

## Track D decision (the roadmap updates)
The cross-dataset report corrected an error in the earlier reassessment: **2A delivered identity *detection*, not *unification*.** Knowing two nodes are the same entity (shared `wikidataId`) is not the same as having one canonical record — the corpus still holds 91 duplicated, drifting copies. That single-canonical-record + contextual-override model is the distinct value only the atomic architecture provides.

**Decision: proceed with Track D, scoped to persons + places** (where reuse concentrates: 33 persons, 39 locations shared). Sequence:
1. Consistency tooling + collision cleanup — **done** (PR #54 + this PR)
2. M34 blockers B1–B4 (canonical merge on `type + wikidataId`; intra-dataset dedup)
3. M34 Phases 3–5 → M35 (entity CLI) → M36 + locations

Documented in `ROADMAP.md` (new "Track D decision" section) and `milestones/index.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
